### PR TITLE
[medUtilities] decide which mode when switching to 3d

### DIFF
--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -145,7 +145,7 @@ void medUtilities::applyInverseOrientationMatrix(medAbstractView* view, double* 
     std::copy(homogeneousVector, homogeneousVector + 3, outPoint);
 }
 
-void medUtilities::switchTo3D(medAbstractView *view, QString mode3D)
+void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
 {
     if (view)
     {
@@ -176,7 +176,26 @@ void medUtilities::switchTo3D(medAbstractView *view, QString mode3D)
                 break;
             }
         }
-        mode3DParam->setValue(mode3D);
+
+        switch(mode3D)
+        {
+        case VR:
+            mode3DParam->setValue("VR");
+            break;
+        case MIP_MAXIMUM:
+            mode3DParam->setValue("MIP - Maximum");
+            break;
+        case MIP_MINIMUM:
+            mode3DParam->setValue("MIP - Minimum");
+            break;
+        case MSR:
+            mode3DParam->setValue("MSR");
+            break;
+        default:
+            qDebug()<<"medUtilities: wrong 3d mode";
+            break;
+        }
+
         renderer3DParam->setValue("Ray Cast");
     }
 }

--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -191,9 +191,6 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
         case MSR:
             mode3DParam->setValue("MSR");
             break;
-        default:
-            qDebug()<<"medUtilities: wrong 3d mode";
-            break;
         }
 
         renderer3DParam->setValue("Ray Cast");

--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -145,7 +145,7 @@ void medUtilities::applyInverseOrientationMatrix(medAbstractView* view, double* 
     std::copy(homogeneousVector, homogeneousVector + 3, outPoint);
 }
 
-void medUtilities::switchToVolumeRendering(medAbstractView *view)
+void medUtilities::switchTo3D(medAbstractView *view, QString mode3D)
 {
     if (view)
     {
@@ -176,7 +176,7 @@ void medUtilities::switchToVolumeRendering(medAbstractView *view)
                 break;
             }
         }
-        mode3DParam->setValue("VR");
+        mode3DParam->setValue(mode3D);
         renderer3DParam->setValue("Ray Cast");
     }
 }

--- a/src/medUtilities/medUtilities.h
+++ b/src/medUtilities/medUtilities.h
@@ -25,7 +25,7 @@ public:
 
     static void applyInverseOrientationMatrix(medAbstractView* view, double* inPoint, double* outPoint, bool withTranslation = true);
 
-    static void switchToVolumeRendering(medAbstractView *view); // Display mesh in 3D orientation
+    static void switchTo3D(medAbstractView *view, QString mode3D = "VR"); // Display mesh in 3D orientation
 
     static medAbstractData *changeMaxNumberOfMeshTriangles(medAbstractData *mesh, int value);
 };

--- a/src/medUtilities/medUtilities.h
+++ b/src/medUtilities/medUtilities.h
@@ -9,6 +9,15 @@ class medAbstractView;
 class MEDUTILITIES_EXPORT medUtilities
 {
 public:
+
+    enum Mode3DType
+    {
+        VR,
+        MIP_MAXIMUM,
+        MIP_MINIMUM,
+        MSR
+    };
+
     static void setDerivedMetaData(medAbstractData* derived, medAbstractData* original,
                                    QString derivationDescription, bool queryForDescription = false);
 
@@ -25,7 +34,7 @@ public:
 
     static void applyInverseOrientationMatrix(medAbstractView* view, double* inPoint, double* outPoint, bool withTranslation = true);
 
-    static void switchTo3D(medAbstractView *view, QString mode3D = "VR"); // Display mesh in 3D orientation
+    static void switchTo3D(medAbstractView *view, Mode3DType mode3D = VR); // Display mesh in 3D orientation
 
     static medAbstractData *changeMaxNumberOfMeshTriangles(medAbstractData *mesh, int value);
 };


### PR DESCRIPTION
A PhD student here wanted to use the mesh manipulation tbx:
she dropped a volume (as a reference to re-position the mesh) then a mesh. After that, when you click on the tbx, it all switches to VR, which is very sloooow with volumes.

That's why I changed `medUtilities::switchToVR()` to `medUtilities::switchTo3D`, and adds a second parameter, a Qstring defining the 3dMode (default: VR).

It implies changes in music-plugins and medInria-private