### PR TITLE
[Paint] udpateView called if show is called on the tbx

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -464,6 +464,12 @@ bool AlgorithmPaintToolBox::registered()
     return factory->registerToolBox<AlgorithmPaintToolBox> ();
 }
 
+void AlgorithmPaintToolBox::showEvent ( QShowEvent * event )
+{
+    Q_UNUSED(event);
+    updateView();
+}
+
 void AlgorithmPaintToolBox::updateMagicWandComputation()
 {
     if (seedPlanted)
@@ -573,19 +579,24 @@ void AlgorithmPaintToolBox::activateMagicWand()
 void AlgorithmPaintToolBox::behaveWithBodyVisibility()
 {
     if(!((QWidget*)sender())->isHidden())
-        return;
-    if ( this->m_strokeButton->isChecked() ) {
-        this->m_viewFilter->removeFromAllViews();
-        m_paintState = (PaintState::None);
-        updateButtons();
+    {
         return;
     }
-    if ( this->m_magicWandButton->isChecked() ) {
-        this->m_viewFilter->removeFromAllViews();
-        m_paintState = (PaintState::None);
-        newSeed(); // accept the current growth
-        updateButtons();
-        return;
+    else
+    {
+        if ( this->m_strokeButton->isChecked() )
+        {
+            this->m_viewFilter->removeFromAllViews();
+            m_paintState = (PaintState::None);
+            updateButtons();
+        }
+        else if ( this->m_magicWandButton->isChecked() )
+        {
+            this->m_viewFilter->removeFromAllViews();
+            m_paintState = (PaintState::None);
+            newSeed(); // accept the current growth
+            updateButtons();
+        }
     }
 }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -153,6 +153,9 @@ protected:
     void addViewEventFilter(medViewEventFilter * filter );
 
 private:
+
+    void showEvent(QShowEvent * event);
+
     typedef dtkSmartPointer<medSeedPointAnnotationData> SeedPoint;
 
     // Stroke's objects


### PR DESCRIPTION
### What's the pb?
In Segmentation workspace, drop an image, select MUSIC Paint Seg, "Paint/Erase" and try to draw something, it crashes.
Note: if you set the toolbox, then drop the image, it doesn't crash.

### What's going on?
After selecting the toolbox, this latter is not aware of what's inside the view, so we need to let it know.

### How does this PR solve this?
Selecting the toolbox calls the method `show()` of the Paint Toolbox. 
`showEvent()` is called every time `show()` is called, so I just reimplemented it to call `updateView()`.
In the end, every time we show the toolbox, we acknowledge the state of the view. 