### PR TITLE
[ComponentSizeThreshold] return value of castToUInt is not a boolean

### DIFF
--- a/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.cpp
@@ -114,16 +114,16 @@ int itkFiltersComponentSizeThresholdProcess::tryUpdate()
         }
         else if ( id== "itkDataImageFloat3" )
         {
-            if (d->castToUInt3<float>())
+            if (d->castToUInt3<float>() == DTK_SUCCEED)
             {
                 res = d->update<unsigned int>();
             }
         }
         else if ( id== "itkDataImageDouble3" )
         {
-            if(d->castToUInt3<double>())
+            if(d->castToUInt3<double>() == DTK_SUCCEED)
             {
-                return d->update<unsigned int>();
+                res = d->update<unsigned int>();
             }
         }
         else


### PR DESCRIPTION
(solves https://github.com/Inria-Asclepios/music/issues/396)

The issue stems from an error in ```itkFiltersComponentSizeThresholdProcess``` where the return value of ```castToUInt``` is treated as a boolean, when in fact it's a DTK success/failure integer. In addition I found a syntax error, where a return statement wasn't properly removed. Also, debugging this made me realise that processes called directly from pipeline steps are not checked for errors. I made an issue for this (https://github.com/Inria-Asclepios/music/issues/397).