### PR TITLE
[manualRegistration] debug linux view reset

### DIFF
--- a/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
@@ -99,7 +99,7 @@ manualRegistrationLandmark::~manualRegistrationLandmark()
     HandleWidget->RemoveAllObservers();
     HandleWidget->Delete();
     HandleWidget=0;
-    View->RemoveObserver(SeedCallback);
+
     SeedCallback = 0;
 }
 

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -286,21 +286,22 @@ void manualRegistrationLandmarkController::Reset()
     {
         for(int i=0;i<Points_Fixed->size();i++)
         {
-            RequestDeletion(Points_Fixed->at(i));
+            Points_Fixed->at(i)->RemoveAllObservers();
+            Points_Fixed->at(i)->Delete();
         }
-        ClearUselessLandmarks();
-        Points_Fixed->clear();
     }
 
     if(ViewMoving)
     {
         for(int i=0;i<Points_Moving->size();i++)
         {
-            RequestDeletion(Points_Moving->at(i));
+            Points_Moving->at(i)->RemoveAllObservers();
+            Points_Moving->at(i)->Delete();
         }
-        ClearUselessLandmarks();
-        Points_Moving->clear();
     }
+
+    Points_Fixed->clear();
+    Points_Moving->clear();
 
     // Update the user label with the number of current landmarks
     Tbx->updateLabels(Points_Fixed->size(),Points_Moving->size());

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -286,22 +286,23 @@ void manualRegistrationLandmarkController::Reset()
     {
         for(int i=0;i<Points_Fixed->size();i++)
         {
-            Points_Fixed->at(i)->RemoveAllObservers();
-            Points_Fixed->at(i)->Delete();
+            RequestDeletion(Points_Fixed->at(i));
         }
+        ClearUselessLandmarks();
+        Points_Fixed->clear();
     }
 
     if(ViewMoving)
     {
         for(int i=0;i<Points_Moving->size();i++)
         {
-            Points_Moving->at(i)->RemoveAllObservers();
-            Points_Moving->at(i)->Delete();
+            RequestDeletion(Points_Moving->at(i));
         }
+        ClearUselessLandmarks();
+        Points_Moving->clear();
     }
 
-    Points_Fixed->clear();
-    Points_Moving->clear();
+    // Update the user label with the number of current landmarks
     Tbx->updateLabels(Points_Fixed->size(),Points_Moving->size());
 }
 

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -362,7 +362,10 @@ void manualRegistrationToolBox::computeRegistration()
 void manualRegistrationToolBox::reset()
 {
     if (d->controller)
-        d->controller->Reset();
+    {
+        d->controller->Reset(); // Delete every landmark on both view
+    }
+
     medAbstractImageView * viewFuse = qobject_cast<medAbstractImageView*>(d->bottomContainer->view());
     medAbstractImageView * viewMoving = qobject_cast<medAbstractImageView*>(d->rightContainer->view());
     viewFuse->removeLayer(1);


### PR DESCRIPTION
Debug on https://github.com/Inria-Asclepios/medInria-public/pull/4

> Open data -> Start Segmentation -> add landmarks -> Close a view (with the X button)
> You will have a seg fault in `manualRegistrationLandmark::~manualRegistrationLandmark()` at `View->RemoveObserver(SeedCallback);`

I wanted also to refresh the views after a Reset() with something like `static_cast<medVtkViewBackend*>(d->leftContainer->view()->backend())->view2D->Render();` but did not succeed right now, and it was not an emergency.

:m:

