### PR TITLE
[mscPaint] change name, correct close by crossed button

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -572,7 +572,7 @@ void AlgorithmPaintToolBox::activateMagicWand()
 void AlgorithmPaintToolBox::hideEvent(QHideEvent *event)
 {
     medAbstractSelectableToolBox::hideEvent(event);
-    initializeToolbox();
+    resetToolbox();
 }
 
 void AlgorithmPaintToolBox::updateMagicWandComputationSpeed()
@@ -1479,7 +1479,7 @@ void AlgorithmPaintToolBox::onViewClosed(medAbstractView* viewClosed)
     }
 
     showButtons(false);
-    initializeToolbox();
+    resetToolbox();
 
     if (viewClosed==currentView)
     {
@@ -1510,7 +1510,7 @@ void AlgorithmPaintToolBox::clearMask()
     m_imageData = NULL;
 }
 
-void AlgorithmPaintToolBox::initializeToolbox()
+void AlgorithmPaintToolBox::resetToolbox()
 {
     if ( this->m_strokeButton->isChecked() )
     {

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -648,6 +648,8 @@ void AlgorithmPaintToolBox::updateView()
 
         // Update cursor if the orientation change
         connect(currentView, SIGNAL(orientationChanged()), this, SLOT(activateCustomedCursor()), Qt::UniqueConnection);
+
+        connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(clearMask()), Qt::UniqueConnection);
     }
 
     // Update cursor to new view
@@ -687,7 +689,8 @@ void AlgorithmPaintToolBox::setLabelColor()
 
 void AlgorithmPaintToolBox::clearMask()
 {
-    if ( m_maskData && m_itkMask ){
+    if ( m_maskData && m_itkMask )
+    {
         m_itkMask->FillBuffer( MaskPixelValues::Unset );
         m_itkMask->Modified();
         m_itkMask->GetPixelContainer()->Modified();
@@ -703,6 +706,7 @@ void AlgorithmPaintToolBox::clearMask()
         }
         m_applyButton->setDisabled(true);
     }
+    m_imageData = NULL;
 }
 
 void AlgorithmPaintToolBox::setData( medAbstractData *medData )
@@ -887,12 +891,14 @@ void AlgorithmPaintToolBox::updateWandRegion(medAbstractImageView * view, QVecto
 {
     setCurrentView(view);
 
-    if ( !m_imageData )
+    if ( !m_imageData && (m_maskAnnotationData!=view->layerData(0)))
     {
         this->setData(view->layerData(0));
     }
-    if (!m_imageData) {
-        dtkWarn() << "Could not set data";
+
+    if (!m_imageData)
+    {
+        displayMessageError("Could not set data");
         return;
     }
 
@@ -1204,8 +1210,6 @@ void AlgorithmPaintToolBox::updateStroke(ClickAndMoveEventFilter * filter, medAb
         // Update Mouse Interaction ToolBox
         view->setCurrentLayer(0);
         getWorkspace()->updateMouseInteractionToolBox();
-
-        connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(clearMask()), Qt::UniqueConnection);
     }
 
     m_maskAnnotationData->invokeModified();

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -114,7 +114,7 @@ public slots:
     void closeView();
     void onViewClosed(medAbstractView* viewClosed);
     void clearMask();
-    void initializeToolbox();
+    void resetToolbox();
 
     void newSeed();
     void removeSeed();

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -97,7 +97,6 @@ public slots:
 
     void copyMetaDataToPaintedData();
     void import();
-    void clearMask();
 
     void setLabel(int newVal);
     void setLabelColor();
@@ -111,7 +110,11 @@ public slots:
     void undo();
     void redo();
     void addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice);
-    void onViewClosed();
+
+    void closeView();
+    void onViewClosed(medAbstractView* viewClosed);
+    void clearMask();
+    void initializeToolbox();
 
     void newSeed();
     void removeSeed();

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -48,7 +48,7 @@ typedef itk::ImageRegionIterator <Mask2dFloatType> Mask2dFloatIterator;
 class MSCALGORITHMPAINT_EXPORT AlgorithmPaintToolBox : public medAbstractSelectableToolBox
 {
     Q_OBJECT
-    MED_TOOLBOX_INTERFACE("MUSIC Paint segmentation", "Paint Tool",
+    MED_TOOLBOX_INTERFACE("Paint Segmentation", "Paint Tool",
                           <<"Segmentation")
 public:
 


### PR DESCRIPTION
From this issue about the closing part: https://github.com/Inria-Asclepios/medInria-public/issues/119
And this issue concerning the name: https://github.com/Inria-Asclepios/medInria-public/issues/114

When you use magic wand, remove only the original data and then use magic wand again, no more crash.

:m: