### PR TITLE
[workspace] init not in tlbx

### DIFF
--- a/app/medInria/medSegmentationWorkspace.cpp
+++ b/app/medInria/medSegmentationWorkspace.cpp
@@ -40,7 +40,6 @@ medSegmentationWorkspace::medSegmentationWorkspace(QWidget * parent /* = NULL */
 medAbstractWorkspace(parent), d(new medSegmentationWorkspacePrivate)
 {
     d->segmentationToolBox = new medSegmentationSelectorToolBox(parent);
-    d->segmentationToolBox->setWorkspace(this);
 
     connect(d->segmentationToolBox,SIGNAL(success()),this,SLOT(onSuccess()));
 

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -240,15 +240,6 @@ void iterativeClosestPointToolBox::updateView()
     }
 }
 
-//void iterativeClosestPointToolBox::setWorkspace(medAbstractWorkspace* workspace)
-//{
-//    medToolBox::setWorkspace(workspace);
-//    medTabbedViewContainers * containers = workspace->stackedViewContainers();
-
-//    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-//    updateView();
-//}
-
 void iterativeClosestPointToolBox::resetComboBoxes()
 {
     d->layerSource->clear();

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -240,14 +240,14 @@ void iterativeClosestPointToolBox::updateView()
     }
 }
 
-void iterativeClosestPointToolBox::setWorkspace(medAbstractWorkspace* workspace)
-{
-    medToolBox::setWorkspace(workspace);
-    medTabbedViewContainers * containers = workspace->stackedViewContainers();
+//void iterativeClosestPointToolBox::setWorkspace(medAbstractWorkspace* workspace)
+//{
+//    medToolBox::setWorkspace(workspace);
+//    medTabbedViewContainers * containers = workspace->stackedViewContainers();
 
-    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-    updateView();
-}
+//    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
+//    updateView();
+//}
 
 void iterativeClosestPointToolBox::resetComboBoxes()
 {

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.h
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.h
@@ -29,7 +29,7 @@ public:
     
 public:
     static bool registered();
-    void setWorkspace(medAbstractWorkspace*);
+    //void setWorkspace(medAbstractWorkspace*);
     void addLayer(unsigned int layer);
     
 public slots:

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.h
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.h
@@ -29,7 +29,6 @@ public:
     
 public:
     static bool registered();
-    //void setWorkspace(medAbstractWorkspace*);
     void addLayer(unsigned int layer);
     
 public slots:

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -184,14 +184,14 @@ void manualRegistrationToolBox::updateView()
 
 }
 
-void manualRegistrationToolBox::setWorkspace(medAbstractWorkspace* workspace)
-{
-    medToolBox::setWorkspace(workspace);
-    medTabbedViewContainers * containers = workspace->stackedViewContainers();
+//void manualRegistrationToolBox::setWorkspace(medAbstractWorkspace* workspace)
+//{
+//    medToolBox::setWorkspace(workspace);
+//    medTabbedViewContainers * containers = workspace->stackedViewContainers();
 
-    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-    updateView();
-}
+//    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
+//    updateView();
+//}
 
 void manualRegistrationToolBox::startManualRegistration()
 {

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -184,15 +184,6 @@ void manualRegistrationToolBox::updateView()
 
 }
 
-//void manualRegistrationToolBox::setWorkspace(medAbstractWorkspace* workspace)
-//{
-//    medToolBox::setWorkspace(workspace);
-//    medTabbedViewContainers * containers = workspace->stackedViewContainers();
-
-//    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-//    updateView();
-//}
-
 void manualRegistrationToolBox::startManualRegistration()
 {
     if(d->regOn)

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -39,7 +39,7 @@ public:
     static bool registered();
     dtkPlugin * plugin();
 
-    void setWorkspace(medAbstractWorkspace* workspace);
+    //void setWorkspace(medAbstractWorkspace* workspace);
     void updateLabels(int left,int right);
 
 protected slots:

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -39,7 +39,6 @@ public:
     static bool registered();
     dtkPlugin * plugin();
 
-    //void setWorkspace(medAbstractWorkspace* workspace);
     void updateLabels(int left,int right);
 
 protected slots:

--- a/src-plugins/medClut/medClutToolBox.cpp
+++ b/src-plugins/medClut/medClutToolBox.cpp
@@ -122,15 +122,6 @@ medClutToolBox::~medClutToolBox(void)
     d = NULL;
 }
 
-void medClutToolBox::setWorkspace(medAbstractWorkspace* workspace)
-{
-    medToolBox::setWorkspace(workspace);
-    medTabbedViewContainers * containers = workspace->stackedViewContainers();
-
-    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-    updateView();
-}
-
 void medClutToolBox::updateView()
 {
     medTabbedViewContainers * containers = this->getWorkspace()->stackedViewContainers();

--- a/src-plugins/medClut/medClutToolBox.h
+++ b/src-plugins/medClut/medClutToolBox.h
@@ -34,10 +34,6 @@ class MEDCLUTPLUGIN_EXPORT medClutToolBox : public medToolBox
 public:
      medClutToolBox(QWidget *parent = 0);
     ~medClutToolBox();
-    /**
-    Whenever the view is changed, update method is triggered.
-    */
-    void setWorkspace(medAbstractWorkspace* workspace);
 
     static bool registered();
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -621,16 +621,6 @@ void AlgorithmPaintToolBox::import()
     maskHasBeenSaved = true;
 }
 
-void AlgorithmPaintToolBox::setWorkspace(medAbstractWorkspace* workspace)
-{
-    medSegmentationAbstractToolBox::setWorkspace(workspace);
-    medTabbedViewContainers * containers = workspace->stackedViewContainers();
-
-    connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()),Qt::UniqueConnection);
-
-    updateView();
-}
-
 void AlgorithmPaintToolBox::updateView()
 {
     medTabbedViewContainers * containers = this->getWorkspace()->stackedViewContainers();

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -59,7 +59,6 @@ public:
     ~AlgorithmPaintToolBox();
 
     static bool registered();
-    void setWorkspace(medAbstractWorkspace* workspace);
 
     inline void setPaintState( PaintState::E value){m_paintState = value;}
     inline PaintState::E paintState(){return m_paintState;}

--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -138,14 +138,6 @@ dtkPlugin* medCropToolBox::plugin()
     return medPluginManager::instance()->plugin("reformatPlugin");
 }
 
-void medCropToolBox::setWorkspace(medAbstractWorkspace* workspace)
-{
-    medToolBox::setWorkspace(workspace);
-    medTabbedViewContainers* containers = workspace->stackedViewContainers();
-    connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-    updateView();
-}
-
 medAbstractData* medCropToolBox::processOutput()
 {
     if (d->view)

--- a/src-plugins/reformat/medCropToolBox.h
+++ b/src-plugins/reformat/medCropToolBox.h
@@ -21,7 +21,6 @@ public:
     virtual ~medCropToolBox();
 
     virtual dtkPlugin* plugin();
-    virtual void setWorkspace(medAbstractWorkspace* workspace);
     virtual medAbstractData* processOutput();
 
     void handleInteractionEvent();

--- a/src-plugins/reformat/reformatWorkspace.cpp
+++ b/src-plugins/reformat/reformatWorkspace.cpp
@@ -55,10 +55,6 @@ reformatWorkspace::reformatWorkspace(QWidget *parent) : medAbstractWorkspace(par
             medToolBox* toolBox = medToolBoxFactory::instance()->createToolBox(toolbox, parent);
             addToolBox(toolBox);
             toolBox->switchMinimize();
-
-            toolBox->setWorkspace(this);
-            connect(this->stackedViewContainers(), SIGNAL(containersSelectedChanged()), toolBox,
-                    SLOT(updateView()), Qt::UniqueConnection);
         }
     }
 }

--- a/src-plugins/reformat/reformatWorkspace.cpp
+++ b/src-plugins/reformat/reformatWorkspace.cpp
@@ -54,8 +54,11 @@ reformatWorkspace::reformatWorkspace(QWidget *parent) : medAbstractWorkspace(par
         {
             medToolBox* toolBox = medToolBoxFactory::instance()->createToolBox(toolbox, parent);
             addToolBox(toolBox);
-            toolBox->setWorkspace(this);
             toolBox->switchMinimize();
+
+            toolBox->setWorkspace(this);
+            connect(this->stackedViewContainers(), SIGNAL(containersSelectedChanged()), toolBox,
+                    SLOT(updateView()), Qt::UniqueConnection);
         }
     }
 }

--- a/src-plugins/reformat/resliceToolBox.cpp
+++ b/src-plugins/reformat/resliceToolBox.cpp
@@ -221,15 +221,6 @@ void resliceToolBox::stopReformat()
     }
 }
 
-void resliceToolBox::setWorkspace(medAbstractWorkspace * workspace)
-{
-    medToolBox::setWorkspace(workspace);
-
-    medTabbedViewContainers * containers = workspace->stackedViewContainers();
-    QObject::connect(containers,SIGNAL(containersSelectedChanged()),this,SLOT(updateView()));
-    updateView();
-}
-
 void resliceToolBox::updateView()
 {
     medTabbedViewContainers * containers = this->getWorkspace()->stackedViewContainers();

--- a/src-plugins/reformat/resliceToolBox.h
+++ b/src-plugins/reformat/resliceToolBox.h
@@ -17,7 +17,6 @@ public:
     ~resliceToolBox();
     static bool registered();
     dtkPlugin* plugin();
-    void setWorkspace(medAbstractWorkspace * workspace);
     medAbstractData *processOutput();
     void changeButtonValue(QString buttonName, double value);
 

--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -143,6 +143,7 @@ void medAbstractWorkspace::addToolBox(medToolBox *toolbox)
 
 void medAbstractWorkspace::removeToolBox(medToolBox *toolbox)
 {
+    toolbox->setWorkspace(NULL);
     d->toolBoxes.removeOne(toolbox);
 }
 

--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -137,6 +137,7 @@ medAbstractWorkspace::~medAbstractWorkspace(void)
 
 void medAbstractWorkspace::addToolBox(medToolBox *toolbox)
 {
+    toolbox->setWorkspace(this);
     d->toolBoxes.append(toolbox);
 }
 

--- a/src/medCore/gui/toolboxes/medDiffusionSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medDiffusionSelectorToolBox.cpp
@@ -193,6 +193,7 @@ void medDiffusionSelectorToolBox::chooseToolBox(int id)
         {
             toolbox->header()->hide();
             d->toolBoxes[identifier] = toolbox;
+            toolbox->setWorkspace(getWorkspace());
 
             if (d->selectorType == ScalarMaps)
             {

--- a/src/medCore/gui/toolboxes/medFilteringSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medFilteringSelectorToolBox.cpp
@@ -119,6 +119,7 @@ void medFilteringSelectorToolBox::changeCurrentToolBox(const QString &identifier
         toolbox = qobject_cast<medFilteringAbstractToolBox *>(tb);
         if(toolbox)
         {
+            toolbox->setWorkspace(getWorkspace());
             toolbox->setStyleSheet("medToolBoxBody {border:none}");
             d->toolBoxes[identifier] = toolbox;
         }

--- a/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
@@ -26,12 +26,17 @@ class MEDCORE_EXPORT medSegmentationAbstractToolBox : public medToolBox
     Q_OBJECT
 
 public:
-             medSegmentationAbstractToolBox(QWidget *parent = 0);
+    medSegmentationAbstractToolBox(QWidget *parent = 0);
     virtual ~medSegmentationAbstractToolBox();
 
     virtual dtkPlugin* plugin() = 0;
 
     virtual medAbstractData *processOutput() = 0;
+
+public slots:
+
+    //! Launched when the view is updated
+    virtual void updateView() = 0;
 
 protected:
     medSegmentationSelectorToolBox *segmentationToolBox();

--- a/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
@@ -35,8 +35,7 @@ public:
 
 public slots:
 
-    //! Launched when the view is updated
-    virtual void updateView() = 0;
+    void updateView(){}
 
 protected:
     medSegmentationSelectorToolBox *segmentationToolBox();

--- a/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationAbstractToolBox.h
@@ -33,10 +33,6 @@ public:
 
     virtual medAbstractData *processOutput() = 0;
 
-public slots:
-
-    void updateView(){}
-
 protected:
     medSegmentationSelectorToolBox *segmentationToolBox();
 

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
@@ -11,16 +11,13 @@
 
 =========================================================================*/
 
-#include <medSegmentationSelectorToolBox.h>
-
-#include <medToolBoxFactory.h>
-#include <medToolBoxTab.h>
 #include <medSegmentationAbstractToolBox.h>
+#include <medSegmentationSelectorToolBox.h>
+#include <medTabbedViewContainers.h>
+#include <medToolBoxFactory.h>
 #include <medToolBoxHeader.h>
+#include <medToolBoxTab.h>
 #include <medViewEventFilter.h>
-
-#include <QtGui>
-
 
 class medSegmentationSelectorToolBoxPrivate
 {
@@ -92,10 +89,13 @@ void medSegmentationSelectorToolBox::changeCurrentToolBox(int index)
         toolbox = qobject_cast<medSegmentationAbstractToolBox*>(tb);
         if (toolbox)
         {
-            medAbstractWorkspace* workspace = getWorkspace();
-            if(workspace)
-                toolbox->setWorkspace(workspace);
+            // Define how to react when the view is updated
+            toolbox->setWorkspace(getWorkspace());
+            connect(this->getWorkspace()->stackedViewContainers(), SIGNAL(containersSelectedChanged()), toolbox,
+                    SLOT(updateView()), Qt::UniqueConnection);
+
             toolbox->setStyleSheet("medToolBoxBody {border:none}");
+
             d->segmentationToolBoxes[identifier] = toolbox;
         }
     }

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.cpp
@@ -89,11 +89,7 @@ void medSegmentationSelectorToolBox::changeCurrentToolBox(int index)
         toolbox = qobject_cast<medSegmentationAbstractToolBox*>(tb);
         if (toolbox)
         {
-            // Define how to react when the view is updated
             toolbox->setWorkspace(getWorkspace());
-            connect(this->getWorkspace()->stackedViewContainers(), SIGNAL(containersSelectedChanged()), toolbox,
-                    SLOT(updateView()), Qt::UniqueConnection);
-
             toolbox->setStyleSheet("medToolBoxBody {border:none}");
 
             d->segmentationToolBoxes[identifier] = toolbox;

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.h
@@ -35,7 +35,7 @@ signals:
 
 public slots:
     void changeCurrentToolBox(int index);
-
+    void updateView(){}
 
 private:
     medSegmentationSelectorToolBoxPrivate *d;

--- a/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.h
+++ b/src/medCore/gui/toolboxes/medSegmentationSelectorToolBox.h
@@ -35,7 +35,6 @@ signals:
 
 public slots:
     void changeCurrentToolBox(int index);
-    void updateView(){}
 
 private:
     medSegmentationSelectorToolBoxPrivate *d;

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -16,6 +16,7 @@
 #include <medAbstractView.h>
 #include <medButton.h>
 #include <medMessageController.h>
+#include <medTabbedViewContainers.h>
 #include <medToolBox.h>
 #include <medToolBoxHeader.h>
 #include <medToolBoxBody.h>
@@ -299,6 +300,8 @@ medAbstractWorkspace* medToolBox::getWorkspace()
 void medToolBox::setWorkspace(medAbstractWorkspace* workspace)
 {
     d->workspace = workspace;
+    connect(workspace->stackedViewContainers(), SIGNAL(containersSelectedChanged()), this,
+            SLOT(updateView()), Qt::UniqueConnection);
 }
 
 void medToolBox::toXMLNode(QDomDocument* doc, QDomElement* currentNode)

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -300,8 +300,11 @@ medAbstractWorkspace* medToolBox::getWorkspace()
 void medToolBox::setWorkspace(medAbstractWorkspace* workspace)
 {
     d->workspace = workspace;
-    connect(workspace->stackedViewContainers(), SIGNAL(containersSelectedChanged()), this,
-            SLOT(updateView()), Qt::UniqueConnection);
+    if (workspace)
+    {
+        connect(workspace->stackedViewContainers(), SIGNAL(containersSelectedChanged()), this,
+                SLOT(updateView()), Qt::UniqueConnection);
+    }
 }
 
 void medToolBox::toXMLNode(QDomDocument* doc, QDomElement* currentNode)

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -114,6 +114,8 @@ public slots:
     //! Switch between errors
     void handleDisplayError(int);
 
+    virtual void updateView(){}
+
 protected slots:
     void onAboutButtonClicked();
     


### PR DESCRIPTION
I tried to work on this issue: https://github.com/Inria-Asclepios/medInria-public/issues/34

> We should remove all the calls to  ```medToolBox::setWorkspace ``` and do it directly in ```medAbstractWorkspace::addToolBox ```.

For now, this is the only way i found to use the toolboxes from the Segmentation workspace.
Working also with the Reformat workspace.

(I'll be in holiday tomorrow, and monday/tuesday of the next week)