### PR TITLE
[medHomepageArea] hide column if empty

### DIFF
--- a/app/medInria/medHomepageArea.cpp
+++ b/app/medInria/medHomepageArea.cpp
@@ -443,10 +443,21 @@ void medHomepageArea::initPage()
     workspaceButtonsLayout->setColumnMinimumWidth(1,120);
     workspaceButtonsLayout->setColumnMinimumWidth(2,120);
     workspaceButtonsLayout->setColumnMinimumWidth(3,120);
-    workspaceButtonsLayout->addLayout(workspaceButtonsLayoutBasic,0,0);
-    workspaceButtonsLayout->addLayout(workspaceButtonsLayoutMethodology,0,1);
-    workspaceButtonsLayout->addLayout(workspaceButtonsLayoutClinical,0,2);
-    workspaceButtonsLayout->addLayout(workspaceButtonsLayoutOther,0,3);
+
+    // Hide a category if empty
+    QList<QVBoxLayout*> layoutList;
+    layoutList << workspaceButtonsLayoutBasic << workspaceButtonsLayoutMethodology
+               << workspaceButtonsLayoutClinical << workspaceButtonsLayoutOther;
+    int columnCount = 0;
+    foreach (QVBoxLayout* curLayout, layoutList)
+    {
+        if (!curLayout->isEmpty())
+        {
+            workspaceButtonsLayout->addLayout(curLayout,0,columnCount);
+            columnCount++;
+        }
+    }
+
     workspaceButtonsLayout->setSpacing(40);
     d->navigationWidget->setLayout ( workspaceButtonsLayout );
 }

--- a/app/medInria/medHomepageArea.cpp
+++ b/app/medInria/medHomepageArea.cpp
@@ -456,6 +456,10 @@ void medHomepageArea::initPage()
             workspaceButtonsLayout->addLayout(curLayout,0,columnCount);
             columnCount++;
         }
+        else
+        {
+            delete curLayout;
+        }
     }
 
     workspaceButtonsLayout->setSpacing(40);


### PR DESCRIPTION
On the main page of the software, we have columns: `Basic`, `Methodology`, `Clinical` and `Other`.

The PR allows to hide any of these columns if empty.

:m: