### PR TITLE
[extract4Dto3D] fixes log related freeze

### DIFF
--- a/app/medInria/medApplication.cpp
+++ b/app/medInria/medApplication.cpp
@@ -90,7 +90,7 @@ medApplication::medApplication(int & argc, char**argv) :
                      this,SLOT(redirectMessageToLog(QString)));
 
     QObject::connect(&medQtMessageHandler::instance(), SIGNAL(newQtMsg(QtMsgType, const char*)),
-                    this,SLOT(receiveQtMsg(QtMsgType , const char*)));
+                    this,SLOT(receiveQtMsg(QtMsgType , const char*)), Qt::DirectConnection);
 
     this->initialize();
 }


### PR DESCRIPTION
(fixes https://github.com/Inria-Asclepios/music/issues/382)
The problem is that passing a pointer through a signal could cause problems when this is done asynchronously, because the data could be deleted once the slot actually gets called. The solution is therefore to make the connection direct.