### PR TITLE
[medCropToolbox] container can't be split

### DIFF
--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -243,6 +243,18 @@ void medCropToolBox::hideEvent(QHideEvent *event)
     medAbstractSelectableToolBox::hideEvent(event);
     setEnable(false);
 
+    medTabbedViewContainers * containers = getWorkspace()->stackedViewContainers();
+    QList<medViewContainer*> containersInTabSelected =  containers->containersInTab(containers->currentIndex());
+
+    for(int i=0;i<containersInTabSelected.length();i++)
+    {
+        if (containersInTabSelected[i]->isSelected())
+        {
+            // allow to split container in other toolboxes
+            containersInTabSelected[i]->setUserSplittable(true);
+            break;
+        }
+    }
 }
 
 void medCropToolBox::setEnable(bool enable)

--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -165,8 +165,8 @@ void medCropToolBox::updateView()
     {
         if (containersInTabSelected[i]->isSelected())
         {
-            view = qobject_cast<medAbstractLayeredView*>(containersInTabSelected[i]->view());
             currentContainer = containersInTabSelected[i];
+            view = qobject_cast<medAbstractLayeredView*>(currentContainer->view());
             break;
         }
     }

--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -160,11 +160,13 @@ void medCropToolBox::updateView()
     medTabbedViewContainers * containers = getWorkspace()->stackedViewContainers();
     QList<medViewContainer*> containersInTabSelected =  containers->containersInTab(containers->currentIndex());
     medAbstractLayeredView* view = NULL;
+    medViewContainer* currentContainer = NULL;
     for(int i=0;i<containersInTabSelected.length();i++)
     {
         if (containersInTabSelected[i]->isSelected())
         {
             view = qobject_cast<medAbstractLayeredView*>(containersInTabSelected[i]->view());
+            currentContainer = containersInTabSelected[i];
             break;
         }
     }
@@ -191,12 +193,16 @@ void medCropToolBox::updateView()
             d->view2D->GetInteractorStyle()->AddObserver(vtkImageView2DCommand::CameraMoveEvent, d->cropCallback);
         }
         d->updateBorderWidgetIfVisible();
+
+        // do not allow to split the container
+        currentContainer->setUserSplittable(false);
     }
     else
     {
         d->view = 0;
         d->view2D = 0;
         d->view3D = 0;
+        currentContainer->setUserSplittable(true);
     }
 }
 


### PR DESCRIPTION
From https://github.com/Inria-Asclepios/medInria-public/issues/14

Do not allow Crop container to be splittable.

:m: