### PR TITLE
[Logs] rm 3D rendering warning on mesh

### DIFF
--- a/src-plugins/medVtkView/medVtkViewNavigator.cpp
+++ b/src-plugins/medVtkView/medVtkViewNavigator.cpp
@@ -629,6 +629,7 @@ void medVtkViewNavigator::changeOrientation(medImageView::Orientation orientatio
     d->currentView->SetRenderWindow(renWin);
     d->currentView->SetCurrentPoint(pos);
     d->currentView->SetTimeIndex(timeIndex);
+    d->currentView->GlobalWarningDisplayOff();
     d->currentView->Render();
 
     d->orientation = orientation;


### PR DESCRIPTION
This PR removes annoying warnings in log when we switch a mesh to 3D:

```
ERROR - lun. nov. 7 15:58:58 2016 - ERROR: In /home/mathildemerle/Dev/medinria-superproject/VTK/Filtering/vtkDemandDrivenPipeline.cxx, line 727
vtkStreamingDemandDrivenPipeline (0x52e0580): Input port 0 of algorithm vtkOpenGLImageSliceMapper(0x280c000) has 0 connections but is not optional.
```

:m: