### PR TITLE
[mscPaint] clear after rm of noName

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -1243,6 +1243,8 @@ void AlgorithmPaintToolBox::updateStroke(ClickAndMoveEventFilter * filter, medAb
         // Update Mouse Interaction ToolBox
         view->setCurrentLayer(0);
         getWorkspace()->updateMouseInteractionToolBox();
+
+        connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(clearMask()), Qt::UniqueConnection);
     }
 
     m_maskAnnotationData->invokeModified();


### PR DESCRIPTION
This PR solves this issue: https://github.com/Inria-Asclepios/music/issues/254

> When using the MUSIC paint segmentation toolbox, a new layer is created representing the painted mask. This layer is not cleared when the user chooses to close it, i.e. the previous painted area is still there.
> Shouldn't closing the layer result in the deletion of the buffered mask data ?
> 
> Steps to reproduce this behavior:
> 1 - open any image data in segmentation workspace
> 2 - using MUSIC paint algorithm, paint whatever on the image
> 3 - close the layer called 'no name'
> 4 - paint again somewhere else on the image
> 5 - the layer called 'no name' is back, with the previous painted area.
> 
> To me closing the layer should do something akin to the button 'Clear Mask'.

:m: