### PR TITLE
[maskAppl] output should be NULL until process successful update

### DIFF
--- a/src-plugins/medMaskApplication/medMaskApplication.cpp
+++ b/src-plugins/medMaskApplication/medMaskApplication.cpp
@@ -71,15 +71,7 @@ public:
                 maskFilter->Update();
 
                 QString identifier = input->identifier();
-                if (!identifier.isEmpty())
-                {
-                    output = medAbstractDataFactory::instance()->createSmartPointer ( identifier );
-                }
-                else
-                {
-                    output = medAbstractDataFactory::instance()->createSmartPointer ( "itkDataImageChar3" );
-                }
-
+                output = medAbstractDataFactory::instance()->createSmartPointer ( identifier );
                 output->setData(maskFilter->GetOutput());
             }
             catch( itk::ExceptionObject & err )

--- a/src-plugins/medMaskApplication/medMaskApplication.cpp
+++ b/src-plugins/medMaskApplication/medMaskApplication.cpp
@@ -158,6 +158,7 @@ void medMaskApplication::clearInput (int channel)
 
     if ( channel == 1 )
     {
+        d->output = NULL;
         d->input = NULL;
     }
 }

--- a/src-plugins/medMaskApplication/medMaskApplication.cpp
+++ b/src-plugins/medMaskApplication/medMaskApplication.cpp
@@ -69,6 +69,17 @@ public:
                 imageCalculatorFilter->ComputeMinimum();
                 maskFilter->SetOutsideValue(std::min(double(imageCalculatorFilter->GetMinimum()), 0.0));
                 maskFilter->Update();
+
+                QString identifier = input->identifier();
+                if (!identifier.isEmpty())
+                {
+                    output = medAbstractDataFactory::instance()->createSmartPointer ( identifier );
+                }
+                else
+                {
+                    output = medAbstractDataFactory::instance()->createSmartPointer ( "itkDataImageChar3" );
+                }
+
                 output->setData(maskFilter->GetOutput());
             }
             catch( itk::ExceptionObject & err )
@@ -126,15 +137,6 @@ void medMaskApplication::setInput ( medAbstractData *data, int channel)
 
     if ( channel == 1 )
     {
-        QString identifier = data->identifier();
-        if (!identifier.isEmpty())
-        {
-            d->output = medAbstractDataFactory::instance()->createSmartPointer ( identifier );
-        }
-        else
-        {
-            d->output = medAbstractDataFactory::instance()->createSmartPointer ( "itkDataImageChar3" );
-        }
         d->input = data;
     }
 }
@@ -156,7 +158,6 @@ void medMaskApplication::clearInput (int channel)
 
     if ( channel == 1 )
     {
-        d->output = NULL;
         d->input = NULL;
     }
 }
@@ -277,7 +278,7 @@ int medMaskApplication::updateMaskType()
 
 medAbstractData * medMaskApplication::output()
 {
-    return ( d->output );
+    return d->output;
 }
 
 // /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Part of the solution of https://github.com/Inria-Asclepios/music/issues/402
### How to reproduce the pb?

Drop a volume and a mask of different dimensions in Segmentation workspace, select Histogram Analysis, click on Create containers. The app crashes.
### What's going on in Histogram Analysis?

Inside the slot launched by this last click, the mask is applied to the image using the `medMaskApplication` process:

``` c++
medAbstractData* HistogramAnalysisToolBox::applyMaskToImage()
{
  dtkSmartPointer<medAbstractProcess> maskProcess = dtkAbstractProcessFactory::instance()->createSmartPointer("medMaskApplication");
  maskProcess->setInput(d->mask, 0);
  maskProcess->setInput(d->image, 1);
  maskProcess->setParameter(d->backgroundSpinBox->value(), 0);
  maskProcess->update();
  d->segmentedImage = maskProcess->output();
  return d->segmentedImage;
}
```

this one is smart enough to notice that the images don't share the same dimensions, so `update()` returns `DTK_ERROR`. But this is unnoticed as you can see from the code above.
Actually in histogramAnalysis, we check that the mask application went well by checking what returns `applyMaskToImage()`, i.e (from the code above) `maskProcess->output();`
### What's wrong in mask application?

The attribute `output` is initialized to `NULL` in the constructor.
However, from the moment you set a volume as input of your process, `output` points to a medAbstractData.
Meaning that if the process fails, `output` is non-null.
### What does this PR?

`output` becomes non-null just before making it point to the output of the itkFilter.

In histogram analysis, now after reproducing the steps described high above, it won't crash but it will create empty containers.
That's why I'll do very soon a PR to modify histogramAnalysisToolbox.

Side note: This "pb" is in many toolboxes, we should apply this modif on them too.