### PR TITLE
[encoding] allows to load files whose path contains accents

### DIFF
--- a/app/medInria/main.cpp
+++ b/app/medInria/main.cpp
@@ -76,6 +76,7 @@ int main(int argc,char* argv[]) {
     medSplashScreen splash(QPixmap(":music_logo.png"));
     setlocale(LC_NUMERIC, "C");
     QLocale::setDefault(QLocale("C"));
+    QTextCodec::setCodecForCStrings(QTextCodec::codecForName("UTF-8"));
 
     if (dtkApplicationArgumentsContain(&application, "-h") || dtkApplicationArgumentsContain(&application, "--help")) {
         qDebug() << "Usage: medInria [--fullscreen|--no-fullscreen] [--stereo] "

--- a/src/medCore/database/medDataManager.cpp
+++ b/src/medCore/database/medDataManager.cpp
@@ -142,7 +142,7 @@ QUuid medDataManager::importPath(const QString& dataPath, bool indexWithoutCopyi
     Q_D(medDataManager);
     QUuid uuid = QUuid::createUuid();
     medAbstractDbController * controller = persistent ?  d->dbController : d->nonPersDbController;
-    controller->importPath(dataPath.toUtf8(), uuid, indexWithoutCopying);
+    controller->importPath(dataPath, uuid, indexWithoutCopying);
     return uuid;
 }
 /** @brief return writers able to handle the data *Memory management is the responsability of the caller*


### PR DESCRIPTION
Try to load different files (.mha, .dcm, folders of .dcm) with and without an accent in their paths.
This PR should make it work.

PS: the method I am using (QTextCodec::setCodecForCStrings) doesn't exist anymore in qt5, I trust @mikejbuckingham and the medInria guys to find a solution.