### PR TITLE
[logs] truncate heavy log file

### DIFF
--- a/app/medInria/medLogger.cpp
+++ b/app/medInria/medLogger.cpp
@@ -136,7 +136,6 @@ void medLogger::createTeeStream(std::ostream* targetStream)
 
 void medLogger::truncateLogFileIfHeavy()
 {
-    // Test the size of the log file and cut if needed
     qint64 filesize = QFileInfo(dtkLogPath(qApp)).size();
 
     // Over 5Mo, the file is truncated from the beginning (old lines are discarded)
@@ -149,7 +148,7 @@ void medLogger::truncateLogFileIfHeavy()
         std::ofstream temp;
         temp.open(path.toUtf8()+"tmp");
 
-        fin.seekg(4000000); // file is going to lose 4Mo
+        fin.seekg(filesize-1000000); // file is going to be cut to 1Mo
 
         std::string line;
         while (getline(fin,line))

--- a/app/medInria/medLogger.cpp
+++ b/app/medInria/medLogger.cpp
@@ -17,8 +17,8 @@ public:
     QList<TeeStream*> teeStreams;
     QList<std::streambuf*> previousStreamBuffers;
 
-    static const double maxLogSize = 5000000;
-    static const double minLogSize = 1000000;
+    static const qint64 maxLogSize = 5000000;
+    static const qint64 minLogSize = 1000000;
 
     medLoggerPrivate() : logFile(dtkLogPath(qApp).toLocal8Bit().data(), std::ios::app) {}
 };
@@ -148,7 +148,7 @@ void medLogger::truncateLogFileIfHeavy()
 
         std::ifstream fin;
         fin.open(path.toUtf8());
-        fin.seekg(filesize-d->minLogSize); // file is going to be cut to 1Mo
+        fin.seekg(filesize - d->minLogSize); // file is going to be cut to minLogSize size
 
         std::string keptText;
         std::string line;

--- a/app/medInria/medLogger.h
+++ b/app/medInria/medLogger.h
@@ -61,4 +61,6 @@ private:
     void finalizeTeeStreams();
 
     void createTeeStream(std::ostream* targetStream);
+
+    void truncateLogFileIfHeavy();
 };

--- a/app/medInria/medLogger.h
+++ b/app/medInria/medLogger.h
@@ -62,5 +62,7 @@ private:
 
     void createTeeStream(std::ostream* targetStream);
 
+    /** Test the size of the log file and cut if needed
+     */
     void truncateLogFileIfHeavy();
 };


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/166
Will be rebased with https://github.com/Inria-Asclepios/medInria-public/pull/178

Add a `medLogger::truncateLogFileIfHeavy()` function in `medLogger::medLogger()` which allow to check the size of the log file at launching of the app, and truncate it if needed (old lines are discarded).

:m: