### PR TITLE
[manualReg] switch to an other toolbox

### DIFF
--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -395,6 +395,16 @@ void manualRegistrationToolBox::reset()
     setDisableComputeResetButtons(true);
 }
 
+void manualRegistrationToolBox::hideEvent(QHideEvent *event)
+{
+    medAbstractSelectableToolBox::hideEvent(event);
+
+    if (d->regOn)
+    {
+        d->b_startManualRegistration->click();
+    }
+}
+
 void manualRegistrationToolBox::save()
 {
     if (d->controller && d->output)

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -46,6 +46,9 @@ public slots:
     void computeRegistration();
     void reset();
 
+protected:
+    void hideEvent(QHideEvent *event);
+
 private:
     void displayButtons(bool);
     void constructContainers(medTabbedViewContainers *);


### PR DESCRIPTION
:D The last PR about switching between toolboxes (it's clearer for you to review several PR on dedicated toolboxes than a big one with everything in it). About this issue: https://github.com/Inria-Asclepios/music/issues/406

The manual registration tool is stopped if we switch.

:m: