### PR TITLE
Metadata writing/reading for VTK and ITK

### DIFF
--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -23,7 +23,6 @@
 #include <vtkPolyData.h>
 #include <vtkPolyDataReader.h>
 #include <vtkStringArray.h>
-#include <vtkXMLPolyDataReader.h>
 
 const char vtkDataMeshReader::ID[] = "vtkDataMeshReader";
 

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -98,9 +98,6 @@ bool vtkDataMeshReader::read(const QString& path) {
             {
                 qDebug() << metaObject()->className() << ": no metadata found in " << path;
             }
-
-            setProgress(100);
-            return true;
         }
         catch (vtkErrorCode::ErrorIds error)
         {
@@ -112,6 +109,9 @@ bool vtkDataMeshReader::read(const QString& path) {
             qDebug() << metaObject()->className() << ": error reading " << path;;
             return false;
         }
+
+        setProgress(100);
+        return true;
     }
     else
     {

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -135,6 +135,7 @@ bool vtkDataMeshReader::extractMetaDataFromFieldData(vtkMetaDataSet* dataSet)
 {
     bool foundMetaData = false;
     vtkFieldData* fieldData = dataSet->GetDataSet()->GetFieldData();
+    QList<QString> arraysToRemove;
 
     for (int i = 0; i < fieldData->GetNumberOfArrays(); i++)
     {
@@ -151,8 +152,19 @@ bool vtkDataMeshReader::extractMetaDataFromFieldData(vtkMetaDataSet* dataSet)
             {
                 data()->addMetaData(metaDataKey, QString(array->GetValue(j)));
             }
+
+            arraysToRemove.append(arrayName);
         }
     }
+
+    foreach (QString arrayName, arraysToRemove)
+    {
+        fieldData->RemoveArray(arrayName.toStdString().c_str());
+    }
+
+    vtkSmartPointer<vtkFieldData> newFieldData = vtkSmartPointer<vtkFieldData>::New();
+    newFieldData->PassData(fieldData);
+    dataSet->GetDataSet()->SetFieldData(newFieldData);
 
     return foundMetaData;
 }

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -122,25 +122,8 @@ bool vtkDataMeshReader::read(const QString& path) {
 
 bool vtkDataMeshReader::extractMetaData(QString path, vtkMetaDataSet* dataSet)
 {
-    if (extractCartoMetaData(dataSet) || extractMetaDataFromHeader(path, dataSet) || extractMetaDataFromFieldData(dataSet))
+    if (extractMetaDataFromFieldData(dataSet) || extractMetaDataFromHeader(path, dataSet) || extractCartoMetaData(dataSet))
     {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
-}
-
-// For CARTO files the patient name and ID is stored in the header and retrieved by vtkMetaSurfaceMesh::ReadVtkFile
-bool vtkDataMeshReader::extractCartoMetaData(vtkMetaDataSet* dataSet)
-{
-    std::string patientName, patientID;
-
-    if (dataSet->GetMetaData("PatientName", patientName) && dataSet->GetMetaData("PatientID", patientID))
-    {
-        data()->setMetaData(medMetaDataKeys::PatientName.key(), QString::fromStdString(patientName));
-        data()->setMetaData(medMetaDataKeys::PatientID.key(), QString::fromStdString(patientID));
         return true;
     }
     else
@@ -185,12 +168,29 @@ bool vtkDataMeshReader::extractMetaDataFromHeader(QString path, vtkMetaDataSet* 
     header = reader->GetHeader();
     QStringList headerElements = header.split("\t");
 
-    for (int i = 0; i < headerElements.count(); i += 2)
+    for (int i = 0; i < headerElements.count() - 1; i += 2)
     {
         data()->setMetaData(headerElements.at(i), headerElements.at(i + 1));
     }
 
     return headerElements.count() >= 2;
+}
+
+// For CARTO files the patient name and ID is stored in the header and retrieved by vtkMetaSurfaceMesh::ReadVtkFile
+bool vtkDataMeshReader::extractCartoMetaData(vtkMetaDataSet* dataSet)
+{
+    std::string patientName, patientID;
+
+    if (dataSet->GetMetaData("PatientName", patientName) && dataSet->GetMetaData("PatientID", patientID))
+    {
+        data()->setMetaData(medMetaDataKeys::PatientName.key(), QString::fromStdString(patientName));
+        data()->setMetaData(medMetaDataKeys::PatientID.key(), QString::fromStdString(patientID));
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 bool vtkDataMeshReader::read(const QStringList& paths) {

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.h
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.h
@@ -55,9 +55,9 @@ private:
 
     static const char ID[];
     bool extractMetaData(QString path, vtkMetaDataSet* dataSet);
-    bool extractCartoMetaData(vtkMetaDataSet* dataSet);
     bool extractMetaDataFromFieldData(vtkMetaDataSet* dataSet);
     bool extractMetaDataFromHeader(QString path, vtkMetaDataSet* dataSet);
+    bool extractCartoMetaData(vtkMetaDataSet* dataSet);
 };
 
 

--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.h
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.h
@@ -20,6 +20,7 @@
 #include <vtkSmartPointer.h>
 
 class vtkDataSetReader;
+class vtkMetaDataSet;
 
 class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshReader: public dtkAbstractDataReader {
     Q_OBJECT
@@ -53,9 +54,10 @@ public slots:
 private:
 
     static const char ID[];
-    QStringList metaDataKeysToCopy();
-    void parseHeaderVtk(QString header, medAbstractData* medData);
-    void parseHeaderVtp(vtkSmartPointer<vtkFieldData> field, medAbstractData *medData);
+    bool extractMetaData(QString path, vtkMetaDataSet* dataSet);
+    bool extractCartoMetaData(vtkMetaDataSet* dataSet);
+    bool extractMetaDataFromFieldData(vtkMetaDataSet* dataSet);
+    bool extractMetaDataFromHeader(QString path, vtkMetaDataSet* dataSet);
 };
 
 

--- a/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
+++ b/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
@@ -25,6 +25,8 @@ class VTKDATAMESHPLUGIN_EXPORT vtkDataMeshWriter : public dtkAbstractDataWriter
     Q_OBJECT
 
 public:
+    static const QString metaDataFieldPrefix;
+
              vtkDataMeshWriter();
     virtual ~vtkDataMeshWriter();
 
@@ -45,8 +47,6 @@ public slots:
 
 private:
     static const char ID[];
-
-    QList<QString> metaDataFields;
 
     void addMetaDataAsFieldData(vtkMetaDataSet* dataSet);
     void clearMetaDataFieldData(vtkMetaDataSet* dataSet);

--- a/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
+++ b/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
@@ -45,7 +45,11 @@ public slots:
 
 private:
     static const char ID[];
+
+    QList<QString> metaDataFields;
+
     void addMetaDataAsFieldData(vtkMetaDataSet* dataSet);
+    void clearMetaDataFieldData(vtkMetaDataSet* dataSet);
 };
 
 

--- a/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
+++ b/src-plugins/vtkDataMesh/writers/vtkDataMeshWriter.h
@@ -45,9 +45,7 @@ public slots:
 
 private:
     static const char ID[];
-    QStringList metaDataKeysToCopy();
-    QString getHeaderVtk();
-    void addHeaderVtpToMesh(vtkMetaDataSet *mesh);
+    void addMetaDataAsFieldData(vtkMetaDataSet* dataSet);
 };
 
 

--- a/src/medImageIO/itkDataImageReaderBase.cpp
+++ b/src/medImageIO/itkDataImageReaderBase.cpp
@@ -279,10 +279,17 @@ void itkDataImageReaderBase::extractMetaData()
         }
         else
         {
-            metaDataKey = QString::fromStdString(key);
+            const medMetaDataKeys::Key* medKey = medMetaDataKeys::Key::fromKeyName(key.c_str());
+            if (medKey)
+            {
+                metaDataKey = medKey->key();
+            }
         }
 
-        data()->setMetaData(metaDataKey, QString(value.c_str()));
+        if (!metaDataKey.isEmpty())
+        {
+            data()->setMetaData(metaDataKey, QString(value.c_str()));
+        }
     }
 }
 

--- a/src/medImageIO/itkDataImageReaderBase.cpp
+++ b/src/medImageIO/itkDataImageReaderBase.cpp
@@ -247,72 +247,43 @@ bool itkDataImageReaderBase::read_image(const QString& path,const char* type)
     typename Image::Pointer im = TReader->GetOutput();
     medData->setData(im);
 
-    const itk::MetaDataDictionary dict = im->GetMetaDataDictionary();
+    extractMetaData();
 
-    //  Recover the pixel meaning from the intent_name.
-    std::string PixMeaning;
-    if (itk::ExposeMetaData(dict,"intent_name",PixMeaning))
-        medData->addMetaData(medAbstractImageData::PixelMeaningMetaData,QString(PixMeaning.c_str()));
-
-    // Add meta data to the medAbstractData volume
-    QStringList keyList = metaDataKeysToCopy();
-    std::string value;
-    foreach(QString key, keyList)
-    {
-        if (itk::ExposeMetaData(dict, key.toStdString(), value))
-        {
-            medData->setMetaData(key, QString(value.c_str()));
-        }
-    }
-
-    if (itk::ExposeMetaData(dict, "MED_MODALITY", value))
-    {
-        medData->setMetaData(medMetaDataKeys::Modality.key(), QString(value.c_str()));
-    }
-    if (itk::ExposeMetaData(dict, "MED_ORIENTATION", value))
-    {
-        medData->setMetaData(medMetaDataKeys::Orientation.key(), QString(value.c_str()));
-    }
     return true;
 }
 
-QStringList itkDataImageReaderBase::metaDataKeysToCopy()
+void itkDataImageReaderBase::extractMetaData()
 {
-    QStringList keys;
+    itk::Object* itkImage = static_cast<itk::Object*>(data()->data());
+    itk::MetaDataDictionary& metaDataDictionary = itkImage->GetMetaDataDictionary();
+    std::vector<std::string> keys = metaDataDictionary.GetKeys();
 
-    keys << medMetaDataKeys::PatientID.key()
-         << medMetaDataKeys::PatientName.key()
-         << medMetaDataKeys::Age.key()
-         << medMetaDataKeys::BirthDate.key()
-         << medMetaDataKeys::Gender.key()
-         << medMetaDataKeys::Description.key()
-         << medMetaDataKeys::StudyID.key()
-         << medMetaDataKeys::StudyDicomID.key()
-         << medMetaDataKeys::StudyDescription.key()
-         << medMetaDataKeys::Institution.key()
-         << medMetaDataKeys::Referee.key()
-         << medMetaDataKeys::StudyDate.key()
-         << medMetaDataKeys::StudyTime.key()
-         << medMetaDataKeys::Performer.key()
-         << medMetaDataKeys::Report.key()
-         << medMetaDataKeys::Protocol.key()
-         << medMetaDataKeys::Origin.key()
-         << medMetaDataKeys::AcquisitionDate.key()
-         << medMetaDataKeys::AcquisitionTime.key()
-         << medMetaDataKeys::Columns.key()
-         << medMetaDataKeys::Rows.key()
-         << medMetaDataKeys::Dimensions.key()
-         << medMetaDataKeys::NumberOfDimensions.key()
-         << medMetaDataKeys::SliceThickness.key()
-         << medMetaDataKeys::Spacing.key()
-         << medMetaDataKeys::XSpacing.key()
-         << medMetaDataKeys::YSpacing.key()
-         << medMetaDataKeys::ZSpacing.key()
-         << medMetaDataKeys::NumberOfComponents.key()
-         << medMetaDataKeys::ComponentType.key()
-         << medMetaDataKeys::PixelType.key();
+    for (int i = 0; i < keys.size(); i++)
+    {
+        std::string key = keys[i];
+        std::string value;
+        itk::ExposeMetaData(metaDataDictionary, key, value);
+        QString metaDataKey;
 
-    return keys;
+        if (key == "intent_name")
+        {
+            metaDataKey = medAbstractImageData::PixelMeaningMetaData;
+        }
+        else if (key == "MED_MODALITY")
+        {
+            metaDataKey = medMetaDataKeys::Modality.key();
+        }
+        else if (key == "MED_ORIENTATION")
+        {
+            metaDataKey = medMetaDataKeys::Orientation.key();
+        }
+        else
+        {
+            metaDataKey = QString::fromStdString(key);
+        }
+
+        data()->setMetaData(metaDataKey, QString(value.c_str()));
+    }
 }
 
 bool itkDataImageReaderBase::read(const QString& path)

--- a/src/medImageIO/itkDataImageReaderBase.h
+++ b/src/medImageIO/itkDataImageReaderBase.h
@@ -50,7 +50,7 @@ protected:
 private:
     template <unsigned DIM,typename T>
     bool read_image(const QString& path,const char* type);
-    QStringList metaDataKeysToCopy();
+    void extractMetaData();
 };
 
 

--- a/src/medImageIO/itkDataImageWriterBase.h
+++ b/src/medImageIO/itkDataImageWriterBase.h
@@ -45,7 +45,7 @@ private:
 
     template <unsigned DIM,typename T>
     bool write_image(const QString& path,const char* type);
-    QStringList metaDataKeysToCopy();
+    void encapsulateMetaData();
 };
 
 


### PR DESCRIPTION
**Requires https://github.com/Inria-Asclepios/medInria-public/pull/51 to work**

This PR adresses two problems (see https://github.com/Inria-Asclepios/medInria-public/issues/46)

- The reader/writer for VTK files stores metadata in the header, but this header is limited to 256 characters.
- The readers/writers for VTK and ITK files do not store all the metadata.

For VTK I stored the metadata as field data for all cases (except CARTO which is handled by a different writer). In the reader I had to make it "backwards-compatible" since the previously written files will have the metadata in the header. Therefore the reader does the following:

- It firsts checks if metadata is present in the field data and loads it.
- If the first attempt failed, it tries to take the metadata from the header (provided it is in the format that was written by the previous version of the writer).
- if still not found, it checks if the metadata was already loaded and stored in the vtkMetaDataSet metadata dictionary. This dictionary is used by vtkMetaSurfaceMesh when loading CARTO files (so you don't have to manually load the data from the header for CARTO files).