### PR TITLE
[database] move-remove data-thumbnail

### DIFF
--- a/src/medCore/database/medDatabaseModel.cpp
+++ b/src/medCore/database/medDatabaseModel.cpp
@@ -11,26 +11,23 @@
 
 =========================================================================*/
 
-#include <QtGui>
-#include <QtCore>
-#include <QtSql>
 #include <QCryptographicHash>
+#include <QtCore>
+#include <QtGui>
+#include <QtSql>
 
 #include <dtkCore/dtkGlobal.h>
 #include <dtkLog/dtkLog.h>
 
+#include <medAbstractDatabaseItem.h>
+#include <medAbstractDbController.h>
 #include <medDatabaseController.h>
 #include <medDatabaseItem.h>
+#include <medDataManager.h>
 #include <medDatabaseModel.h>
 #include <medDatabaseNonPersistentController.h>
-
-#include <medAbstractDbController.h>
-#include <medDataManager.h>
 #include <medMetaDataKeys.h>
-#include <medAbstractDatabaseItem.h>
-
 #include <medSettingsManager.h>
-
 
 QString anonymise(const QString name)
 {
@@ -38,9 +35,6 @@ QString anonymise(const QString name)
     r.resize(10);
     return QString(r);
 }
-
-
-
 
 // /////////////////////////////////////////////////////////////////
 // medDatabaseModelPrivate
@@ -73,7 +67,7 @@ public:
 
     QHash<medDataIndex, QModelIndex> medIndexMap;
 
-    enum { DataCount = 12 };
+    enum { DataCount = 13 };
 };
 
 medAbstractDatabaseItem *medDatabaseModelPrivate::item(const QModelIndex& index) const
@@ -143,7 +137,7 @@ medDatabaseModel::medDatabaseModel(QObject *parent, bool justBringStudies) : QAb
     d->seAttributes[i++] = medMetaDataKeys::Performer.key();
     d->seAttributes[i++] = medMetaDataKeys::Institution.key();
     d->seAttributes[i++] = medMetaDataKeys::Report.key();
-
+    d->seAttributes[i++] = medMetaDataKeys::ThumbnailPath.key();
 
     d->ptDefaultData =  d->data;
     d->ptDefaultData[0] = tr("[No Patient Name]");
@@ -192,10 +186,11 @@ bool medDatabaseModel::hasChildren ( const QModelIndex & parent ) const
 
 int medDatabaseModel::columnCount(const QModelIndex& parent) const
 {
+    //-1: do not take into account Thumbnail for columns display
     if (parent.isValid())
-        return static_cast<medAbstractDatabaseItem *>(parent.internalPointer())->columnCount();
+        return static_cast<medAbstractDatabaseItem *>(parent.internalPointer())->columnCount()-1;
     else
-        return d->root->columnCount();
+        return d->root->columnCount()-1;
 }
 
 int medDatabaseModel::columnIndex(const QString& title) const
@@ -672,7 +667,6 @@ void medDatabaseModel::updateSerie(const medDataIndex& dataIndex)
             QModelIndex parentIndex = index.parent();
             medDataIndex stDataIndex(dataIndex);
             stDataIndex.setSeriesId(-1);
-            QModelIndex stIndex = d->medIndexMap.value(stDataIndex);
 
             medAbstractDatabaseItem *parent = item->parent();
             if(!parent)

--- a/src/medCore/database/medDatabaseRemover.cpp
+++ b/src/medCore/database/medDatabaseRemover.cpp
@@ -15,17 +15,18 @@
 
 #include <QSqlError>
 
-#include <medAbstractDataFactory.h>
 #include <dtkCore/dtkAbstractDataReader.h>
 #include <dtkCore/dtkAbstractDataWriter.h>
-#include <medAbstractData.h>
 #include <dtkCore/dtkGlobal.h>
 #include <dtkLog/dtkLog.h>
 
+#include <medAbstractData.h>
+#include <medAbstractDataFactory.h>
+#include <medAbstractImageData.h>
+#include <medDataIndex.h>
+#include <medDataManager.h>
 #include <medDatabaseController.h>
 #include <medStorage.h>
-#include <medDataIndex.h>
-#include <medAbstractImageData.h>
 
 #define EXEC_QUERY(q) execQuery(q, __FILE__ , __LINE__ )
 namespace
@@ -224,7 +225,12 @@ void medDatabaseRemover::removeSeries ( int patientDbId, int studyDbId, int seri
     if ( query.next() )
     {
         thumbnail = query.value ( 0 ).toString();
-        this->removeFile ( thumbnail );
+
+        medAbstractDbController * dbc = medDataManager::instance()->controllerForDataSource(d->index.dataSourceId());
+        if (thumbnail == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
+        {
+            this->removeFile ( thumbnail );
+        }
         QString path = query.value ( 1 ).toString();
 
         // if path is empty then it was an indexed series
@@ -279,7 +285,12 @@ void medDatabaseRemover::removeStudy ( int patientDbId, int studyDbId )
     if ( query.next() )
     {
         thumbnail = query.value ( 0 ).toString();
-        this->removeFile ( thumbnail );
+
+        medAbstractDbController * dbc = medDataManager::instance()->controllerForDataSource(d->index.dataSourceId());
+        if (thumbnail == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
+        {
+            this->removeFile ( thumbnail );
+        }
     }
     if( removeTableRow ( d->T_STUDY, studyDbId ) )
         emit removed(medDataIndex(1, patientDbId, studyDbId, -1, -1));
@@ -301,8 +312,6 @@ void medDatabaseRemover::removePatient ( int patientDbId )
     QSqlDatabase db(d->db);
     QSqlQuery query ( db );
 
-    QString patientName;
-    QString patientBirthdate;
     QString patientId;
 
     query.prepare ( "SELECT thumbnail, patientId  FROM " + d->T_PATIENT + " WHERE id = :patient " );
@@ -311,7 +320,12 @@ void medDatabaseRemover::removePatient ( int patientDbId )
     if ( query.next() )
     {
         QString thumbnail = query.value ( 0 ).toString();
-        this->removeFile ( thumbnail );
+
+        medAbstractDbController * dbc = medDataManager::instance()->controllerForDataSource(d->index.dataSourceId());
+        if (thumbnail == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
+        {
+            this->removeFile ( thumbnail );
+        }
         patientId = query.value ( 1 ).toString();
     }
     if( removeTableRow ( d->T_PATIENT, patientDbId ) )

--- a/src/medCore/database/medDatabaseRemover.h
+++ b/src/medCore/database/medDatabaseRemover.h
@@ -13,12 +13,11 @@
 
 #pragma once
 
-#include <QtCore/QObject>
-
+#include <medCoreExport.h>
 #include <medDataIndex.h>
 #include <medJobItem.h>
-
-#include <medCoreExport.h>
+#include <QtCore/QObject>
+#include <QSqlQuery>
 
 class medDatabaseRemoverPrivate;
 
@@ -28,12 +27,11 @@ class medDatabaseRemoverPrivate;
  */
 class MEDCORE_EXPORT medDatabaseRemover : public medJobItem
 {
-    Q_OBJECT;
+    Q_OBJECT
 
 public:
      medDatabaseRemover(const medDataIndex &index);
     ~medDatabaseRemover();
-
 
 signals:
 
@@ -51,16 +49,17 @@ protected:
 
     void removeImage( int patientId, int studyId, int seriesId, int imageId);
 
-
     bool isSeriesEmpty( int seriesId );
     void removeSeries( int patientId, int studyId, int seriesId );
+
     bool isStudyEmpty( int studyId );
     void removeStudy( int patientId, int studyId );
+
     bool isPatientEmpty( int patientId );
     void removePatient( int patientId );
 
     void removeFile( const QString & filename );
-
+    void removeThumbnailIfNeeded(QSqlQuery query);
     void removeDataFile( const medDataIndex &index, const QString & filename );
     bool removeTableRow( const QString &table, int id );
 


### PR DESCRIPTION
Found through this issue: https://github.com/Inria-Asclepios/medInria-public/issues/16

Cf this issue: https://github.com/Inria-Asclepios/medInria-public/issues/24

We update in medDatabaseModel the thumbnail location in the moved data.
In medDatabaseRemover we check the thumbnail location of the patient/study/etc removed.

:m: