### PR TITLE
[medAbstractWorkspace] rm last layer removes also the view

### DIFF
--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -522,14 +522,16 @@ void medAbstractWorkspace::removeLayer()
     int layer = item->data(Qt::UserRole).toInt();
 
     medAbstractLayeredView *layerView = dynamic_cast<medAbstractLayeredView *>(medViewContainerManager::instance()->container(containerUuid)->view());
-    if(!layerView)
-        return;
+    if(layerView)
+    {
+        layerView->removeLayer(layer);
 
-    layerView->removeLayer(layer);
-
-    this->updateLayersToolBox();
+        if (layerView->layersCount() == 0) // remove the view if no more layer
+        {
+            medViewContainerManager::instance()->container(containerUuid)->removeView();
+        }
+    }
 }
-
 
 void medAbstractWorkspace::buildTemporaryPool()
 {


### PR DESCRIPTION
In Layer settings, when you removed the last layer, there was an empty data displayed on the view. This PR allows to clean and remove the view when there is no data left on the view. I removed also the call to 
`updateLayersToolBox()` because it's automatically done.

:m:
