### PR TITLE
Qt messages handler

### DIFF
--- a/app/medInria/main.cpp
+++ b/app/medInria/main.cpp
@@ -28,6 +28,7 @@
 #include <medPluginManager.h>
 #include <medDataIndex.h>
 #include <medDatabaseController.h>
+#include <medQtMessageHandler.h>
 #include <medSettingsManager.h>
 #include <medStorage.h>
 
@@ -69,25 +70,6 @@ void forceShow(medMainWindow& mainwindow )
 }
 
 
-void myMessageOutput(QtMsgType type, const char *msg)
-{
-    switch (type)
-    {
-    case QtDebugMsg:
-        dtkDebug()<<msg;
-        break;
-    case QtWarningMsg:
-        dtkWarn()<<msg;
-        break;
-    case QtCriticalMsg:
-        dtkError()<<msg;
-        break;
-    case QtFatalMsg:
-        dtkFatal()<<msg;
-        abort();
-    }
-}
-
 int main(int argc,char* argv[]) {
 
     qRegisterMetaType<medDataIndex>("medDataIndex");
@@ -114,7 +96,7 @@ int main(int argc,char* argv[]) {
     std::cerr.rdbuf(loggerErr.rdbuf());
 
     // Redirect Qt messages into dtkMsg
-    qInstallMsgHandler(myMessageOutput);
+    qInstallMsgHandler(medQtMessageHandler::msgHandler);
 
     // Copy dtkMsg into log file
     // TRACE >> DEBUG >> INFO >> WARN >> ERROR >> FATAL
@@ -125,9 +107,9 @@ int main(int argc,char* argv[]) {
     dtkLogger::instance().attachFile(dtkLogPath(&application));
     dtkLogger::instance().attachConsole();
 
-    qDebug() << "####################################";
-    qDebug() << "Version: "    << MEDINRIA_VERSION;
-    qDebug() << "Build Date: " << MEDINRIA_BUILD_DATE;
+    dtkDebug() << "####################################";
+    dtkDebug() << "Version: "    << MEDINRIA_VERSION;
+    dtkDebug() << "Build Date: " << MEDINRIA_BUILD_DATE;
 
     medSplashScreen splash(QPixmap(":music_logo.png"));
     setlocale(LC_NUMERIC, "C");

--- a/app/medInria/medApplication.cpp
+++ b/app/medInria/medApplication.cpp
@@ -11,6 +11,8 @@
 
 =========================================================================*/
 
+#include <medApplication.h>
+
 #include <dtkCore/dtkGlobal.h>
 #include <dtkLog/dtkLog.h>
 #include <dtkCore/dtkAbstractDataFactory.h>
@@ -20,7 +22,6 @@
 
 #include <medAbstractDataFactory.h>
 #include <medAbstractWorkspace.h>
-#include <medApplication.h>
 #include <medDataManager.h>
 #include <medDatabaseController.h>
 #include <medDatabaseNonPersistentController.h>

--- a/app/medInria/medApplication.cpp
+++ b/app/medInria/medApplication.cpp
@@ -11,41 +11,37 @@
 
 =========================================================================*/
 
-#include <medApplication.h>
-
-#include <locale.h>
-
-#include <QtGui>
-
 #include <dtkCore/dtkGlobal.h>
 #include <dtkLog/dtkLog.h>
 #include <dtkCore/dtkAbstractDataFactory.h>
 #include <dtkCore/dtkAbstractData.h>
 
-#include <medPluginManager.h>
-
-#include <medWorkspaceFactory.h>
-#include <medAbstractWorkspace.h>
-#include <medFilteringWorkspace.h>
-#include <medDiffusionWorkspace.h>
-#include <medRegistrationWorkspace.h>
-#include <medVisualizationWorkspace.h>
-#include <medSegmentationWorkspace.h>
+#include <locale.h>
 
 #include <medAbstractDataFactory.h>
-#include <medSeedPointAnnotationData.h>
-
+#include <medAbstractWorkspace.h>
+#include <medApplication.h>
 #include <medDataManager.h>
 #include <medDatabaseController.h>
 #include <medDatabaseNonPersistentController.h>
 #include <medDatabaseSettingsWidget.h>
-
+#include <medDiffusionWorkspace.h>
+#include <medFilteringWorkspace.h>
 #include <medMainWindow.h>
+#include <medPluginManager.h>
 #include <medQtMessageHandler.h>
+#include <medRegistrationWorkspace.h>
+#include <medSeedPointAnnotationData.h>
+#include <medSegmentationWorkspace.h>
 #include <medSettingsWidget.h>
 #include <medSettingsWidgetFactory.h>
 #include <medStartupSettingsWidget.h>
 #include <medStyleSheetParser.h>
+#include <medVisualizationWorkspace.h>
+#include <medWorkspaceFactory.h>
+
+#include <QtGui>
+
 
 class medApplicationPrivate
 {
@@ -92,7 +88,7 @@ medApplication::medApplication(int & argc, char**argv) :
     QObject::connect(this,SIGNAL(messageReceived(const QString&)),
                      this,SLOT(redirectMessageToLog(QString)));
 
-    connect(&medQtMessageHandler::instance(), SIGNAL(newMsg(QtMsgType, const char*)),
+    QObject::connect(&medQtMessageHandler::instance(), SIGNAL(newMsg(QtMsgType, const char*)),
                     this,SLOT(receiveMsg(QtMsgType , const char*)));
 
     this->initialize();

--- a/app/medInria/medApplication.cpp
+++ b/app/medInria/medApplication.cpp
@@ -88,8 +88,8 @@ medApplication::medApplication(int & argc, char**argv) :
     QObject::connect(this,SIGNAL(messageReceived(const QString&)),
                      this,SLOT(redirectMessageToLog(QString)));
 
-    QObject::connect(&medQtMessageHandler::instance(), SIGNAL(newMsg(QtMsgType, const char*)),
-                    this,SLOT(receiveMsg(QtMsgType , const char*)));
+    QObject::connect(&medQtMessageHandler::instance(), SIGNAL(newQtMsg(QtMsgType, const char*)),
+                    this,SLOT(receiveQtMsg(QtMsgType , const char*)));
 
     this->initialize();
 }
@@ -188,7 +188,7 @@ void medApplication::initialize()
     datafactory->registerDataType<medSeedPointAnnotationData>();
 }
 
-void medApplication::receiveMsg(QtMsgType type, const char *msg)
+void medApplication::receiveQtMsg(QtMsgType type, const char *msg)
 {
     switch (type)
     {

--- a/app/medInria/medApplication.cpp
+++ b/app/medInria/medApplication.cpp
@@ -35,17 +35,16 @@
 #include <medAbstractDataFactory.h>
 #include <medSeedPointAnnotationData.h>
 
-#include <medSettingsWidgetFactory.h>
-#include <medSettingsWidget.h>
-#include <medStartupSettingsWidget.h>
-#include <medDatabaseSettingsWidget.h>
-
 #include <medDataManager.h>
 #include <medDatabaseController.h>
 #include <medDatabaseNonPersistentController.h>
+#include <medDatabaseSettingsWidget.h>
 
 #include <medMainWindow.h>
-
+#include <medQtMessageHandler.h>
+#include <medSettingsWidget.h>
+#include <medSettingsWidgetFactory.h>
+#include <medStartupSettingsWidget.h>
 #include <medStyleSheetParser.h>
 
 class medApplicationPrivate
@@ -93,8 +92,12 @@ medApplication::medApplication(int & argc, char**argv) :
     QObject::connect(this,SIGNAL(messageReceived(const QString&)),
                      this,SLOT(redirectMessageToLog(QString)));
 
+    connect(&medQtMessageHandler::instance(), SIGNAL(newMsg(QtMsgType, const char*)),
+                    this,SLOT(receiveMsg(QtMsgType , const char*)));
+
     this->initialize();
 }
+
 
 medApplication::~medApplication(void)
 {
@@ -187,4 +190,23 @@ void medApplication::initialize()
     //TODO I did something... was it enough ? - Flo
     medAbstractDataFactory * datafactory = medAbstractDataFactory::instance();
     datafactory->registerDataType<medSeedPointAnnotationData>();
+}
+
+void medApplication::receiveMsg(QtMsgType type, const char *msg)
+{
+    switch (type)
+    {
+    case QtDebugMsg:
+        dtkDebug()<<msg;
+        break;
+    case QtWarningMsg:
+        dtkWarn()<<msg;
+        break;
+    case QtCriticalMsg:
+        dtkError()<<msg;
+        break;
+    case QtFatalMsg:
+        dtkFatal()<<msg;
+        abort();
+    }
 }

--- a/app/medInria/medApplication.h
+++ b/app/medInria/medApplication.h
@@ -37,6 +37,7 @@ public slots:
     void redirectMessageToSplash(const QString& message);
     void redirectMessageToLog(const QString & message);
     void redirectErrorMessageToLog(const QString & message);
+    void receiveMsg(QtMsgType type, const char *msg);
 
     void open(const medDataIndex & index);
     void open(QString path);
@@ -47,5 +48,4 @@ protected:
 private:
     medApplicationPrivate *d;
 };
-
 

--- a/app/medInria/medApplication.h
+++ b/app/medInria/medApplication.h
@@ -37,7 +37,7 @@ public slots:
     void redirectMessageToSplash(const QString& message);
     void redirectMessageToLog(const QString & message);
     void redirectErrorMessageToLog(const QString & message);
-    void receiveMsg(QtMsgType type, const char *msg);
+    void receiveQtMsg(QtMsgType type, const char *msg);
 
     void open(const medDataIndex & index);
     void open(QString path);

--- a/app/medInria/medQtMessageHandler.cpp
+++ b/app/medInria/medQtMessageHandler.cpp
@@ -27,5 +27,5 @@ medQtMessageHandler &medQtMessageHandler::instance()
 
 void medQtMessageHandler::msgHandler(QtMsgType type, const char *msg)
 {
-    emit instance().newMsg(type, msg);
+    emit instance().newQtMsg(type, msg);
 }

--- a/app/medInria/medQtMessageHandler.cpp
+++ b/app/medInria/medQtMessageHandler.cpp
@@ -1,0 +1,31 @@
+/*=========================================================================
+
+medInria
+
+Copyright (c) INRIA 2013 - 2014. All rights reserved.
+See LICENSE.txt for details.
+
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+=========================================================================*/
+
+#include "medQtMessageHandler.h"
+
+medQtMessageHandler::medQtMessageHandler() : QObject()
+{
+    // important
+    qRegisterMetaType<QtMsgType>("QtMsgType");
+}
+
+medQtMessageHandler &medQtMessageHandler::instance()
+{
+    static medQtMessageHandler obj;
+    return obj;
+}
+
+void medQtMessageHandler::msgHandler(QtMsgType type, const char *msg)
+{
+    emit instance().newMsg(type, msg);
+}

--- a/app/medInria/medQtMessageHandler.cpp
+++ b/app/medInria/medQtMessageHandler.cpp
@@ -15,7 +15,7 @@ PURPOSE.
 
 medQtMessageHandler::medQtMessageHandler() : QObject()
 {
-    // important
+    // register the type in order to be recognized by the metaObject system of Qt (here as parameter of signal)
     qRegisterMetaType<QtMsgType>("QtMsgType");
 }
 

--- a/app/medInria/medQtMessageHandler.h
+++ b/app/medInria/medQtMessageHandler.h
@@ -1,0 +1,27 @@
+/*=========================================================================
+
+medInria
+
+Copyright (c) INRIA 2013 - 2014. All rights reserved.
+See LICENSE.txt for details.
+
+This software is distributed WITHOUT ANY WARRANTY; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+=========================================================================*/
+
+#include <QtGui>
+
+class medQtMessageHandler: public QObject
+{
+    Q_OBJECT
+    medQtMessageHandler();
+public :
+    static medQtMessageHandler & instance();
+    static void msgHandler(QtMsgType type, const char *msg);
+
+signals :
+    void newMsg(QtMsgType type, const char *msg);
+
+};

--- a/app/medInria/medQtMessageHandler.h
+++ b/app/medInria/medQtMessageHandler.h
@@ -16,8 +16,8 @@ PURPOSE.
 class medQtMessageHandler: public QObject
 {
     Q_OBJECT
-public :
     medQtMessageHandler();
+public :
     static medQtMessageHandler & instance();
     static void msgHandler(QtMsgType type, const char *msg);
 

--- a/app/medInria/medQtMessageHandler.h
+++ b/app/medInria/medQtMessageHandler.h
@@ -16,8 +16,8 @@ PURPOSE.
 class medQtMessageHandler: public QObject
 {
     Q_OBJECT
-    medQtMessageHandler();
 public :
+    medQtMessageHandler();
     static medQtMessageHandler & instance();
     static void msgHandler(QtMsgType type, const char *msg);
 

--- a/app/medInria/medQtMessageHandler.h
+++ b/app/medInria/medQtMessageHandler.h
@@ -22,6 +22,6 @@ public :
     static void msgHandler(QtMsgType type, const char *msg);
 
 signals :
-    void newMsg(QtMsgType type, const char *msg);
+    void newQtMsg(QtMsgType type, const char *msg);
 
 };


### PR DESCRIPTION
### What's going on?
After testing, I found out that many freezes we had were due to the management of qt messages (see https://github.com/Inria-Asclepios/medInria-public/issues/142, https://github.com/Inria-Asclepios/medInria-public/issues/148).
I noticed that these freezes appear when you call a process in a thread and this process launches a qMessage : e.g Gaussian filter, many mesh-related processes. 

Thanks to Flo's debug, I know that a thread is blocked in the *write()* method of dtkLogEnginePrivate.

My theory is that two threads are trying to write ate the same time with dtkLogger.

### The solution I propose
Make the process's thread emit a signal, caught in the main thread to let only the main thread deal with the dtkLogger.
So I created my own QtMessageHandler. This one is called every time a qMessage is used, it will then emit a signal. The associated slot is invoked in the main thread (it is in _medApplication_); this slot redirects the qMessages (transforms it in _dtkMessages_), which are then written.

It's a theory, I can be wrong, but it seems to work well.

Now, you can wait for the phase of "tests of the fixes of the tests" or give it a try before merging.