### PR TITLE
[Manual registration] Proper linking of the different views

### DIFF
--- a/app/medInria/medRegistrationWorkspace.cpp
+++ b/app/medInria/medRegistrationWorkspace.cpp
@@ -60,11 +60,6 @@ medRegistrationWorkspace::medRegistrationWorkspace(QWidget *parent) : medAbstrac
     d->fixedLayerGroup->setLinkAllParameters(true);
     d->movingLayerGroup->setLinkAllParameters(true);
 
-    QList<medLayerParameterGroup*> layerGroups;
-    layerGroups.append(d->fixedLayerGroup);
-    layerGroups.append(d->movingLayerGroup);
-    this->setLayerGroups(layerGroups);
-
 //    this->setUserLayerPoolable(false);
     connect(this->stackedViewContainers(), SIGNAL(currentChanged(int)), this, SLOT(updateUserLayerClosable(int)));
     connect(d->registrationToolBox, SIGNAL(movingDataRegistered(medAbstractData*)), this, SLOT(updateFromRegistrationSuccess(medAbstractData*)));
@@ -172,21 +167,10 @@ void medRegistrationWorkspace::updateFromMovingContainer()
     d->fuseContainer->addData(movingData);
     fuseView  = dynamic_cast<medAbstractLayeredView*>(d->fuseContainer->view());
 
-    if(movingData)
-    {
-        d->viewGroup->addImpactedView(movingView);
-        d->viewGroup->addImpactedView(fuseView);
-        d->viewGroup->removeParameter("DataList");
 
-        d->movingLayerGroup->addImpactedlayer(movingView, movingData);
-        d->movingLayerGroup->addImpactedlayer(fuseView, movingData);
-    }
     if (!d->registrationToolBox->setMovingData(movingData))
     {
         // delete the view because something failed at some point
-        d->viewGroup->removeImpactedView(movingView);
-        d->movingLayerGroup->removeImpactedlayer(movingView, movingData);
-        d->movingLayerGroup->removeImpactedlayer(fuseView, movingData);
         movingView->deleteLater();
     }
 }
@@ -230,22 +214,9 @@ void medRegistrationWorkspace::updateFromFixedContainer()
     d->fuseContainer->addData(fixedData);
     fuseView  = dynamic_cast<medAbstractLayeredView*>(d->fuseContainer->view());
 
-    if(fixedData)
-    {
-        d->viewGroup->addImpactedView(fixedView);
-        d->viewGroup->addImpactedView(fuseView);
-        d->viewGroup->removeParameter("DataList");
-
-        d->fixedLayerGroup->addImpactedlayer(fixedView, fixedData);
-        d->fixedLayerGroup->addImpactedlayer(fuseView, fixedData);
-    }
-
     if (!d->registrationToolBox->setFixedData(fixedData))
     {
         // delete the view because something failed at some point
-        d->viewGroup->removeImpactedView(fixedView);
-        d->fixedLayerGroup->removeImpactedlayer(fixedView, fixedData);
-        d->fixedLayerGroup->removeImpactedlayer(fuseView, fixedData);
         fixedView->deleteLater();
     }
 }
@@ -284,20 +255,12 @@ void medRegistrationWorkspace::updateFromRegistrationSuccess(medAbstractData *ou
         return;
     }
 
-
     medAbstractLayeredView* fuseView  = dynamic_cast<medAbstractLayeredView*>(d->fuseContainer->view());
     if(!fuseView)
     {
         qWarning() << "Non layered view are not suported yet in registration workspace.";
         return;
     }
-
-    d->viewGroup->addImpactedView(movingView);
-    d->viewGroup->addImpactedView(fuseView);
-    d->viewGroup->removeParameter("DataList");
-
-    d->movingLayerGroup->addImpactedlayer(movingView, output);
-    d->movingLayerGroup->addImpactedlayer(fuseView, output);
 
     connect(d->movingContainer,SIGNAL(viewContentChanged()),
             this, SLOT(updateFromMovingContainer()));

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -450,6 +450,13 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers * ta
 
         tabContainers->lockTabs();
 
+        d->viewGroup->addImpactedView(d->rightContainer->view());
+        d->viewGroup->addImpactedView(d->leftContainer->view());
+        d->viewGroup->addImpactedView(d->bottomContainer->view());
+        d->viewGroup->setLinkAllParameters(true);
+        d->viewGroup->removeParameter("Position");
+        d->viewGroup->removeParameter("DataList");
+
         d->layerGroup1->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->bottomContainer->view()), d->currentView->layerData(0));
         d->layerGroup1->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->leftContainer->view()), d->currentView->layerData(0));
         d->layerGroup2->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->bottomContainer->view()), d->currentView->layerData(1));

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -106,10 +106,15 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medRegis
     d->viewGroup->setLinkAllParameters(true);
     d->viewGroup->removeParameter("Position");
     d->viewGroup->removeParameter("DataList");
+
     d->layerGroup1 = new medLayerParameterGroup("Fixed", this);
-    d->layerGroup2 = new medLayerParameterGroup("Moving", this);
     d->layerGroup1->setLinkAllParameters(true);
+    d->layerGroup1->removeParameter("Slicing");
+
+    d->layerGroup2 = new medLayerParameterGroup("Moving", this);
     d->layerGroup2->setLinkAllParameters(true);
+    d->layerGroup2->removeParameter("Slicing");
+
 
     d->regOn           = false;
     d->currentView     = 0;
@@ -271,6 +276,7 @@ void manualRegistrationToolBox::synchroniseMovingFuseView()
     medAbstractImageView * viewMoving = qobject_cast<medAbstractImageView*>(d->rightContainer->view());
     medAbstractImageView * viewFuse = qobject_cast<medAbstractImageView*>(d->bottomContainer->view());
 
+    d->layerGroup2->addImpactedlayer(viewFuse,viewFuse->layerData(1));
     // Synchronize Lut
     QList<medAbstractInteractor*> interactors = viewMoving->layerInteractors(0);
     QString lutCurrent;
@@ -443,6 +449,11 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers * ta
         }
 
         tabContainers->lockTabs();
+
+        d->layerGroup1->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->bottomContainer->view()), d->currentView->layerData(0));
+        d->layerGroup1->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->leftContainer->view()), d->currentView->layerData(0));
+        d->layerGroup2->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->bottomContainer->view()), d->currentView->layerData(1));
+        d->layerGroup2->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->rightContainer->view()), d->currentView->layerData(1));
 
         d->leftContainer->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);
         d->rightContainer->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -105,6 +105,7 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medRegis
     d->viewGroup = new medViewParameterGroup("ManualRegistration", this);
     d->viewGroup->setLinkAllParameters(true);
     d->viewGroup->removeParameter("Position");
+    d->viewGroup->removeParameter("DataList");
     d->layerGroup1 = new medLayerParameterGroup("Fixed", this);
     d->layerGroup2 = new medLayerParameterGroup("Moving", this);
     d->layerGroup1->setLinkAllParameters(true);
@@ -270,7 +271,6 @@ void manualRegistrationToolBox::synchroniseMovingFuseView()
     medAbstractImageView * viewMoving = qobject_cast<medAbstractImageView*>(d->rightContainer->view());
     medAbstractImageView * viewFuse = qobject_cast<medAbstractImageView*>(d->bottomContainer->view());
 
-    d->layerGroup2->addImpactedlayer(viewFuse,viewFuse->layerData(1));
     // Synchronize Lut
     QList<medAbstractInteractor*> interactors = viewMoving->layerInteractors(0);
     QString lutCurrent;
@@ -443,18 +443,6 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers * ta
         }
 
         tabContainers->lockTabs();
-
-        d->viewGroup->addImpactedView(d->rightContainer->view());
-        d->viewGroup->addImpactedView(d->leftContainer->view());
-        d->viewGroup->addImpactedView(d->bottomContainer->view());
-        d->viewGroup->setLinkAllParameters(true);
-        d->viewGroup->removeParameter("Position");
-        d->viewGroup->removeParameter("DataList");
-
-        d->layerGroup1->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->bottomContainer->view()), d->currentView->layerData(0));
-        d->layerGroup1->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->leftContainer->view()), d->currentView->layerData(0));
-        d->layerGroup2->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->bottomContainer->view()), d->currentView->layerData(1));
-        d->layerGroup2->addImpactedlayer(qobject_cast<medAbstractLayeredView*>(d->rightContainer->view()), d->currentView->layerData(1));
 
         d->leftContainer->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);
         d->rightContainer->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);


### PR DESCRIPTION
### What's he pb?
As posted [here](https://github.com/Inria-Asclepios/medInria-public/issues/55#issuecomment-221528501), with Manual registration, when you slice on one view, it automatically slices on the other one; which is not very convenient when you try to register to data.
This behaviour has been noticed in the VT pipeline, but appears as well in the Registration workspace.

### What's going on?
It's simple, the different views are linked in many ways including in position/slicing.

### How to solve it?
By removing the linking in position and slicing in manual registration and in the registration workspace.

