### PR TITLE
[medSlider] Where you click is where you get

### DIFF
--- a/src/medCore/gui/commonWidgets/medSlider.cpp
+++ b/src/medCore/gui/commonWidgets/medSlider.cpp
@@ -49,7 +49,7 @@ void medSlider::paintEvent(QPaintEvent *ev)
     }
 }
 
-void medSlider::mousePressEvent ( QMouseEvent * event )
+void medSlider::mousePressEvent(QMouseEvent *event)
 {
     QSlider::mousePressEvent(event);
     setValue(QStyle::sliderValueFromPosition(minimum(), maximum(), event->x(), width()));

--- a/src/medCore/gui/commonWidgets/medSlider.cpp
+++ b/src/medCore/gui/commonWidgets/medSlider.cpp
@@ -49,3 +49,9 @@ void medSlider::paintEvent(QPaintEvent *ev)
     }
 }
 
+void medSlider::mousePressEvent ( QMouseEvent * event )
+{
+    QSlider::mousePressEvent(event);
+    setValue(QStyle::sliderValueFromPosition(minimum(), maximum(), event->x(), width()));
+    event->accept();
+}

--- a/src/medCore/gui/commonWidgets/medSlider.h
+++ b/src/medCore/gui/commonWidgets/medSlider.h
@@ -28,6 +28,7 @@ public slots:
 
 protected:
     void paintEvent(QPaintEvent *ev);
+    void mousePressEvent ( QMouseEvent * event );
 
 private:
     QList<int> ticksList;

--- a/src/medCore/gui/commonWidgets/medSlider.h
+++ b/src/medCore/gui/commonWidgets/medSlider.h
@@ -28,7 +28,7 @@ public slots:
 
 protected:
     void paintEvent(QPaintEvent *ev);
-    void mousePressEvent ( QMouseEvent * event );
+    void mousePressEvent(QMouseEvent *event);
 
 private:
     QList<int> ticksList;


### PR DESCRIPTION
When clicking on the bar of the slider, this one moves incrementally: if you click at the left extremity of the bar, the slider will move on step to the left ... You get the idea.

With this PR, the slider jumps where you click.

It is appreciated when changing the slice.

Note: medSlider is only used inside medIntParameters, so you know where to do the tests. (I will see if I can use medSlider in more cases)