### PR TITLE
[manualRegistration] solves Reset bugs

### DIFF
--- a/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
@@ -130,16 +130,26 @@ void manualRegistrationLandmark::On()
 
 void manualRegistrationLandmark::ShowOrHide()
 {
-    if (!View->GetRenderWindow() || ToDelete)
-        return;
-    if (HandleWidget->GetInteractor() && HandleWidget->GetRepresentation()->GetRenderer())
-        if (HandleWidget->GetInteractor()->GetRenderWindow())
+    if (!ToDelete)
+    {
+        if (View->GetRenderWindow())
         {
-            if (Indices[View->GetSliceOrientation()]!=View->GetSlice())
-                Off();
-            else
-                On();
+            if (HandleWidget->GetInteractor() && HandleWidget->GetRepresentation()->GetRenderer())
+            {
+                if (HandleWidget->GetInteractor()->GetRenderWindow())
+                {
+                    if (Indices[View->GetSliceOrientation()]!=View->GetSlice())
+                    {
+                        Off();
+                    }
+                    else
+                    {
+                        On();
+                    }
+                }
+            }
         }
+    }
 }
 
 vtkPointHandleRepresentation2D * manualRegistrationLandmark::GetHandleRepresentation()

--- a/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
@@ -130,13 +130,14 @@ void manualRegistrationLandmark::On()
 
 void manualRegistrationLandmark::ShowOrHide()
 {
-    if (!ToDelete)
+    if (!ToDelete && View)
     {
-        if (View->GetRenderWindow())
+        if (HandleWidget)
         {
-            if (HandleWidget->GetInteractor() && HandleWidget->GetRepresentation()->GetRenderer())
+            if (HandleWidget->GetInteractor() && HandleWidget->GetRepresentation())
             {
-                if (HandleWidget->GetInteractor()->GetRenderWindow())
+                if (HandleWidget->GetInteractor()->GetRenderWindow() &&
+                        HandleWidget->GetRepresentation()->GetRenderer())
                 {
                     if (Indices[View->GetSliceOrientation()]!=View->GetSlice())
                     {

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -147,6 +147,7 @@ manualRegistrationLandmarkController::manualRegistrationLandmarkController()
 //----------------------------------------------------------------------------
 manualRegistrationLandmarkController::~manualRegistrationLandmarkController()
 {
+    this->Reset();
     delete Points_Moving;
     delete Points_Fixed;
 

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -292,8 +292,7 @@ void manualRegistrationLandmarkController::Reset()
     {
         for(int i=0;i<Points_Fixed->size();i++)
         {
-            Points_Fixed->at(i)->RemoveAllObservers();
-            Points_Fixed->at(i)->Delete();
+            RequestDeletion(Points_Fixed->at(i));
         }
     }
 
@@ -301,16 +300,12 @@ void manualRegistrationLandmarkController::Reset()
     {
         for(int i=0;i<Points_Moving->size();i++)
         {
-            Points_Moving->at(i)->RemoveAllObservers();
-            Points_Moving->at(i)->Delete();
+            RequestDeletion(Points_Moving->at(i));
         }
     }
 
     Points_Fixed->clear();
     Points_Moving->clear();
-
-    // Update the user label with the number of current landmarks
-    Tbx->updateLabels(Points_Fixed->size(),Points_Moving->size());
 }
 
 void manualRegistrationLandmarkController::ClearUselessLandmarks()
@@ -371,5 +366,7 @@ void manualRegistrationLandmarkController::RequestDeletion(manualRegistrationLan
         if (Points_Moving->size()>i && !Points_Moving->at(i)->GetToDelete())
             cptMoving++;
     }
+
+    // Update the user label with the number of current landmarks
     Tbx->updateLabels(cptFixed,cptMoving);
 }

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -234,7 +234,7 @@ void manualRegistrationLandmarkController::AddPoint(manualRegistrationLandmark *
     if (!landmark->HasObserver (vtkCommand::DeleteEvent, this->Command) )
         landmark->AddObserver(vtkCommand::DeleteEvent, this->Command, 0);
 
-    Tbx->updateLabels(Points_Fixed->size(),Points_Moving->size());
+    Tbx->updateGUI(Points_Fixed->size(),Points_Moving->size());
 }
 
 ////----------------------------------------------------------------------------
@@ -369,5 +369,5 @@ void manualRegistrationLandmarkController::RequestDeletion(manualRegistrationLan
     }
 
     // Update the user label with the number of current landmarks
-    Tbx->updateLabels(cptFixed,cptMoving);
+    Tbx->updateGUI(cptFixed,cptMoving);
 }

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -147,9 +147,15 @@ manualRegistrationLandmarkController::manualRegistrationLandmarkController()
 //----------------------------------------------------------------------------
 manualRegistrationLandmarkController::~manualRegistrationLandmarkController()
 {
+    delete Points_Moving;
+    delete Points_Fixed;
+
     this->Command->Delete();
+
     if (this->InteractorCollection)
+    {
         this->InteractorCollection->UnRegister(this);
+    }
 }
 
 void manualRegistrationLandmarkController::SetInteractorCollection (vtkCollection* arg)

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -371,12 +371,12 @@ void manualRegistrationToolBox::reset()
         // Refresh views except at closing
         if (viewMoving)
         {
-            d->rightContainer->view()->viewWidget()->update();
+            viewMoving->viewWidget()->update();
         }
 
         if (viewFix)
         {
-            d->leftContainer->view()->viewWidget()->update();
+            viewFix->viewWidget()->update();
         }
     }
 
@@ -528,10 +528,10 @@ void manualRegistrationToolBox::displayButtons(bool show)
 
 void manualRegistrationToolBox::updateLabels(int left,int right)
 {
-    d->numberOfLdInLeftContainer->setText( "Number of landmarks in left container  : " + QString::number(left));
-    d->numberOfLdInRightContainer->setText("Number of landmarks in right container : " + QString::number(right));
+    d->numberOfLdInLeftContainer->setText( "Number of landmarks in left container: " + QString::number(left));
+    d->numberOfLdInRightContainer->setText("Number of landmarks in right container: " + QString::number(right));
 
-    if ((left>0) || (right>0))
+    if((left>0) && (left==right))
     {
         disableComputeButton(false);
     }

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -526,7 +526,7 @@ void manualRegistrationToolBox::displayButtons(bool show)
     }
 }
 
-void manualRegistrationToolBox::updateLabels(int left,int right)
+void manualRegistrationToolBox::updateGUI(int left,int right)
 {
     d->numberOfLdInLeftContainer->setText( "Number of landmarks in left container: " + QString::number(left));
     d->numberOfLdInRightContainer->setText("Number of landmarks in right container: " + QString::number(right));

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -126,8 +126,8 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medRegis
     d->process         = 0;
     d->output          = 0;
 
-    disableSaveButtons(true);
-    disableComputeResetButtons(true);
+    setDisableSaveButtons(true);
+    setDisableComputeResetButtons(true);
     displayButtons(false);
 }
 
@@ -355,7 +355,7 @@ void manualRegistrationToolBox::computeRegistration()
     qobject_cast<medAbstractImageView*>(d->bottomContainer->view())->addLayer(d->output);
     synchroniseMovingFuseView();
 
-    disableSaveButtons(false);
+    setDisableSaveButtons(false);
 }
 
 void manualRegistrationToolBox::reset()
@@ -393,8 +393,8 @@ void manualRegistrationToolBox::reset()
     synchroniseMovingFuseView();
 
     // Disable Save/Transformation/Compute/Reset buttons
-    disableSaveButtons(true);
-    disableComputeResetButtons(true);
+    setDisableSaveButtons(true);
+    setDisableComputeResetButtons(true);
 }
 
 void manualRegistrationToolBox::save()
@@ -497,21 +497,21 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers * ta
     }
 }
 
-void manualRegistrationToolBox::disableSaveButtons(bool param)
+void manualRegistrationToolBox::setDisableSaveButtons(bool disable)
 {
-    d->b_save->setDisabled(param);
-    d->b_exportTransformation->setDisabled(param);
+    d->b_save->setDisabled(disable);
+    d->b_exportTransformation->setDisabled(disable);
 }
 
-void manualRegistrationToolBox::disableComputeResetButtons(bool param)
+void manualRegistrationToolBox::setDisableComputeResetButtons(bool disable)
 {
-    d->b_computeRegistration->setDisabled(param);
-    disableResetButton(param);
+    d->b_computeRegistration->setDisabled(disable);
+    setDisableResetButton(disable);
 }
 
-void manualRegistrationToolBox::disableResetButton(bool param)
+void manualRegistrationToolBox::setDisableResetButton(bool disable)
 {
-    d->b_reset->setDisabled(param);
+    d->b_reset->setDisabled(disable);
 }
 
 void manualRegistrationToolBox::displayButtons(bool show)
@@ -541,13 +541,13 @@ void manualRegistrationToolBox::updateGUI(int left,int right)
     {
         if(left>0)
         {
-            disableComputeResetButtons(false);
+            setDisableComputeResetButtons(false);
         }
     }
 
     if ((left>0) || (right>0))
     {
         // at least one landmark put
-        disableResetButton(false);
+        setDisableResetButton(false);
     }
 }

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -127,7 +127,7 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medRegis
     d->output          = 0;
 
     disableSaveButtons(true);
-    disableComputeButton(true);
+    disableComputeResetButtons(true);
     displayButtons(false);
 }
 
@@ -392,9 +392,9 @@ void manualRegistrationToolBox::reset()
 
     synchroniseMovingFuseView();
 
-    // Disable Save/Transformation/Compute buttons
+    // Disable Save/Transformation/Compute/Reset buttons
     disableSaveButtons(true);
-    disableComputeButton(true);
+    disableComputeResetButtons(true);
 }
 
 void manualRegistrationToolBox::save()
@@ -503,9 +503,15 @@ void manualRegistrationToolBox::disableSaveButtons(bool param)
     d->b_exportTransformation->setDisabled(param);
 }
 
-void manualRegistrationToolBox::disableComputeButton(bool param)
+void manualRegistrationToolBox::disableComputeResetButtons(bool param)
 {
     d->b_computeRegistration->setDisabled(param);
+    disableResetButton(param);
+}
+
+void manualRegistrationToolBox::disableResetButton(bool param)
+{
+    d->b_reset->setDisabled(param);
 }
 
 void manualRegistrationToolBox::displayButtons(bool show)
@@ -531,8 +537,17 @@ void manualRegistrationToolBox::updateGUI(int left,int right)
     d->numberOfLdInLeftContainer->setText( "Number of landmarks in left container: " + QString::number(left));
     d->numberOfLdInRightContainer->setText("Number of landmarks in right container: " + QString::number(right));
 
-    if((left>0) && (left==right))
+    if (left==right)
     {
-        disableComputeButton(false);
+        if(left>0)
+        {
+            disableComputeResetButtons(false);
+        }
+    }
+
+    if ((left>0) || (right>0))
+    {
+        // at least one landmark put
+        disableResetButton(false);
     }
 }

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -39,7 +39,7 @@ public:
     static bool registered();
     dtkPlugin * plugin();
 
-    void updateLabels(int left,int right);
+    void updateGUI(int left,int right);
 
 protected slots:
     void updateView();    

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -58,6 +58,8 @@ private:
     void displayButtons(bool);
     void constructContainers(medTabbedViewContainers *);
     void disableSaveButtons(bool);
+    void disableComputeButton(bool param);
+
     manualRegistrationToolBoxPrivate *d;
 };
 

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -57,9 +57,9 @@ public slots:
 private:
     void displayButtons(bool);
     void constructContainers(medTabbedViewContainers *);
-    void disableSaveButtons(bool);
-    void disableComputeResetButtons(bool);
-    void disableResetButton(bool);
+    void setDisableSaveButtons(bool);
+    void setDisableComputeResetButtons(bool);
+    void setDisableResetButton(bool);
 
     manualRegistrationToolBoxPrivate *d;
 };

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -58,7 +58,8 @@ private:
     void displayButtons(bool);
     void constructContainers(medTabbedViewContainers *);
     void disableSaveButtons(bool);
-    void disableComputeButton(bool param);
+    void disableComputeResetButtons(bool);
+    void disableResetButton(bool);
 
     manualRegistrationToolBoxPrivate *d;
 };


### PR DESCRIPTION
Solves:

 - memory leak https://github.com/Inria-Asclepios/medInria-public/issues/13,
 - refresh views after a Reset to remove the display of landmarks https://github.com/Inria-Asclepios/medInria-public/issues/13,
 - Reset then Close actions do not crash,
 - no space before ":" in English,
 - Reset disables the Compute button,
 - Reset then scroll crash is solved: https://github.com/Inria-Asclepios/medInria-public/issues/87

:m: