### PR TITLE
Fixed log loops and signal errors

### DIFF
--- a/app/medInria/medApplication.h
+++ b/app/medInria/medApplication.h
@@ -37,7 +37,7 @@ public slots:
     void redirectMessageToSplash(const QString& message);
     void redirectMessageToLog(const QString & message);
     void redirectErrorMessageToLog(const QString & message);
-    void receiveQtMsg(QtMsgType type, const char *msg);
+    void receiveQtMsg(QtMsgType type, const QString& message);
 
     void open(const medDataIndex & index);
     void open(QString path);

--- a/app/medInria/medQtMessageHandler.cpp
+++ b/app/medInria/medQtMessageHandler.cpp
@@ -27,5 +27,5 @@ medQtMessageHandler &medQtMessageHandler::instance()
 
 void medQtMessageHandler::msgHandler(QtMsgType type, const char *msg)
 {
-    emit instance().newQtMsg(type, msg);
+    emit instance().newQtMsg(type, QString(msg));
 }

--- a/app/medInria/medQtMessageHandler.h
+++ b/app/medInria/medQtMessageHandler.h
@@ -22,6 +22,6 @@ public :
     static void msgHandler(QtMsgType type, const char *msg);
 
 signals :
-    void newQtMsg(QtMsgType type, const char *msg);
+    void newQtMsg(QtMsgType type, const QString& message);
 
 };


### PR DESCRIPTION
(fixes https://github.com/Inria-Asclepios/music/issues/382, replaces https://github.com/Inria-Asclepios/medInria-public/pull/162)
This PR fixes some of the issues we've had with log files:

* The log messages are sent by an asynchronous signal using char*, which leads to debug messages with strange characters because the data containing the message was trashed in memory. To fix this I had used a previous solution (https://github.com/Inria-Asclepios/medInria-public/pull/162) where I made the signal synchronous, which guaranteed that the message was being written before the data was trashed. This worked but introduced another bug: if the logger sends its own message during the process, it caused a recursion into the logging process which provoked a freeze. I dropped this idea and instead used QThreadLocalStorage to track if a same thread enters the logging process recursively. If that happens, the second message is not written (so any messages sent by the logger itself will be dropped).
* Since I removed the correction that prevented the message from being trashed in memory, I added another fix for that: instead of using char*, the signal uses QString&, and for this type of data Qt automatically does a copy to ensure integrity of the data being sent.

So now there should be no freeze, and the logging is kept in asynchronous mode, which prevents the processes from lagging because they don't have to wait for the messages to be written (as before). 