### PR TITLE
[NavX] Adds the possibility to export a list of data

### DIFF
--- a/src/medCore/data/medAbstractDataWriter.h
+++ b/src/medCore/data/medAbstractDataWriter.h
@@ -4,6 +4,8 @@
 #include <dtkCore/dtkAbstractDataWriter.h>
 #include <medCoreExport.h>
 
+
+class medAbstractData;
 /**
  * Extending dtkAbstractDataWriter class to allow the export of a list of data
  */
@@ -13,7 +15,7 @@ class MEDCORE_EXPORT medAbstractDataWriter : public dtkAbstractDataWriter
 
 public:
     using dtkAbstractDataWriter::setData;
-    virtual void setData(QList<dtkAbstractData*> data) {}
+    virtual void setData(QList<medAbstractData*> data) {}
 };
 
 

--- a/src/medCore/data/medAbstractDataWriter.h
+++ b/src/medCore/data/medAbstractDataWriter.h
@@ -1,0 +1,21 @@
+#ifndef MEDABSTRACTDATAWRITER
+#define MEDABSTRACTDATAWRITER
+
+#include <dtkCore/dtkAbstractDataWriter.h>
+#include <medCoreExport.h>
+
+/**
+ * Extending dtkAbstractDataWriter class to allow the export of a list of data
+ */
+class MEDCORE_EXPORT medAbstractDataWriter : public dtkAbstractDataWriter
+{
+    Q_OBJECT
+
+public:
+    using dtkAbstractDataWriter::setData;
+    virtual void setData(QList<dtkAbstractData*> data) {}
+};
+
+
+#endif // MEDABSTRACTDATAWRITER
+

--- a/src/medCore/database/medDataManager.cpp
+++ b/src/medCore/database/medDataManager.cpp
@@ -18,7 +18,6 @@
 #include <medAbstractDataFactory.h>
 #include <medDatabaseController.h>
 #include <medDatabaseNonPersistentController.h>
-#include <medDatabaseExporter.h>
 #include <medMessageController.h>
 #include <medJobManager.h>
 #include <medPluginManager.h>
@@ -233,20 +232,17 @@ void medDataManager::exportData(medAbstractData* data)
 void medDataManager::exportDataToPath(medAbstractData *data, const QString & filename, const QString & writer)
 {
     medDatabaseExporter *exporter = new medDatabaseExporter (data, filename, writer);
-    QFileInfo info(filename);
-    medMessageProgress *message = medMessageController::instance()->showProgress("Exporting data to " + info.baseName());
-
-    connect(exporter, SIGNAL(progressed(int)), message, SLOT(setProgress(int)));
-    connect(exporter, SIGNAL(success(QObject *)), message, SLOT(success()));
-    connect(exporter, SIGNAL(failure(QObject *)), message, SLOT(failure()));
-
-    medJobManager::instance()->registerJobItem(exporter);
-    QThreadPool::globalInstance()->start(exporter);
+    launchExporter(exporter, filename);
 }
 
-void medDataManager::exportDataToPath(QList<medAbstractData*> data, const QString & filename, const QString & writer)
+void medDataManager::exportDataToPath(QList<medAbstractData*> dataList, const QString & filename, const QString & writer)
 {
-    medDatabaseExporter *exporter = new medDatabaseExporter (data, filename, writer);
+    medDatabaseExporter *exporter = new medDatabaseExporter (dataList, filename, writer);
+    launchExporter(exporter, filename);
+}
+
+void medDataManager::launchExporter(medDatabaseExporter* exporter, const QString & filename)
+{
     QFileInfo info(filename);
     medMessageProgress *message = medMessageController::instance()->showProgress("Exporting data to " + info.baseName());
 

--- a/src/medCore/database/medDataManager.cpp
+++ b/src/medCore/database/medDataManager.cpp
@@ -244,6 +244,20 @@ void medDataManager::exportDataToPath(medAbstractData *data, const QString & fil
     QThreadPool::globalInstance()->start(exporter);
 }
 
+void medDataManager::exportDataToPath(QList<dtkAbstractData*> data, const QString & filename, const QString & writer)
+{
+    medDatabaseExporter *exporter = new medDatabaseExporter (data, filename, writer);
+    QFileInfo info(filename);
+    medMessageProgress *message = medMessageController::instance()->showProgress("Exporting data to " + info.baseName());
+
+    connect(exporter, SIGNAL(progressed(int)), message, SLOT(setProgress(int)));
+    connect(exporter, SIGNAL(success(QObject *)), message, SLOT(success()));
+    connect(exporter, SIGNAL(failure(QObject *)), message, SLOT(failure()));
+
+    medJobManager::instance()->registerJobItem(exporter);
+    QThreadPool::globalInstance()->start(exporter);
+}
+
 
 QList<medDataIndex> medDataManager::moveStudy(const medDataIndex& indexStudy, const medDataIndex& toPatient)
 {

--- a/src/medCore/database/medDataManager.cpp
+++ b/src/medCore/database/medDataManager.cpp
@@ -244,7 +244,7 @@ void medDataManager::exportDataToPath(medAbstractData *data, const QString & fil
     QThreadPool::globalInstance()->start(exporter);
 }
 
-void medDataManager::exportDataToPath(QList<dtkAbstractData*> data, const QString & filename, const QString & writer)
+void medDataManager::exportDataToPath(QList<medAbstractData*> data, const QString & filename, const QString & writer)
 {
     medDatabaseExporter *exporter = new medDatabaseExporter (data, filename, writer);
     QFileInfo info(filename);

--- a/src/medCore/database/medDataManager.h
+++ b/src/medCore/database/medDataManager.h
@@ -19,12 +19,14 @@
 #include <QUuid>
 
 #include <medCoreExport.h>
+#include <medDatabaseExporter.h>
 #include <medDataIndex.h>
 
 class medDataManagerPrivate;
 class medAbstractData;
 class medAbstractDbController;
 class dtkAbstractDataWriter;
+
 
 class MEDCORE_EXPORT medDataManager : public QObject
 {
@@ -43,7 +45,7 @@ public:
 
     void exportData(medAbstractData* data);
     void exportDataToPath(medAbstractData* data, const QString& path, const QString& format = "");
-    void exportDataToPath(QList<medAbstractData *> data, const QString& path, const QString& format = "");
+    void exportDataToPath(QList<medAbstractData *> dataList, const QString& path, const QString& format = "");
 
     QUuid makePersistent(medAbstractData* data);
 
@@ -84,6 +86,7 @@ private:
     virtual ~medDataManager();
 
     static medDataManager * s_instance;
+    void launchExporter(medDatabaseExporter* exporter, const QString & filename);
 
     Q_DECLARE_PRIVATE(medDataManager)
 };

--- a/src/medCore/database/medDataManager.h
+++ b/src/medCore/database/medDataManager.h
@@ -22,6 +22,7 @@
 #include <medDataIndex.h>
 
 class medDataManagerPrivate;
+class dtkAbstractData;
 class medAbstractData;
 class medAbstractDbController;
 class dtkAbstractDataWriter;
@@ -43,6 +44,7 @@ public:
 
     void exportData(medAbstractData* data);
     void exportDataToPath(medAbstractData* data, const QString& path, const QString& format = "");
+    void exportDataToPath(QList<dtkAbstractData*> data, const QString& path, const QString& format = "");
 
     QUuid makePersistent(medAbstractData* data);
 

--- a/src/medCore/database/medDataManager.h
+++ b/src/medCore/database/medDataManager.h
@@ -22,7 +22,6 @@
 #include <medDataIndex.h>
 
 class medDataManagerPrivate;
-class dtkAbstractData;
 class medAbstractData;
 class medAbstractDbController;
 class dtkAbstractDataWriter;
@@ -44,7 +43,7 @@ public:
 
     void exportData(medAbstractData* data);
     void exportDataToPath(medAbstractData* data, const QString& path, const QString& format = "");
-    void exportDataToPath(QList<dtkAbstractData*> data, const QString& path, const QString& format = "");
+    void exportDataToPath(QList<medAbstractData *> data, const QString& path, const QString& format = "");
 
     QUuid makePersistent(medAbstractData* data);
 

--- a/src/medCore/database/medDatabaseExporter.cpp
+++ b/src/medCore/database/medDatabaseExporter.cpp
@@ -21,8 +21,10 @@ class medDatabaseExporterPrivate
 {
 public:
     medAbstractData *data;
+    QList<dtkAbstractData*> dataList;
     QString          filename;
     QString          writer;
+    bool saveMultipleData;
 };
 
 medDatabaseExporter::medDatabaseExporter(medAbstractData * data, const QString & filename, const QString & writer) : medJobItem(), d(new medDatabaseExporterPrivate)
@@ -30,6 +32,16 @@ medDatabaseExporter::medDatabaseExporter(medAbstractData * data, const QString &
     d->data     = data;
     d->filename = filename;
     d->writer   = writer;
+    d->saveMultipleData = false;
+}
+
+medDatabaseExporter::medDatabaseExporter(QList<dtkAbstractData*> data, const QString & filename, const QString & writer) : medJobItem(), d(new medDatabaseExporterPrivate)
+{
+    d->data     = NULL;
+    d->dataList = data;
+    d->filename = filename;
+    d->writer   = writer;
+    d->saveMultipleData = true;
 }
 
 medDatabaseExporter::~medDatabaseExporter(void)
@@ -47,7 +59,8 @@ medDatabaseExporter::~medDatabaseExporter(void)
 */
 void medDatabaseExporter::internalRun(void)
 {
-    if (!d->data)
+    if ((!d->saveMultipleData && !d->data) ||
+            (d->saveMultipleData && d->dataList.isEmpty()))
     {
         emit showError("Cannot export data", 3000);
         return;
@@ -59,7 +72,14 @@ void medDatabaseExporter::internalRun(void)
     }
 
     dtkAbstractDataWriter * dataWriter = medAbstractDataFactory::instance()->writer(d->writer);
-    dataWriter->setData(d->data);
+    if(!d->saveMultipleData)
+    {
+        dataWriter->setData(d->data);
+    }
+    else
+    {
+        dataWriter->setData(d->dataList);
+    }
 
 
     if ( ! dataWriter->canWrite(d->filename) || ! dataWriter->write(d->filename)) {

--- a/src/medCore/database/medDatabaseExporter.cpp
+++ b/src/medCore/database/medDatabaseExporter.cpp
@@ -22,7 +22,7 @@ class medDatabaseExporterPrivate
 {
 public:
     medAbstractData *data;
-    QList<dtkAbstractData*> dataList;
+    QList<medAbstractData*> dataList;
     QString          filename;
     QString          writer;
     bool saveMultipleData;
@@ -36,7 +36,7 @@ medDatabaseExporter::medDatabaseExporter(medAbstractData * data, const QString &
     d->saveMultipleData = false;
 }
 
-medDatabaseExporter::medDatabaseExporter(QList<dtkAbstractData*> data, const QString & filename, const QString & writer) : medJobItem(), d(new medDatabaseExporterPrivate)
+medDatabaseExporter::medDatabaseExporter(QList<medAbstractData*> data, const QString & filename, const QString & writer) : medJobItem(), d(new medDatabaseExporterPrivate)
 {
     d->data     = NULL;
     d->dataList = data;

--- a/src/medCore/database/medDatabaseExporter.cpp
+++ b/src/medCore/database/medDatabaseExporter.cpp
@@ -79,17 +79,11 @@ void medDatabaseExporter::internalRun(void)
     }
     else
     {
-        medAbstractDataWriter* medDataWriter;
-        try
+        medAbstractDataWriter* medDataWriter = dynamic_cast<medAbstractDataWriter*>(dataWriter);
+        if(medDataWriter)
         {
-            medDataWriter = dynamic_cast<medAbstractDataWriter*>(dataWriter);
+            medDataWriter->setData(d->dataList);
         }
-        catch (const std::exception& e)
-        {
-            qDebug()<<"medDatabaseExporter::internalRun(void): "<< e.what();
-            return;
-        }
-        medDataWriter->setData(d->dataList);
     }
 
 

--- a/src/medCore/database/medDatabaseExporter.cpp
+++ b/src/medCore/database/medDatabaseExporter.cpp
@@ -16,6 +16,7 @@
 #include <medAbstractData.h>
 #include <dtkCore/dtkAbstractDataWriter.h>
 #include <medAbstractDataFactory.h>
+#include <medAbstractDataWriter.h>
 
 class medDatabaseExporterPrivate
 {
@@ -78,7 +79,17 @@ void medDatabaseExporter::internalRun(void)
     }
     else
     {
-        dataWriter->setData(d->dataList);
+        medAbstractDataWriter* medDataWriter;
+        try
+        {
+            medDataWriter = dynamic_cast<medAbstractDataWriter*>(dataWriter);
+        }
+        catch (const std::exception& e)
+        {
+            qDebug()<<"medDatabaseExporter::internalRun(void): "<< e.what();
+            return;
+        }
+        medDataWriter->setData(d->dataList);
     }
 
 

--- a/src/medCore/database/medDatabaseExporter.cpp
+++ b/src/medCore/database/medDatabaseExporter.cpp
@@ -80,10 +80,8 @@ void medDatabaseExporter::internalRun(void)
     else
     {
         medAbstractDataWriter* medDataWriter = dynamic_cast<medAbstractDataWriter*>(dataWriter);
-        if(medDataWriter)
-        {
-            medDataWriter->setData(d->dataList);
-        }
+        Q_ASSERT(medDataWriter != NULL);
+        medDataWriter->setData(d->dataList);
     }
 
 

--- a/src/medCore/database/medDatabaseExporter.h
+++ b/src/medCore/database/medDatabaseExporter.h
@@ -18,7 +18,6 @@
 
 #include <medJobItem.h>
 
-class dtkAbstractData;
 class medAbstractData;
 class medDatabaseExporterPrivate;
 
@@ -28,7 +27,7 @@ class MEDCORE_EXPORT medDatabaseExporter : public medJobItem
 
 public:
      medDatabaseExporter(medAbstractData * data, const QString & filename, const QString & writer);
-     medDatabaseExporter(QList<dtkAbstractData*> data, const QString & filename, const QString & writer);
+     medDatabaseExporter(QList<medAbstractData *> data, const QString & filename, const QString & writer);
     ~medDatabaseExporter();
 
 protected:

--- a/src/medCore/database/medDatabaseExporter.h
+++ b/src/medCore/database/medDatabaseExporter.h
@@ -18,6 +18,7 @@
 
 #include <medJobItem.h>
 
+class dtkAbstractData;
 class medAbstractData;
 class medDatabaseExporterPrivate;
 
@@ -27,6 +28,7 @@ class MEDCORE_EXPORT medDatabaseExporter : public medJobItem
 
 public:
      medDatabaseExporter(medAbstractData * data, const QString & filename, const QString & writer);
+     medDatabaseExporter(QList<dtkAbstractData*> data, const QString & filename, const QString & writer);
     ~medDatabaseExporter();
 
 protected:


### PR DESCRIPTION
### The need
The specificity of exporting a scene into NavX format is that you save several datasets into one single file (an xml). Which is hardly doable in the app right now: a ```dtkAbstractDataWriter``` only accepts one single ```medAbstractData*```.

### What the PR brings
I added in the core, a new class ```medAbstractDataWriter``` which inherits from ```dtkAbstractDataWriter``` and possesses a method allowing to have a list of ```medAbstractData``` as input.
The NavX writer will then inherit from this class.

({Probably giving a list of datasets will be profitable for other writers as well)