### PR TITLE
[ICP] uses medComboBox (tiny)

### DIFF
--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -53,7 +53,7 @@ public:
     QDoubleSpinBox * ScaleFactor,* MaxMeanDistance;
     QSpinBox * MaxNumIterations, * MaxNumLandmarks;
     QCheckBox * bStartByMatchingCentroids,*bCheckMeanDistance;
-    QComboBox* bTransformationComboBox;
+    medComboBox* bTransformationComboBox;
 };
 
 iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent) : medRegistrationAbstractToolBox(parent), d(new iterativeClosestPointToolBoxPrivate)
@@ -87,7 +87,7 @@ iterativeClosestPointToolBox::iterativeClosestPointToolBox(QWidget *parent) : me
     QLabel * transformation_Label = new QLabel("Transformation");
     transformation_layout->addWidget(transformation_Label);
 
-    d->bTransformationComboBox = new QComboBox(widget);
+    d->bTransformationComboBox = new medComboBox(widget);
     d->bTransformationComboBox->addItem("Rigid body");
     d->bTransformationComboBox->addItem("Similarity");
     d->bTransformationComboBox->addItem("Affine");


### PR DESCRIPTION
Reminder: instead of QComboBox, medComboBox can only be scrolled when it has focus, it prevents annoying behaviours when scrolling down a toolbox.