### PR TITLE
[thumbnail] wrong pixmap location

### DIFF
--- a/src/medCore/database/medDataManager.cpp
+++ b/src/medCore/database/medDataManager.cpp
@@ -398,7 +398,7 @@ QPixmap medDataManager::thumbnail(const medDataIndex & index)
         pix = dbc->thumbnail(index);
     }
 
-    return pix.isNull() ? QPixmap(":/medGui/pixmaps/default_thumbnail.png") : pix;
+    return pix.isNull() ? QPixmap(":/pixmaps/default_thumbnail.png") : pix;
 }
 
 void medDataManager::setWriterPriorities()


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/16 

The default thumbnail was wrong. The fact that this particular image gives the default thumbnail can be studied also in a future PR.

:m: