### PR TITLE
[manualReg+Crop+Reslice] switch to changeSelectedToolBoxEvent

### DIFF
--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -395,7 +395,7 @@ void manualRegistrationToolBox::reset()
     setDisableComputeResetButtons(true);
 }
 
-void manualRegistrationToolBox::changeSelectedToolBoxEvent()
+void manualRegistrationToolBox::clear()
 {
     if (d->regOn)
     {

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -395,10 +395,8 @@ void manualRegistrationToolBox::reset()
     setDisableComputeResetButtons(true);
 }
 
-void manualRegistrationToolBox::hideEvent(QHideEvent *event)
+void manualRegistrationToolBox::changeSelectedToolBoxEvent()
 {
-    medAbstractSelectableToolBox::hideEvent(event);
-
     if (d->regOn)
     {
         d->b_startManualRegistration->click();

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -47,7 +47,7 @@ public slots:
     void reset();
 
 protected:
-    void hideEvent(QHideEvent *event);
+    void changeSelectedToolBoxEvent();
 
 private:
     void displayButtons(bool);

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -47,7 +47,7 @@ public slots:
     void reset();
 
 protected:
-    void changeSelectedToolBoxEvent();
+    virtual void clear();
 
 private:
     void displayButtons(bool);

--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -224,12 +224,10 @@ void medCropToolBox::showEvent(QShowEvent *event)
 {
     medAbstractSelectableToolBox::showEvent(event);
     setEnable(true);
-
 }
 
-void medCropToolBox::hideEvent(QHideEvent *event)
+void medCropToolBox::changeSelectedToolBoxEvent()
 {
-    medAbstractSelectableToolBox::hideEvent(event);
     setEnable(false);
 
     // allow to split container in other toolboxes

--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -226,7 +226,7 @@ void medCropToolBox::showEvent(QShowEvent *event)
     setEnable(true);
 }
 
-void medCropToolBox::changeSelectedToolBoxEvent()
+void medCropToolBox::clear()
 {
     setEnable(false);
 

--- a/src-plugins/reformat/medCropToolBox.h
+++ b/src-plugins/reformat/medCropToolBox.h
@@ -35,7 +35,7 @@ public slots:
 
 protected:
     void showEvent(QShowEvent *event);
-    void changeSelectedToolBoxEvent();
+    virtual void clear();
 
 private:
     medCropToolBoxPrivate* const d;

--- a/src-plugins/reformat/medCropToolBox.h
+++ b/src-plugins/reformat/medCropToolBox.h
@@ -35,7 +35,7 @@ public slots:
 
 protected:
     void showEvent(QShowEvent *event);
-    void hideEvent(QHideEvent *event);
+    void changeSelectedToolBoxEvent();
 
 private:
     medCropToolBoxPrivate* const d;

--- a/src-plugins/reformat/resliceToolBox.cpp
+++ b/src-plugins/reformat/resliceToolBox.cpp
@@ -205,7 +205,7 @@ void resliceToolBox::stopReformat()
     }
 }
 
-void resliceToolBox::changeSelectedToolBoxEvent()
+void resliceToolBox::clear()
 {
     stopReformat();
 }

--- a/src-plugins/reformat/resliceToolBox.cpp
+++ b/src-plugins/reformat/resliceToolBox.cpp
@@ -205,9 +205,8 @@ void resliceToolBox::stopReformat()
     }
 }
 
-void resliceToolBox::hideEvent(QHideEvent *event)
+void resliceToolBox::changeSelectedToolBoxEvent()
 {
-    medAbstractSelectableToolBox::hideEvent(event);
     stopReformat();
 }
 

--- a/src-plugins/reformat/resliceToolBox.h
+++ b/src-plugins/reformat/resliceToolBox.h
@@ -33,5 +33,5 @@ public slots:
     void switchSpacingAndDimension(const QString &value);
 
 protected:
-    void changeSelectedToolBoxEvent();
+    virtual void clear();
 };

--- a/src-plugins/reformat/resliceToolBox.h
+++ b/src-plugins/reformat/resliceToolBox.h
@@ -33,5 +33,5 @@ public slots:
     void switchSpacingAndDimension(const QString &value);
 
 protected:
-    void hideEvent(QHideEvent *event);
+    void changeSelectedToolBoxEvent();
 };

--- a/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -35,9 +35,6 @@ public:
 
     void setSelectorToolBox(medSelectorToolBox *toolbox);
 
-    //! Called when scrolled in medSelectorToolBox
-    virtual void changeSelectedToolBoxEvent(){}
-
 public slots:
 
     void updateView(){}

--- a/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -35,12 +35,12 @@ public:
 
     void setSelectorToolBox(medSelectorToolBox *toolbox);
 
+    //! Called when scrolled in medSelectorToolBox
+    virtual void changeSelectedToolBoxEvent(){}
+
 public slots:
 
     void updateView(){}
-
-    //! Called when scrolled in medSelectorToolBox
-    virtual void changeSelectedToolBoxEvent(){}
 
 protected:
 

--- a/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/medCore/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -39,9 +39,12 @@ public slots:
 
     void updateView(){}
 
+    //! Called when scrolled in medSelectorToolBox
+    virtual void changeSelectedToolBoxEvent(){}
+
 protected:
 
-    //! Launched when scrolled in medSelectorToolBox
+    //! Called when toolbox is hidden (scroll in medSelectorToolBox, workspace changed, etc)
     virtual void showEvent(QShowEvent *event);
     virtual void hideEvent(QHideEvent *event);
 

--- a/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
@@ -105,7 +105,7 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
     {
         // Remove previous tlbx from current tlbx
         d->currentToolBox->hide();
-        d->currentToolBox->changeSelectedToolBoxEvent();
+        d->currentToolBox->clear();
 
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = NULL;

--- a/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
@@ -105,6 +105,8 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
     {
         // Remove previous tlbx from current tlbx
         d->currentToolBox->hide();
+        d->currentToolBox->changeSelectedToolBoxEvent();
+
         d->mainLayout->removeWidget(d->currentToolBox);
         d->currentToolBox = NULL;
     }


### PR DESCRIPTION
Following https://github.com/Inria-Asclepios/medInria-public/pull/201

Adapt manual registration, cropping and reslice to the switch between toolboxes.

(will be rebased)

:m: 