### PR TITLE
[medAbstractProcess] add mesh and volume error messages

### DIFF
--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -328,20 +328,20 @@ void medToolBox::handleDisplayError(int error)
 void medToolBox::displayPixelTypeError()
 {
     QString error = "Pixel type not yet implemented";
-    qDebug() << description() + ": " + error;
+    qDebug() << name() + ": " + error;
     medMessageController::instance()->showError(error,3000);
 }
 
 void medToolBox::displayDataDimensionError()
 {
     QString error = "This toolbox is designed to be used with 3D volumes";
-    qDebug() << description() + ": " + error;
+    qDebug() << name() + ": " + error;
     medMessageController::instance()->showError(error,3000);
 }
 
 void medToolBox::displayMeshTypeError()
 {
     QString error = "This toolbox is designed to be used with meshes";
-    qDebug() << description() + ": " + error;
+    qDebug() << name() + ": " + error;
     medMessageController::instance()->showError(error,3000);
 }

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -65,6 +65,8 @@ medToolBox::medToolBox(QWidget *parent) : QWidget(parent), d(new medToolBoxPriva
     connect(d->body, SIGNAL(maximized()), this, SLOT(behaveWithBodyVisibility()));
 
     this->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+
+    connect(this, SIGNAL(displayError(int)), this, SLOT(handleDisplayError(int)));
 }
 
 medToolBox::~medToolBox(void)
@@ -307,6 +309,22 @@ void medToolBox::toXMLNode(QDomDocument* doc, QDomElement* currentNode)
 	QDomElement elmt=doc->createElement("description");
 	elmt.appendChild(doc->createTextNode(description()));
 	currentNode->appendChild(elmt);
+}
+
+void medToolBox::handleDisplayError(int error)
+{
+    switch (error)
+    {
+    case 2:
+        displayPixelTypeError();
+        break;
+    case 3:
+        displayDataDimensionError();
+        break;
+    case 4:
+        displayMeshTypeError();
+        break;
+    }
 }
 
 void medToolBox::displayPixelTypeError()

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -20,6 +20,7 @@
 #include <medToolBoxBody.h>
 #include <medToolBoxTab.h>
 #include <medButton.h>
+#include <medMessageController.h>
 
 #include <dtkCore/dtkGlobal.h>
 #include <dtkCore/dtkPlugin>
@@ -308,3 +309,23 @@ void medToolBox::toXMLNode(QDomDocument* doc, QDomElement* currentNode)
 	currentNode->appendChild(elmt);
 }
 
+void medToolBox::displayPixelTypeError()
+{
+    QString error = "Pixel type not yet implemented";
+    qDebug() << description() + ": " + error;
+    medMessageController::instance()->showError(error,3000);
+}
+
+void medToolBox::displayDataDimensionError()
+{
+    QString error = "This toolbox is designed to be used with 3D volumes";
+    qDebug() << description() + ": " + error;
+    medMessageController::instance()->showError(error,3000);
+}
+
+void medToolBox::displayMeshTypeError()
+{
+    QString error = "This toolbox is designed to be used with meshes";
+    qDebug() << description() + ": " + error;
+    medMessageController::instance()->showError(error,3000);
+}

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -65,8 +65,6 @@ medToolBox::medToolBox(QWidget *parent) : QWidget(parent), d(new medToolBoxPriva
     connect(d->body, SIGNAL(maximized()), this, SLOT(behaveWithBodyVisibility()));
 
     this->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
-
-    connect(this, SIGNAL(displayError(int)), this, SLOT(handleDisplayError(int)));
 }
 
 medToolBox::~medToolBox(void)

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -325,6 +325,7 @@ void medToolBox::handleDisplayError(int error)
         displayMessageError("This toolbox is designed to be used with meshes");
         break;
     default:
+        displayMessageError("This action failed (undefined error)");
         break;
     }
 }

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -312,35 +312,25 @@ void medToolBox::handleDisplayError(int error)
 {
     switch (error)
     {
-    case medAbstractProcess::PIXEL_TYPE:
-        displayPixelTypeError();
+    case medAbstractProcess::PIXEL_TYPE:   //! Handle volume errors: pixel type
+        displayMessageError("Pixel type not yet implemented");
         break;
-    case medAbstractProcess::DIMENSION:
-        displayDataDimensionError();
+    case medAbstractProcess::DIMENSION_3D: //! Handle volume errors: dimension
+        displayMessageError("This toolbox is designed to be used with 3D volumes");
         break;
-    case medAbstractProcess::MESH_TYPE:
-        displayMeshTypeError();
+    case medAbstractProcess::DIMENSION_4D: //! Handle volume errors: dimension
+        displayMessageError("This toolbox is designed to be used with 4D volumes");
+        break;
+    case medAbstractProcess::MESH_TYPE:    //! Handle mesh errors: data type
+        displayMessageError("This toolbox is designed to be used with meshes");
+        break;
+    default:
         break;
     }
 }
 
-void medToolBox::displayPixelTypeError()
+void medToolBox::displayMessageError(QString error)
 {
-    QString error = "Pixel type not yet implemented";
-    qDebug() << name() + ": " + error;
-    medMessageController::instance()->showError(error,3000);
-}
-
-void medToolBox::displayDataDimensionError()
-{
-    QString error = "This toolbox is designed to be used with 3D volumes";
-    qDebug() << name() + ": " + error;
-    medMessageController::instance()->showError(error,3000);
-}
-
-void medToolBox::displayMeshTypeError()
-{
-    QString error = "This toolbox is designed to be used with meshes";
     qDebug() << name() + ": " + error;
     medMessageController::instance()->showError(error,3000);
 }

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -12,7 +12,7 @@
 =========================================================================*/
 
 #include <medAbstractData.h>
-
+#include <medAbstractProcess.h>
 #include <medAbstractView.h>
 
 #include <medToolBox.h>
@@ -313,13 +313,13 @@ void medToolBox::handleDisplayError(int error)
 {
     switch (error)
     {
-    case 2:
+    case medAbstractProcess::PIXEL_TYPE:
         displayPixelTypeError();
         break;
-    case 3:
+    case medAbstractProcess::DIMENSION:
         displayDataDimensionError();
         break;
-    case 4:
+    case medAbstractProcess::MESH_TYPE:
         displayMeshTypeError();
         break;
     }

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -14,13 +14,12 @@
 #include <medAbstractData.h>
 #include <medAbstractProcess.h>
 #include <medAbstractView.h>
-
+#include <medButton.h>
+#include <medMessageController.h>
 #include <medToolBox.h>
 #include <medToolBoxHeader.h>
 #include <medToolBoxBody.h>
 #include <medToolBoxTab.h>
-#include <medButton.h>
-#include <medMessageController.h>
 
 #include <dtkCore/dtkGlobal.h>
 #include <dtkCore/dtkPlugin>

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -30,13 +30,6 @@ class medToolBoxBody;
 class medToolBoxHeader;
 class dtkPlugin;
 
-typedef enum {
-    UNDEFINED=0, //! Miscellanous
-    PIXELTYPE,   //! Pixel type not yet implemented
-    DIMENSION,   //! Not a 3D volume
-    MESHTYPE,    //! Not a mesh
-} DATAERROR;
-
 /**
  * @brief Toolbox that includes a title bar and a widget container.
  *
@@ -105,6 +98,12 @@ signals:
     */
     void failure();
 
+    /**
+     * @brief Emitted when an action from the toolbox failed and we want to display specific user messages.
+     *
+     * Typically used when a dtkProcess returned.
+    */
+    void displayError(int);
 
 public slots:
     virtual void clear();
@@ -115,6 +114,9 @@ public slots:
     void show();
     //Behaviour when you hide/minimize your toolbox
     virtual void behaveWithBodyVisibility(){}
+
+    //! Switch between errors
+    void handleDisplayError(int);
 
     //! Handle volume errors: pixel type
     void displayPixelTypeError();

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -68,14 +68,8 @@ public:
     
     virtual void toXMLNode(QDomDocument* doc, QDomElement* currentNode);
 
-    //! Handle volume errors: pixel type
-    void displayPixelTypeError();
-
-    //! Handle volume errors: dimension
-    void displayDataDimensionError();
-
-    //! Handle mesh errors: data type
-    void displayMeshTypeError();
+    //! Display a qDebug and a medMessageController
+    void displayMessageError(QString error);
 
 signals:
     /**

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -30,6 +30,13 @@ class medToolBoxBody;
 class medToolBoxHeader;
 class dtkPlugin;
 
+typedef enum {
+    UNDEFINED=0, //! Miscellanous
+    PIXELTYPE,   //! Pixel type not yet implemented
+    DIMENSION,   //! Not a 3D volume
+    MESHTYPE,    //! Not a mesh
+} DATAERROR;
+
 /**
  * @brief Toolbox that includes a title bar and a widget container.
  *
@@ -108,6 +115,15 @@ public slots:
     void show();
     //Behaviour when you hide/minimize your toolbox
     virtual void behaveWithBodyVisibility(){}
+
+    //! Handle volume errors: pixel type
+    void displayPixelTypeError();
+
+    //! Handle volume errors: dimension
+    void displayDataDimensionError();
+
+    //! Handle mesh errors: data type
+    void displayMeshTypeError();
 
 protected slots:
     void onAboutButtonClicked();

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -68,6 +68,15 @@ public:
     
     virtual void toXMLNode(QDomDocument* doc, QDomElement* currentNode);
 
+    //! Handle volume errors: pixel type
+    void displayPixelTypeError();
+
+    //! Handle volume errors: dimension
+    void displayDataDimensionError();
+
+    //! Handle mesh errors: data type
+    void displayMeshTypeError();
+
 signals:
     /**
      * @brief Tells the world to add a new toolbox to the medToolboxContainer.
@@ -98,13 +107,6 @@ signals:
     */
     void failure();
 
-    /**
-     * @brief Emitted when an action from the toolbox failed and we want to display specific user messages.
-     *
-     * Typically used when a dtkProcess returned.
-    */
-    void displayError(int);
-
 public slots:
     virtual void clear();
     void switchMinimize();
@@ -117,15 +119,6 @@ public slots:
 
     //! Switch between errors
     void handleDisplayError(int);
-
-    //! Handle volume errors: pixel type
-    void displayPixelTypeError();
-
-    //! Handle volume errors: dimension
-    void displayDataDimensionError();
-
-    //! Handle mesh errors: data type
-    void displayMeshTypeError();
 
 protected slots:
     void onAboutButtonClicked();

--- a/src/medCore/medJobItem.h
+++ b/src/medCore/medJobItem.h
@@ -59,7 +59,7 @@ signals:
     void cancelled (QObject* sender);
     void showError (const QString& message, unsigned int timeout);
     void activate(QObject* sender,bool active);
-    void displayError(int error);
+    void failure(int error);
 
     /**
     * This signal is emitted when the process cannot be cancelled anymore.

--- a/src/medCore/medJobItem.h
+++ b/src/medCore/medJobItem.h
@@ -59,6 +59,7 @@ signals:
     void cancelled (QObject* sender);
     void showError (const QString& message, unsigned int timeout);
     void activate(QObject* sender,bool active);
+    void displayError(int error);
 
     /**
     * This signal is emitted when the process cannot be cancelled anymore.

--- a/src/medCore/process/medAbstractProcess.cpp
+++ b/src/medCore/process/medAbstractProcess.cpp
@@ -16,7 +16,9 @@
 
 medAbstractProcess::medAbstractProcess(medAbstractProcess * parent) : dtkAbstractProcess(*new medAbstractProcessPrivate(this), parent)
 {
+
 }
+
 
 medAbstractProcess::medAbstractProcess(const medAbstractProcess& other) : dtkAbstractProcess(*new medAbstractProcessPrivate(*other.d_func()), other)
 {

--- a/src/medCore/process/medAbstractProcess.cpp
+++ b/src/medCore/process/medAbstractProcess.cpp
@@ -16,14 +16,14 @@
 
 medAbstractProcess::medAbstractProcess(medAbstractProcess * parent) : dtkAbstractProcess(*new medAbstractProcessPrivate(this), parent)
 {
-
 }
-
 
 medAbstractProcess::medAbstractProcess(const medAbstractProcess& other) : dtkAbstractProcess(*new medAbstractProcessPrivate(*other.d_func()), other)
 {
+
 }
 
 medAbstractProcess::~medAbstractProcess()
 {
 }
+

--- a/src/medCore/process/medAbstractProcess.cpp
+++ b/src/medCore/process/medAbstractProcess.cpp
@@ -12,47 +12,16 @@
 =========================================================================*/
 
 #include <medAbstractProcess.h>
-#include <medMessageController.h>
 #include <dtkCore/dtkAbstractObject.h>
 
 medAbstractProcess::medAbstractProcess(medAbstractProcess * parent) : dtkAbstractProcess(*new medAbstractProcessPrivate(this), parent)
 {
-    connect(this, SIGNAL(showError(QString, uint)), medMessageController::instance(), SLOT(showError(QString,uint)));
 }
 
 medAbstractProcess::medAbstractProcess(const medAbstractProcess& other) : dtkAbstractProcess(*new medAbstractProcessPrivate(*other.d_func()), other)
 {
-    connect(this, SIGNAL(showError(QString, uint)), medMessageController::instance(), SLOT(showError(QString,uint)));
 }
 
 medAbstractProcess::~medAbstractProcess()
 {
-}
-
-void medAbstractProcess::displayVolumeError(QString id)
-{
-    QString error;
-    if ( !id.contains("3"))
-    {
-        error = "This toolbox is designed to be used with 3D volumes";
-    }
-    else
-    {
-        error = "Pixel type not yet implemented (" + id + ")";
-    }
-    qDebug() << description() + ": " + error;
-    emit showError(error, 3000);
-}
-
-int medAbstractProcess::isMeshTypeError(QString id)
-{
-    if(!id.contains("vtkDataMesh"))
-    {
-        QString error = "This toolbox is designed to be used with meshes";
-        qDebug() << description() + ": " + error;
-        emit showError(error, 3000);
-
-        return DTK_FAILURE;
-    }
-    return DTK_SUCCEED;
 }

--- a/src/medCore/process/medAbstractProcess.cpp
+++ b/src/medCore/process/medAbstractProcess.cpp
@@ -17,11 +17,12 @@
 
 medAbstractProcess::medAbstractProcess(medAbstractProcess * parent) : dtkAbstractProcess(*new medAbstractProcessPrivate(this), parent)
 {
+    connect(this, SIGNAL(showError(QString, uint)), medMessageController::instance(), SLOT(showError(QString,uint)));
 }
 
 medAbstractProcess::medAbstractProcess(const medAbstractProcess& other) : dtkAbstractProcess(*new medAbstractProcessPrivate(*other.d_func()), other)
 {
-    
+    connect(this, SIGNAL(showError(QString, uint)), medMessageController::instance(), SLOT(showError(QString,uint)));
 }
 
 medAbstractProcess::~medAbstractProcess()
@@ -40,7 +41,7 @@ void medAbstractProcess::displayVolumeError(QString id)
         error = "Pixel type not yet implemented (" + id + ")";
     }
     qDebug() << description() + ": " + error;
-    medMessageController::instance()->showError(error, 3000);
+    emit showError(error, 3000);
 }
 
 int medAbstractProcess::isMeshTypeError(QString id)
@@ -49,7 +50,7 @@ int medAbstractProcess::isMeshTypeError(QString id)
     {
         QString error = "This toolbox is designed to be used with meshes";
         qDebug() << description() + ": " + error;
-        medMessageController::instance()->showError(error, 3000);
+        emit showError(error, 3000);
 
         return DTK_FAILURE;
     }

--- a/src/medCore/process/medAbstractProcess.cpp
+++ b/src/medCore/process/medAbstractProcess.cpp
@@ -12,6 +12,7 @@
 =========================================================================*/
 
 #include <medAbstractProcess.h>
+#include <medMessageController.h>
 #include <dtkCore/dtkAbstractObject.h>
 
 medAbstractProcess::medAbstractProcess(medAbstractProcess * parent) : dtkAbstractProcess(*new medAbstractProcessPrivate(this), parent)
@@ -27,3 +28,30 @@ medAbstractProcess::~medAbstractProcess()
 {
 }
 
+void medAbstractProcess::displayVolumeError(QString id)
+{
+    QString error;
+    if ( !id.contains("3"))
+    {
+        error = "This toolbox is designed to be used with 3D volumes";
+    }
+    else
+    {
+        error = "Pixel type not yet implemented (" + id + ")";
+    }
+    qDebug() << description() + ": " + error;
+    medMessageController::instance()->showError(error, 3000);
+}
+
+int medAbstractProcess::isMeshTypeError(QString id)
+{
+    if(!id.contains("vtkDataMesh"))
+    {
+        QString error = "This toolbox is designed to be used with meshes";
+        qDebug() << description() + ": " + error;
+        medMessageController::instance()->showError(error, 3000);
+
+        return DTK_FAILURE;
+    }
+    return DTK_SUCCEED;
+}

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -44,6 +44,9 @@ public slots:
     virtual medAbstractData *output() = 0;
     virtual int update () = 0;
 
+signals:
+  void showError(QString, uint);
+
 private:
     using dtkAbstractProcess::onCanceled;
     using dtkAbstractProcess::read;

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -37,7 +37,8 @@ public:
     enum DataError
     {
         PIXEL_TYPE = 2, //! Pixel type not yet implemented
-        DIMENSION,      //! Not a 3D volume
+        DIMENSION_3D,   //! Not a 3D volume
+        DIMENSION_4D,   //! Not a 4D volume
         MESH_TYPE,      //! Not a mesh
         UNDEFINED,      //! Miscellanous
     };

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -21,6 +21,17 @@
 
 class medAbstractProcessPrivate;
 
+namespace DATAERROR
+{
+enum DATAERROR
+{
+    PIXELTYPE = 2, //! Pixel type not yet implemented
+    DIMENSION = 3, //! Not a 3D volume
+    MESHTYPE  = 4, //! Not a mesh
+    UNDEFINED = 5, //! Miscellanous
+};
+}
+
 /**
  * Extending dtkAbstractProcess class to hold more specific information
  */

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -21,17 +21,6 @@
 
 class medAbstractProcessPrivate;
 
-namespace DATAERROR
-{
-enum DATAERROR
-{
-    PIXELTYPE = 2, //! Pixel type not yet implemented
-    DIMENSION = 3, //! Not a 3D volume
-    MESHTYPE  = 4, //! Not a mesh
-    UNDEFINED = 5, //! Miscellanous
-};
-}
-
 /**
  * Extending dtkAbstractProcess class to hold more specific information
  */
@@ -44,6 +33,14 @@ public:
     medAbstractProcess(const medAbstractProcess& other);
     virtual ~medAbstractProcess();
     virtual void setInput ( medAbstractData *data, int channel = 0 ){}
+
+    enum DataError
+    {
+        PIXEL_TYPE = 2, //! Pixel type not yet implemented
+        DIMENSION,      //! Not a 3D volume
+        MESH_TYPE,      //! Not a mesh
+        UNDEFINED,      //! Miscellanous
+    };
 
 public slots:
     virtual medAbstractData *output() = 0;

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -34,6 +34,12 @@ public:
     virtual ~medAbstractProcess();
     virtual void setInput ( medAbstractData *data, int channel = 0 ){}
 
+    //! Handle volume errors: dimension, pixel type
+   void displayVolumeError(QString id);
+
+   //! Handle mesh errors: data type
+  int isMeshTypeError(QString id);
+
 public slots:
     virtual medAbstractData *output() = 0;
     virtual int update () = 0;

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -34,18 +34,9 @@ public:
     virtual ~medAbstractProcess();
     virtual void setInput ( medAbstractData *data, int channel = 0 ){}
 
-    //! Handle volume errors: dimension, pixel type
-   void displayVolumeError(QString id);
-
-   //! Handle mesh errors: data type
-  int isMeshTypeError(QString id);
-
 public slots:
     virtual medAbstractData *output() = 0;
     virtual int update () = 0;
-
-signals:
-  void showError(QString, uint);
 
 private:
     using dtkAbstractProcess::onCanceled;

--- a/src/medCore/process/medRunnableProcess.cpp
+++ b/src/medCore/process/medRunnableProcess.cpp
@@ -52,11 +52,17 @@ dtkAbstractProcess * medRunnableProcess::getProcess()
 
 void medRunnableProcess::internalRun()
 {
-    if (d->process) {
-        if (d->process->update() == 0)
+    if (d->process)
+    {
+        int res = d->process->update();
+
+        if (res == 0)
             emit success (this);
         else
+        {
             emit failure (this);
+            emit displayError(res);
+        }
     }
 }
 

--- a/src/medCore/process/medRunnableProcess.cpp
+++ b/src/medCore/process/medRunnableProcess.cpp
@@ -56,12 +56,14 @@ void medRunnableProcess::internalRun()
     {
         int res = d->process->update();
 
-        if (res == 0)
+        if (res == DTK_SUCCEED)
+        {
             emit success (this);
+        }
         else
         {
             emit failure (this);
-            emit displayError(res);
+            emit failure (res); // Can be connected to medToolBox::handleDisplayError(int error)
         }
     }
 }

--- a/src/medCore/process/medRunnableProcess.h
+++ b/src/medCore/process/medRunnableProcess.h
@@ -38,7 +38,6 @@ public:
      medRunnableProcess();
     ~medRunnableProcess();
 
-
     void setProcess (dtkAbstractProcess *proc);
     dtkAbstractProcess * getProcess();
 


### PR DESCRIPTION
This PR allows to standardize a bit our data error messages.
`description()` is defined in the specific process and is going to be the name of the process.

(Thx @fcollot for the translation of the error messages ^^)

:m: