### PR TITLE
[medVtkViewItkDataImageInteractor] fixes scroll bug in 4-window view

### DIFF
--- a/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src-plugins/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -701,9 +701,8 @@ void medVtkViewItkDataImageInteractor::updateSlicingParam()
 
     d->slicingParameter->blockSignals(true);
     d->slicingParameter->setRange(d->view2d->GetSliceMin(), d->view2d->GetSliceMax());
-    d->slicingParameter->blockSignals(false);
-
     d->slicingParameter->setValue(d->view2d->GetSlice());
+    d->slicingParameter->blockSignals(false);
 }
 
 void medVtkViewItkDataImageInteractor::enableWIndowLevel(bool enable)


### PR DESCRIPTION
see https://github.com/Inria-Asclepios/medInria-public/issues/192

The problem was caused by a loop in the slots being called.