### PR TITLE
[medTabbedViewContainer] add function to get first container and view

### DIFF
--- a/src-plugins/reformat/resliceToolBox.cpp
+++ b/src-plugins/reformat/resliceToolBox.cpp
@@ -214,17 +214,7 @@ void resliceToolBox::stopReformat()
 
 void resliceToolBox::updateView()
 {
-    medTabbedViewContainers * containers = this->getWorkspace()->stackedViewContainers();
-    QList<medViewContainer*> containersInTabSelected =  containers->containersInTab(containers->currentIndex());
-    medAbstractView *view=NULL;
-    for(int i=0;i<containersInTabSelected.length();i++)
-    {
-        if (containersInTabSelected[i]->isSelected())
-        {
-            view = containersInTabSelected[i]->view();
-            break;
-        }
-    }
+    medAbstractView *view = this->getWorkspace()->stackedViewContainers()->getFirstSelectedContainerView();
 
     if (view && d->currentView!= view)
     {

--- a/src/medCore/gui/medTabbedViewContainers.cpp
+++ b/src/medCore/gui/medTabbedViewContainers.cpp
@@ -80,6 +80,28 @@ QList <QUuid> medTabbedViewContainers::containersSelected()
     return d->containerSelectedForTabIndex.value(this->currentIndex());
 }
 
+medViewContainer* medTabbedViewContainers::getFirstSelectedContainer()
+{
+    QList<QUuid> listUuid = containersSelected();
+    if (listUuid.count() > 0)
+    {
+        // only keep the first selected container
+        return medViewContainerManager::instance()->container(listUuid[0]);
+    }
+
+    return NULL;
+}
+
+medAbstractView* medTabbedViewContainers::getFirstSelectedContainerView()
+{
+    medViewContainer* currentFirstContainer = getFirstSelectedContainer();
+    if (currentFirstContainer)
+    {
+        return currentFirstContainer->view();
+    }
+    return NULL;
+}
+
 void medTabbedViewContainers::lockTabs()
 {
     this->setTabsClosable(false);

--- a/src/medCore/gui/medTabbedViewContainers.h
+++ b/src/medCore/gui/medTabbedViewContainers.h
@@ -49,6 +49,9 @@ public:
 
     medAbstractWorkspace * owningWorkspace() const;
 
+    medViewContainer* getFirstSelectedContainer();
+    medAbstractView*  getFirstSelectedContainerView();
+
 public slots:
     medViewContainer* addContainerInTab();
     medViewContainer* addContainerInTab(const QString &name);


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/134

Provide two functions in `medTabbedViewContainer`. The first one returns the first selected container, and the second one its view. This allows to get directly the view with "getWorkspace()->stackedViewContainers()->getFirstSelectedContainerView();" as you can see in the example.

I wanted to see that with you before changing every toolbox in MUSIC ^^.

:m:
