### PR TITLE
[logs] stops the app crash at closing

### DIFF
--- a/app/medInria/main.cpp
+++ b/app/medInria/main.cpp
@@ -32,6 +32,11 @@
 #include <medSettingsManager.h>
 #include <medStorage.h>
 
+typedef boost::iostreams::tee_device<std::ostream, std::ofstream> TeeDevice;
+typedef boost::iostreams::stream<TeeDevice> TeeStream;
+TeeStream logger;
+TeeStream loggerErr;
+
 void forceShow(medMainWindow& mainwindow )
 {
     //Idea and code taken from the OpenCOR project, Thanks Allan for the code!
@@ -80,19 +85,16 @@ int main(int argc,char* argv[]) {
     medApplication application(argc,argv);
 
     // Copy std::cout and std::cerr in log file
-    typedef boost::iostreams::tee_device<std::ostream, std::ofstream> TeeDevice;
-    typedef boost::iostreams::stream<TeeDevice> TeeStream;
-
     std::ofstream logFile(dtkLogPath(&application).toLocal8Bit().data(), std::ios::app);
 
     std::ostream tmp(std::cout.rdbuf());
     TeeDevice outputDevice(tmp, logFile);
-    TeeStream logger(outputDevice);
+    logger.open(outputDevice);
     std::cout.rdbuf(logger.rdbuf());
 
     std::ostream tmpErr(std::cerr.rdbuf());
     TeeDevice outputDeviceErr(tmpErr, logFile);
-    TeeStream loggerErr(outputDeviceErr);
+    loggerErr.open(outputDeviceErr);
     std::cerr.rdbuf(loggerErr.rdbuf());
 
     // Redirect Qt messages into dtkMsg

--- a/app/medInria/main.cpp
+++ b/app/medInria/main.cpp
@@ -80,10 +80,10 @@ int main(int argc,char* argv[]) {
     medApplication application(argc,argv);
 
     // Copy std::cout and std::cerr in log file
-    std::ofstream logFile(dtkLogPath(&application).toLocal8Bit().data(), std::ios::app);
-
     typedef boost::iostreams::tee_device<std::ostream, std::ofstream> TeeDevice;
     typedef boost::iostreams::stream<TeeDevice> TeeStream;
+
+    std::ofstream logFile(dtkLogPath(&application).toLocal8Bit().data(), std::ios::app);
 
     std::streambuf* oldCoutBuffer = std::cout.rdbuf();
     std::streambuf* oldCerrBuffer = std::cerr.rdbuf();

--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -11,6 +11,9 @@
 
 =========================================================================*/
 
+#include <boost/iostreams/tee.hpp>
+#include <boost/iostreams/stream.hpp>
+
 #include <medMainWindow.h>
 
 #include <QtGui>
@@ -46,6 +49,11 @@
 #else
 # define CONTROL_KEY "Ctrl"
 #endif
+
+typedef boost::iostreams::tee_device<std::ostream, std::ofstream> TeeDevice;
+typedef boost::iostreams::stream<TeeDevice> TeeStream;
+extern TeeStream logger;
+extern TeeStream loggerErr;
 
 //--------------------------------------------------------------------------
 // medMainWindowStyle
@@ -660,6 +668,10 @@ void medMainWindow::availableSpaceOnStatusBar()
 
 void medMainWindow::closeEvent(QCloseEvent *event)
 {
+    // Close boost::iostreams open in main.cpp for logs
+    logger.close();
+    loggerErr.close();
+
     if ( QThreadPool::globalInstance()->activeThreadCount() > 0 )
     {
         int res = QMessageBox::information(this,

--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -11,9 +11,6 @@
 
 =========================================================================*/
 
-#include <boost/iostreams/tee.hpp>
-#include <boost/iostreams/stream.hpp>
-
 #include <medMainWindow.h>
 
 #include <QtGui>
@@ -49,11 +46,6 @@
 #else
 # define CONTROL_KEY "Ctrl"
 #endif
-
-typedef boost::iostreams::tee_device<std::ostream, std::ofstream> TeeDevice;
-typedef boost::iostreams::stream<TeeDevice> TeeStream;
-extern TeeStream logger;
-extern TeeStream loggerErr;
 
 //--------------------------------------------------------------------------
 // medMainWindowStyle
@@ -699,9 +691,8 @@ void medMainWindow::closeEvent(QCloseEvent *event)
     }
     this->saveSettings();
 
-    // Close boost::iostreams open in main.cpp for logs
-    logger.close();
-    loggerErr.close();
+    dtkInfo() << "### Application is closing...";
+    dtkInfo() << "####################################";
 
     event->accept();
 }

--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -668,10 +668,6 @@ void medMainWindow::availableSpaceOnStatusBar()
 
 void medMainWindow::closeEvent(QCloseEvent *event)
 {
-    // Close boost::iostreams open in main.cpp for logs
-    logger.close();
-    loggerErr.close();
-
     if ( QThreadPool::globalInstance()->activeThreadCount() > 0 )
     {
         int res = QMessageBox::information(this,
@@ -702,6 +698,11 @@ void medMainWindow::closeEvent(QCloseEvent *event)
         return;
     }
     this->saveSettings();
+
+    // Close boost::iostreams open in main.cpp for logs
+    logger.close();
+    loggerErr.close();
+
     event->accept();
 }
 


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/143

boost streams were not closed at the closing of the application, creating a crash.

:m: