### PR TITLE
[Crop] displays output in the current tab

### DIFF
--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -523,7 +523,8 @@ void medCropToolBoxPrivate::replaceViewWithOutputData(medAbstractWorkspace& work
 {
     if (outputData.length() >= 0)
     {
-        medViewContainer* viewContainer = workspace.stackedViewContainers()->containersInTab(0).at(0);
+        medTabbedViewContainers* tabbedViewContainers = workspace.stackedViewContainers();
+        medViewContainer* viewContainer = tabbedViewContainers->containersInTab(tabbedViewContainers->currentIndex()).at(0);
 
         viewContainer->removeView();
         viewContainer->setMultiLayered(true);


### PR DESCRIPTION
### What's the pb?
Reformat workspace, open an image; create a new tab, drop another image in the view.
Use the cropping tool, "Apply". Nothing happens in the current view, go back to the first tab and you 'll see the result of your crop.

### What's this PR doing?
It opens the output of the crop in the current tab.
