### PR TITLE
[Paint] solve problem switching to other tlbx or rm datasets

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -394,7 +394,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 
     connect (m_strokeButton, SIGNAL(pressed()), this, SLOT(activateStroke ()));
     connect (m_magicWandButton, SIGNAL(pressed()),this,SLOT(activateMagicWand()));
-    connect (m_clearMaskButton, SIGNAL(pressed()), this, SLOT(initializeToolBox()));
+    connect (m_clearMaskButton, SIGNAL(pressed()), this, SLOT(clearToolBox()));
     connect (m_applyButton, SIGNAL(pressed()),this, SLOT(import()));
 
     if (this->selectorToolBox()) // empty in pipelines
@@ -574,7 +574,7 @@ void AlgorithmPaintToolBox::hideEvent(QHideEvent *event)
 {
     medAbstractSelectableToolBox::hideEvent(event);
 
-    initializeToolBox();
+    clearToolBox();
 }
 
 void AlgorithmPaintToolBox::updateMagicWandComputationSpeed()
@@ -632,7 +632,7 @@ void AlgorithmPaintToolBox::updateView()
             // Update cursor if the orientation change
             connect(currentView, SIGNAL(orientationChanged()), this, SLOT(activateCustomedCursor()), Qt::UniqueConnection);
 
-            connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(initializeToolBox()), Qt::UniqueConnection);
+            connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(clearToolBox()), Qt::UniqueConnection);
 
             // Update cursor to new view
             if ( this->m_strokeButton->isChecked() )
@@ -643,12 +643,22 @@ void AlgorithmPaintToolBox::updateView()
             {
                 deactivateCustomedCursor(); // Deactivate painting cursor
             }
+
+            disableButtons(false);
         }
     }
     else
     {
+        disableButtons(true);
         currentView = NULL;
     }
+}
+
+void AlgorithmPaintToolBox::disableButtons(bool isToDisable)
+{
+    m_strokeButton->setDisabled(isToDisable);
+    m_magicWandButton->setDisabled(isToDisable);
+    m_interpolateButton->setDisabled(isToDisable);
 }
 
 void AlgorithmPaintToolBox::setLabel(int newVal)
@@ -1448,7 +1458,7 @@ void AlgorithmPaintToolBox::addSliceToStack(medAbstractView * view,const unsigne
             m_redoStacks->value(view)->clear();
 }
 
-void AlgorithmPaintToolBox::initializeToolBox()
+void AlgorithmPaintToolBox::clearToolBox()
 {
     if (currentView && (currentView->layersCount()>0))
     {
@@ -1457,7 +1467,7 @@ void AlgorithmPaintToolBox::initializeToolBox()
         {
             if (currentView->layerData(i)->identifier() == "medImageMaskAnnotationData")
             {
-                currentView->removeLayer(i); // call initializeToolBox() again
+                currentView->removeLayer(i); // call clearToolBox() again
             }
         }
         clearMask(currentView);
@@ -1485,7 +1495,11 @@ void AlgorithmPaintToolBox::clearMask(medAbstractView* view)
         {
             m_imageData->removeAttachedData(m_maskAnnotationData);
             maskHasBeenSaved = false;
-            setData(currentView->layerData(0));
+
+            if (currentView && (currentView->layersCount()>0))
+            {
+                setData(currentView->layerData(0));
+            }
         }
         m_applyButton->setDisabled(true);
     }

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -1461,7 +1461,7 @@ void AlgorithmPaintToolBox::clear()
             if (currentView->layerData(i)->identifier() == "medImageMaskAnnotationData")
             {
                 currentView->removeLayer(i); // call clear() again
-                return;
+                break;
             }
         }
     }

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -573,7 +573,12 @@ void AlgorithmPaintToolBox::activateMagicWand()
 void AlgorithmPaintToolBox::hideEvent(QHideEvent *event)
 {
     medAbstractSelectableToolBox::hideEvent(event);
-    resetToolbox();
+
+    // remove additionnal data set
+    if (currentView->layersCount() > 1)
+    {
+        currentView->removeLayer(1);
+    }
 }
 
 void AlgorithmPaintToolBox::updateMagicWandComputationSpeed()
@@ -634,7 +639,7 @@ void AlgorithmPaintToolBox::updateView()
         // Update cursor if the orientation change
         connect(currentView, SIGNAL(orientationChanged()), this, SLOT(activateCustomedCursor()), Qt::UniqueConnection);
 
-        connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(closeView()), Qt::UniqueConnection);
+        connect(currentView,SIGNAL(layerRemoved(unsigned int)),this,SLOT(initializeToolBox(unsigned int)), Qt::UniqueConnection);
     }
 
     // Update cursor to new view
@@ -1445,22 +1450,24 @@ void AlgorithmPaintToolBox::addSliceToStack(medAbstractView * view,const unsigne
             m_redoStacks->value(view)->clear();
 }
 
-void AlgorithmPaintToolBox::closeView()
+void AlgorithmPaintToolBox::initializeToolBox(unsigned int layerRemoved)
 {
     // close every data in the view
     medAbstractView* view = qobject_cast<medAbstractView*>(QObject::sender());
     medAbstractLayeredView* layeredView = dynamic_cast<medAbstractLayeredView*>(view);
 
+    // remove additionnal data set
+    if ((layerRemoved == 0) && (layeredView->layersCount() > 0))
+    {
+        layeredView->removeLayer(0);
+        return;
+    }
+
+    // initialize toolbox with original or no data set
+    onViewClosed(view);
     if (layeredView->layersCount() > 0)
     {
-        // remove a data, which will recursively call this closeView() function
-        // until there is no more data in the view
-        layeredView->removeLayer(0);
-    }
-    else
-    {
-        // clean the toolbox when there is no data left in the view
-        onViewClosed(view);
+        updateView();
     }
 }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -570,10 +570,8 @@ void AlgorithmPaintToolBox::activateMagicWand()
     deactivateCustomedCursor();
 }
 
-void AlgorithmPaintToolBox::hideEvent(QHideEvent *event)
+void AlgorithmPaintToolBox::changeSelectedToolBoxEvent()
 {
-    medAbstractSelectableToolBox::hideEvent(event);
-
     clearToolBox();
 }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -1464,14 +1464,10 @@ void AlgorithmPaintToolBox::clear()
                 return;
             }
         }
-        clearMask();
-        updateView();
     }
-    else // if no more data set in list, this is called a last time
-    {
-        clearMask();
-        updateView();
-    }
+
+    clearMask();
+    updateView();
 }
 
 void AlgorithmPaintToolBox::clearMask()

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -637,17 +637,17 @@ void AlgorithmPaintToolBox::updateView()
                 deactivateCustomedCursor(); // Deactivate painting cursor
             }
 
-            setDisabled(false);
+            setButtonsDisabled(false);
         }
     }
     else
     {
-        setDisabled(true);
+        setButtonsDisabled(true);
         currentView = NULL;
     }
 }
 
-void AlgorithmPaintToolBox::setDisabled(bool disable)
+void AlgorithmPaintToolBox::setButtonsDisabled(bool disable)
 {
     m_strokeButton->setDisabled(disable);
     m_magicWandButton->setDisabled(disable);

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -111,9 +111,8 @@ public slots:
     void redo();
     void addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice);
 
-    void initializeToolBox(unsigned int layerRemoved);
-    void onViewClosed(medAbstractView* viewClosed);
-    void clearMask();
+    void initializeToolBox();
+    void clearMask(medAbstractView *view);
     void resetToolbox();
 
     void newSeed();

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -152,7 +152,7 @@ protected:
 
     void addViewEventFilter(medViewEventFilter * filter );
 
-    void hideEvent(QHideEvent *event);
+    void changeSelectedToolBoxEvent();
 
     void disableButtons(bool isToDisable);
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -111,7 +111,7 @@ public slots:
     void redo();
     void addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice);
 
-    void closeView();
+    void initializeToolBox(unsigned int layerRemoved);
     void onViewClosed(medAbstractView* viewClosed);
     void clearMask();
     void resetToolbox();

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -111,8 +111,8 @@ public slots:
     void redo();
     void addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice);
 
-    void clearToolBox();
-    void clearMask(medAbstractView *view);
+    virtual void clear();
+    void clearMask();
     void resetToolbox();
 
     void newSeed();
@@ -152,9 +152,7 @@ protected:
 
     void addViewEventFilter(medViewEventFilter * filter );
 
-    void changeSelectedToolBoxEvent();
-
-    void disableButtons(bool isToDisable);
+    void setDisabled(bool disable);
 
 private:
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -111,7 +111,7 @@ public slots:
     void redo();
     void addSliceToStack(medAbstractView * view,const unsigned char planeIndex,QList<int> listIdSlice);
 
-    void initializeToolBox();
+    void clearToolBox();
     void clearMask(medAbstractView *view);
     void resetToolbox();
 
@@ -153,6 +153,8 @@ protected:
     void addViewEventFilter(medViewEventFilter * filter );
 
     void hideEvent(QHideEvent *event);
+
+    void disableButtons(bool isToDisable);
 
 private:
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.h
@@ -152,7 +152,7 @@ protected:
 
     void addViewEventFilter(medViewEventFilter * filter );
 
-    void setDisabled(bool disable);
+    void setButtonsDisabled(bool disable);
 
 private:
 


### PR DESCRIPTION
Begin to solve problems switching from toolbox to other tlbx: https://github.com/Inria-Asclepios/music/issues/406

This PR solves data removing problems in Paint:
( these 3 points call the `initializeToolBox` function)
 * when the user removes directly the additional mask, it doesn't remove the original data set, and the toolbox is initialized;
 * when the user removes directly the original data set, the toolbox is initialized;
 * when we switch to an other toolbox, the additional (mask) data is removed and the toolbox is initialized.

:m: