### PR TITLE
[SegmentationWorkspace] move signal events in mscPaint

### DIFF
--- a/app/medInria/medSegmentationWorkspace.cpp
+++ b/app/medInria/medSegmentationWorkspace.cpp
@@ -13,29 +13,15 @@
 
 #include <medSegmentationWorkspace.h>
 
-#include <medSegmentationSelectorToolBox.h>
-#include <medSegmentationAbstractToolBox.h>
-
-#include <medAbstractView.h>
-
-#include <medProgressionStack.h>
-#include <medTabbedViewContainers.h>
-#include <medViewContainer.h>
-#include <medWorkspaceFactory.h>
-#include <medToolBoxFactory.h>
-#include <medViewEventFilter.h>
-#include <medViewContainerManager.h>
-#include <medRunnableProcess.h>
 #include <medDataManager.h>
-#include <medJobManager.h>
-#include <medMetaDataKeys.h>
-#include <medViewParameterGroup.h>
 #include <medLayerParameterGroup.h>
-
-#include <dtkLog/dtkLog.h>
+#include <medSegmentationAbstractToolBox.h>
+#include <medSegmentationSelectorToolBox.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
+#include <medViewParameterGroup.h>
 
 #include <stdexcept>
-
 
 class medSegmentationWorkspacePrivate
 {
@@ -55,9 +41,6 @@ medAbstractWorkspace(parent), d(new medSegmentationWorkspacePrivate)
 {
     d->segmentationToolBox = new medSegmentationSelectorToolBox(parent);
     d->segmentationToolBox->setWorkspace(this);
-
-    connect(d->segmentationToolBox, SIGNAL(installEventFilterRequest(medViewEventFilter*)),
-            this, SLOT(addViewEventFilter(medViewEventFilter*)));
 
     connect(d->segmentationToolBox,SIGNAL(success()),this,SLOT(onSuccess()));
 
@@ -108,17 +91,6 @@ bool medSegmentationWorkspace::isUsable()
 {
     medToolBoxFactory * tbFactory = medToolBoxFactory::instance();
     return (tbFactory->toolBoxesFromCategory("segmentation").size()!=0); 
-}
-
-void medSegmentationWorkspace::addViewEventFilter( medViewEventFilter * filter)
-{
-    foreach(QUuid uuid, this->stackedViewContainers()->containersSelected())
-    {
-        medViewContainer *container = medViewContainerManager::instance()->container(uuid);
-        if(!container)
-            return;
-        filter->installOnView(container->view());
-    }
 }
 
 //TODO: not tested yet

--- a/app/medInria/medSegmentationWorkspace.h
+++ b/app/medInria/medSegmentationWorkspace.h
@@ -15,10 +15,6 @@
 
 #include <medAbstractWorkspace.h>
 
-
-class medAbstractView;
-class medViewEventFilter;
-
 class medSegmentationWorkspacePrivate;
 class medSegmentationSelectorToolBox;
 
@@ -45,10 +41,7 @@ public:
     medSegmentationSelectorToolBox * segmentationToobox();
 
 protected slots:
-    void addViewEventFilter(medViewEventFilter * filter );
-
     void onSuccess();
-
 
 private:
     medSegmentationWorkspacePrivate *d;

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -438,9 +438,6 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     connect(reduceBrushSize_shortcut,SIGNAL(activated()),this,SLOT(reduceBrushSize()));
 
     maskHasBeenSaved = false;
-
-    connect(this, SIGNAL(installEventFilterRequest(medViewEventFilter*)),
-            this, SLOT(addViewEventFilter(medViewEventFilter*)));
 }
 
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
@@ -496,7 +493,7 @@ void AlgorithmPaintToolBox::activateStroke()
     updateButtons();
     this->m_magicWandButton->setChecked(false);
     m_viewFilter = ( new ClickAndMoveEventFilter(this) );
-    emit installEventFilterRequest(m_viewFilter);
+    addViewEventFilter(m_viewFilter);
     addBrushSize_shortcut->setEnabled(true);
     reduceBrushSize_shortcut->setEnabled(true);
 
@@ -569,7 +566,7 @@ void AlgorithmPaintToolBox::activateMagicWand()
     updateButtons();
     this->m_strokeButton->setChecked(false);
     m_viewFilter = ( new ClickAndMoveEventFilter(this) );
-    emit installEventFilterRequest(m_viewFilter);
+    addViewEventFilter(m_viewFilter);
     deactivateCustomedCursor();
 }
 
@@ -1289,7 +1286,7 @@ void AlgorithmPaintToolBox::updateMouseInteraction() //Apply the current interac
     if (m_paintState != PaintState::None)
     {
         m_viewFilter = ( new ClickAndMoveEventFilter(this) );
-        emit installEventFilterRequest(m_viewFilter);
+        addViewEventFilter(m_viewFilter);
     }
 }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -1,13 +1,18 @@
 #include <mscAlgorithmPaintToolBox.h>
 
-#include <medAbstractData.h>
+#include <itkConnectedThresholdImageFilter.h>
+#include <itkDanielssonDistanceMapImageFilter.h>
+#include <itkExtractImageFilter.h>
+#include <itkImageLinearIteratorWithIndex.h>
+#include <itkImageSliceIteratorWithIndex.h>
+#include <itkInvertIntensityImageFilter.h>
+#include <itkMinimumMaximumImageCalculator.h>
+#include <itkSubtractImageFilter.h>
+
 #include <medAbstractDataFactory.h>
 #include <medAbstractImageData.h>
 #include <medAbstractImageView.h>
-#include <medDataIndex.h>
 #include <medDataManager.h>
-#include <medImageMaskAnnotationData.h>
-#include <medMetaDataKeys.h>
 #include <medMessageController.h>
 #include <medPluginManager.h>
 #include <medSegmentationSelectorToolBox.h>
@@ -15,34 +20,9 @@
 #include <medToolBoxFactory.h>
 #include <medUtilities.h>
 #include <medViewContainer.h>
-#include <medVtkViewBackend.h>
-
-#include <dtkCore/dtkAbstractProcessFactory.h>
-#include <dtkLog/dtkLog.h>
-#include <dtkCore/dtkGlobal.h>
+#include <medViewContainerManager.h>
 
 #include <vnl/vnl_cross.h>
-#include <vnl/vnl_vector.h>
-
-#include <itkImageRegionIterator.h>
-#include <itkConnectedThresholdImageFilter.h>
-#include <itkMinimumMaximumImageCalculator.h>
-#include <itkDanielssonDistanceMapImageFilter.h>
-#include <itkExtractImageFilter.h>
-
-#include <itkInvertIntensityImageFilter.h>
-#include <itkSubtractImageFilter.h>
-#include <itkImageSliceIteratorWithIndex.h>
-#include <itkConstSliceIterator.h>
-#include <itkImageLinearIteratorWithIndex.h>
-
-#include <QtCore>
-#include <QColorDialog>
-
-#include <algorithm>
-#include <set>
-
-#include <limits>
 
 namespace msc
 {
@@ -458,6 +438,9 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
     connect(reduceBrushSize_shortcut,SIGNAL(activated()),this,SLOT(reduceBrushSize()));
 
     maskHasBeenSaved = false;
+
+    connect(this, SIGNAL(installEventFilterRequest(medViewEventFilter*)),
+            this, SLOT(addViewEventFilter(medViewEventFilter*)));
 }
 
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
@@ -2125,6 +2108,17 @@ void AlgorithmPaintToolBox::computeIntermediateSlice(Mask2dFloatType::Pointer di
         ++iti1;
         ++ito;
         ++itmask;
+    }
+}
+
+void AlgorithmPaintToolBox::addViewEventFilter( medViewEventFilter * filter)
+{
+    foreach(QUuid uuid, this->getWorkspace()->stackedViewContainers()->containersSelected())
+    {
+        medViewContainer *container = medViewContainerManager::instance()->container(uuid);
+        if(!container)
+            return;
+        filter->installOnView(container->view());
     }
 }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -2116,9 +2116,10 @@ void AlgorithmPaintToolBox::addViewEventFilter( medViewEventFilter * filter)
     foreach(QUuid uuid, this->getWorkspace()->stackedViewContainers()->containersSelected())
     {
         medViewContainer *container = medViewContainerManager::instance()->container(uuid);
-        if(!container)
-            return;
-        filter->installOnView(container->view());
+        if(container)
+        {
+            filter->installOnView(container->view());
+        }
     }
 }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -7,8 +7,7 @@
 #include <medImageMaskAnnotationData.h>
 #include <medIntParameter.h>
 #include <medSegmentationAbstractToolBox.h>
-
-#include <QVector3D>
+#include <medViewEventFilter.h>
 
 #include <itkImage.h>
 #include <itkImageRegionIterator.h>
@@ -69,10 +68,10 @@ public:
     void setSeedPlanted(bool,MaskType::IndexType,unsigned int,double);
     void setSeed(QVector3D);
 
-    inline void setCurrentIdSlice(unsigned int id){currentIdSlice = id;};
-    inline unsigned int getCurrentIdSlice(){return currentIdSlice;};
-    inline void setCurrentPlaneIndex(unsigned int index){currentPlaneIndex = index;};
-    inline unsigned int getCurrentPlaneIndex(){return currentPlaneIndex;};
+    inline void setCurrentIdSlice(unsigned int id){currentIdSlice = id;}
+    inline unsigned int getCurrentIdSlice(){return currentIdSlice;}
+    inline void setCurrentPlaneIndex(unsigned int index){currentPlaneIndex = index;}
+    inline unsigned int getCurrentPlaneIndex(){return currentPlaneIndex;}
     void setParameter(int channel, int value);
     void setCurrentView(medAbstractImageView* view);
 
@@ -151,6 +150,12 @@ protected:
 
     void copySliceFromMask3D(itk::Image<unsigned char,2>::Pointer copy,const char planeIndex,const char * direction,const unsigned int slice);
     void pasteSliceToMask3D(itk::Image<unsigned char,2>::Pointer image2D,const char planeIndex,const char * direction,const unsigned int slice);
+
+signals:
+    void installEventFilterRequest(medViewEventFilter *filter);
+
+protected slots:
+    void addViewEventFilter(medViewEventFilter * filter );
 
 private:
     typedef dtkSmartPointer<medSeedPointAnnotationData> SeedPoint;

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -151,10 +151,6 @@ protected:
     void copySliceFromMask3D(itk::Image<unsigned char,2>::Pointer copy,const char planeIndex,const char * direction,const unsigned int slice);
     void pasteSliceToMask3D(itk::Image<unsigned char,2>::Pointer image2D,const char planeIndex,const char * direction,const unsigned int slice);
 
-signals:
-    void installEventFilterRequest(medViewEventFilter *filter);
-
-protected slots:
     void addViewEventFilter(medViewEventFilter * filter );
 
 private:

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -7,7 +7,6 @@
 #include <medImageMaskAnnotationData.h>
 #include <medIntParameter.h>
 #include <medSegmentationAbstractToolBox.h>
-#include <medViewEventFilter.h>
 
 #include <QVector3D>
 
@@ -152,9 +151,6 @@ protected:
 
     void copySliceFromMask3D(itk::Image<unsigned char,2>::Pointer copy,const char planeIndex,const char * direction,const unsigned int slice);
     void pasteSliceToMask3D(itk::Image<unsigned char,2>::Pointer image2D,const char planeIndex,const char * direction,const unsigned int slice);
-
-signals:
-    void installEventFilterRequest(medViewEventFilter *filter);
 
 private:
     typedef dtkSmartPointer<medSeedPointAnnotationData> SeedPoint;

--- a/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
@@ -15,7 +15,6 @@
 
 #include <medToolBox.h>
 #include <medCoreExport.h>
-#include <medViewEventFilter.h>
 
 class medAbstractData;
 class medSegmentationSelectorToolBox;
@@ -33,9 +32,6 @@ public:
     virtual dtkPlugin* plugin() = 0;
 
     virtual medAbstractData *processOutput() = 0;
-
-signals:
-    void installEventFilterRequest(medViewEventFilter *filter);
 
 protected:
     medSegmentationSelectorToolBox *segmentationToolBox();

--- a/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
@@ -15,6 +15,7 @@
 
 #include <medToolBox.h>
 #include <medCoreExport.h>
+#include <medViewEventFilter.h>
 
 class medAbstractData;
 class medSegmentationSelectorToolBox;
@@ -32,6 +33,9 @@ public:
     virtual dtkPlugin* plugin() = 0;
 
     virtual medAbstractData *processOutput() = 0;
+
+signals:
+    void installEventFilterRequest(medViewEventFilter *filter);
 
 protected:
     medSegmentationSelectorToolBox *segmentationToolBox();

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
@@ -97,9 +97,6 @@ void medSegmentationSelectorToolBox::changeCurrentToolBox(int index)
                 toolbox->setWorkspace(workspace);
             toolbox->setStyleSheet("medToolBoxBody {border:none}");
             d->segmentationToolBoxes[identifier] = toolbox;
-            connect(toolbox, SIGNAL(installEventFilterRequest(medViewEventFilter*)),
-                    this, SIGNAL(installEventFilterRequest(medViewEventFilter*)),
-                    Qt::UniqueConnection);
         }
     }
 

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.h
@@ -31,7 +31,6 @@ public:
      medSegmentationAbstractToolBox* currentToolBox();
 
 signals:
-     void installEventFilterRequest(medViewEventFilter *filter);
      void inputChanged();
 
 public slots:


### PR DESCRIPTION
In Histogram, VoiCutter, VariationalSeg, polygonROI and CoronarySeg, you had a `Object::connect: No such signal polygonRoiToolBox::installEventFilterRequest(medViewEventFilter*)` warning, as see at third point of this issue: https://github.com/Inria-Asclepios/music/issues/91

The only toolbox which had this signal was mscPaint (and Paint, but it's going to be removed), so i moved it in medSegmentationAbstractToolBox where other tlbx could access if needed.