### PR TITLE
[RegistrationWorkspace] allow to switch to 3D without switching the o…

### DIFF
--- a/app/medInria/medRegistrationWorkspace.cpp
+++ b/app/medInria/medRegistrationWorkspace.cpp
@@ -116,6 +116,7 @@ void medRegistrationWorkspace::setInitialGroups()
     d->viewGroup->setLinkAllParameters(true);
     d->viewGroup->removeParameter("DataList");
     d->viewGroup->removeParameter("Position");
+    d->viewGroup->removeParameter("Orientation");
 
     d->fixedLayerGroup->setLinkAllParameters(true);
     d->fixedLayerGroup->removeParameter("Slicing");


### PR DESCRIPTION
…ther views

From https://github.com/Inria-Asclepios/medInria-public/issues/122

> Open the registration workspace, put data, click on Fuse, switch to 3D view. The first tab is also put in 3D. It would be good to block that, it's confusing for users.

:m: