### PR TITLE
[progressBar] activate bar in N4, binaryOpe and maskApplication

### DIFF
--- a/src-plugins/itkN4BiasCorrection/itkN4BiasCorrectionToolBox.cpp
+++ b/src-plugins/itkN4BiasCorrection/itkN4BiasCorrectionToolBox.cpp
@@ -248,7 +248,7 @@ void itkN4BiasCorrectionToolBox::run()
     runProcess->setProcess (d->process);
     
     d->progression_stack->addJobItem(runProcess, "Progress:");
-    
+    d->progression_stack->setActive(runProcess,true);
     d->progression_stack->disableCancel(runProcess);
     
     connect (runProcess, SIGNAL (success  (QObject*)),  this, SIGNAL (success ()));

--- a/src-plugins/medBinaryOperation/medBinaryOperationToolBox.cpp
+++ b/src-plugins/medBinaryOperation/medBinaryOperationToolBox.cpp
@@ -183,7 +183,7 @@ void medBinaryOperationToolBox::run()
     runProcess->setProcess (d->process);
     
     d->progression_stack->addJobItem(runProcess, "Progress:");
-    
+    d->progression_stack->setActive(runProcess,true);
     d->progression_stack->disableCancel(runProcess);
     
     connect (runProcess, SIGNAL (success  (QObject*)),  this, SIGNAL (success ()));

--- a/src-plugins/medMaskApplication/medMaskApplicationToolBox.cpp
+++ b/src-plugins/medMaskApplication/medMaskApplicationToolBox.cpp
@@ -134,7 +134,7 @@ void medMaskApplicationToolBox::run()
         runProcess->setProcess (d->process);
 
         d->progression_stack->addJobItem(runProcess, "Progress:");
-
+        d->progression_stack->setActive(runProcess,true);
         d->progression_stack->disableCancel(runProcess);
 
         connect (runProcess, SIGNAL (success  (QObject*)),  this, SIGNAL (success ()));


### PR DESCRIPTION
From https://github.com/Inria-Asclepios/medInria-public/issues/88

```
These toolboxes progress bars do not change during the process computation:

 * N4 bias
 * binaryOperation
 * maskApplication
```
-> progress bar activated.

_PS: there are 2 types of activation. You can look at the way mscSuperResolutions handle that._

:m: