### PR TITLE
[medAbstractSelectableTbx] separate switchs between medSelectorTlbx a…

### DIFF
--- a/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -35,9 +35,6 @@ public:
 
     void setSelectorToolBox(medSelectorToolBox *toolbox);
 
-    //! Called when scrolled in medSelectorToolBox
-    virtual void changeSelectedToolBoxEvent(){}
-
 public slots:
 
     void updateView(){}

--- a/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -35,12 +35,12 @@ public:
 
     void setSelectorToolBox(medSelectorToolBox *toolbox);
 
+    //! Called when scrolled in medSelectorToolBox
+    virtual void changeSelectedToolBoxEvent(){}
+
 public slots:
 
     void updateView(){}
-
-    //! Called when scrolled in medSelectorToolBox
-    virtual void changeSelectedToolBoxEvent(){}
 
 protected:
 

--- a/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -39,9 +39,12 @@ public slots:
 
     void updateView(){}
 
+    //! Called when scrolled in medSelectorToolBox
+    virtual void changeSelectedToolBoxEvent(){}
+
 protected:
 
-    //! Launched when scrolled in medSelectorToolBox
+    //! Called when toolbox is hidden (scroll in medSelectorToolBox, workspace changed, etc)
     virtual void showEvent(QShowEvent *event);
     virtual void hideEvent(QHideEvent *event);
 

--- a/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
@@ -105,7 +105,7 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
     {
         // Remove previous tlbx from current tlbx
         d->currentToolBox->hide();
-        d->currentToolBox->changeSelectedToolBoxEvent();
+        d->currentToolBox->clear();
 
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = NULL;

--- a/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
@@ -105,6 +105,8 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
     {
         // Remove previous tlbx from current tlbx
         d->currentToolBox->hide();
+        d->currentToolBox->changeSelectedToolBoxEvent();
+
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = NULL;
     }


### PR DESCRIPTION
…nd workspace

From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/195

I separated some events: 
* when we switch between workspaces or scroll between toolboxes: `medAbstractSelectableToolBox::showEvent` and `medAbstractSelectableToolBox::showEvent` are called to remove or add the connection between containers changes and `updateView`, as before.

* when we scroll between toolboxes: `medAbstractSelectableToolBox::changeSelectedToolBoxEvent()` is called, or if it exists, its implementation in specific toolboxes. These functions are used to remove data or interactors or disable buttons. That was defined previously in `hideEvent` functions, but we don't want to call it when we switch between workspaces.

:m: