### PR TITLE
[dataImageWriter] add mha by default on export

### DIFF
--- a/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.cpp
+++ b/src-plugins/itkDataImage/writers/itkMetaDataImageWriter.cpp
@@ -49,7 +49,7 @@ QStringList itkMetaDataImageWriter::handled() const {
 
 QStringList itkMetaDataImageWriter::supportedFileExtensions() const
 {
-    return QStringList() << ".mhd";
+    return QStringList() << ".mha" << ".mhd";
 }
 
 bool itkMetaDataImageWriter::registered() {


### PR DESCRIPTION
Third point of https://github.com/Inria-Asclepios/music/issues/242

The user did not see anymore the mha extension on export pop-up. This PR allows to show mha and mhd together.

NB: .mha files are made of one file, and mhd files are made of 1 header file and 1 raw file.

:m: