### PR TITLE
[manualRegistration] delete landmark behavior solved

### DIFF
--- a/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
@@ -66,7 +66,7 @@ public:
             if (Roi->GetHandleWidget() && Roi->GetHandleWidget()->GetInteractor())
             {
                 std::string keycode = Roi->GetHandleWidget()->GetInteractor()->GetKeySym();
-                if (keycode == "Delete")
+                if (keycode == "BackSpace")
                 {
                     Roi->InvokeEvent(vtkCommand::DeleteEvent);
                 }

--- a/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmark.cpp
@@ -61,17 +61,21 @@ public:
             Roi->SetIndices(ind);
             Roi->ShowOrHide();
 
-            
+            // Remove chosen landmark and related one on other view,
+            // cf. manualRegistrationLandmarkControllerCommand::Execute
             if (Roi->GetHandleWidget() && Roi->GetHandleWidget()->GetInteractor())
-                if (Roi->GetHandleWidget()->GetInteractor()->GetControlKey())
+            {
+                std::string keycode = Roi->GetHandleWidget()->GetInteractor()->GetKeySym();
+                if (keycode == "Delete")
                 {
                     Roi->InvokeEvent(vtkCommand::DeleteEvent);
-                    return;
                 }
+            }
         }
-        
-        if(event == vtkImageView2D::SliceChangedEvent)
+        else if(event == vtkImageView2D::SliceChangedEvent)
+        {
             Roi->ShowOrHide();
+        }
     }
 
     void setRoi(manualRegistrationLandmark *Roi)

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -121,11 +121,12 @@ void manualRegistrationLandmarkControllerCommand::Execute ( vtkObject *caller, u
             this->Controller->AddPoint(landmark,1);
         }
     }
-
-    if (event == vtkCommand::DeleteEvent)
+    else if (event == vtkCommand::DeleteEvent)
     {
         manualRegistrationLandmark* landmark = manualRegistrationLandmark::SafeDownCast (caller);
         this->Controller->RequestDeletion(landmark);
+        this->Controller->GetViewFixed()->viewWidget()->update();
+        this->Controller->GetViewMoving()->viewWidget()->update();
     }
 }
 

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -64,7 +64,7 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medAbstr
     connect(d->b_startManualRegistration,SIGNAL(clicked()),this,SLOT(startManualRegistration()));
     d->b_startManualRegistration->setObjectName("startManualRegistrationButton");
 
-    QLabel* explanation = new QLabel("To add a landmark: \n\tShift + left mouse button\n", widget);
+    QLabel* explanation = new QLabel("To add a landmark: \tShift + left mouse button\nTo remove a landmark duo: \tDelete + left mouse button", widget);
 
     d->numberOfLdInLeftContainer = new QLabel("Number of landmarks in left container: 0",widget);
     d->numberOfLdInRightContainer = new QLabel("Number of landmarks in right container: 0",widget);

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -64,7 +64,7 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medAbstr
     connect(d->b_startManualRegistration,SIGNAL(clicked()),this,SLOT(startManualRegistration()));
     d->b_startManualRegistration->setObjectName("startManualRegistrationButton");
 
-    QLabel* explanation = new QLabel("To add a landmark: \tShift + left mouse button\nTo remove a landmark duo: \tDelete + left mouse button", widget);
+    QLabel* explanation = new QLabel("To add a landmark: \n\tShift + left mouse button\nTo remove a landmark duo: \n\tBackspace + left mouse button", widget);
 
     d->numberOfLdInLeftContainer = new QLabel("Number of landmarks in left container: 0",widget);
     d->numberOfLdInRightContainer = new QLabel("Number of landmarks in right container: 0",widget);

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -64,7 +64,7 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medAbstr
     connect(d->b_startManualRegistration,SIGNAL(clicked()),this,SLOT(startManualRegistration()));
     d->b_startManualRegistration->setObjectName("startManualRegistrationButton");
 
-    QLabel* explanation = new QLabel("To add a landmark: \n\tShift + left mouse button\nTo remove a landmark duo: \n\tBackspace + left mouse button", widget);
+    QLabel* explanation = new QLabel("To add a landmark: \n\tShift + left mouse button\nTo remove a pair of landmarks: \n\tBackspace + left mouse button", widget);
 
     d->numberOfLdInLeftContainer = new QLabel("Number of landmarks in left container: 0",widget);
     d->numberOfLdInRightContainer = new QLabel("Number of landmarks in right container: 0",widget);


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/150

CTRL is already used to select view in medInria/MUSIC, we can't use it for something else, as the deletion of landmarks in manual registration.

I switched the landmark removal to the "BackSpace" button, updated both views afterwards, and added and explaination for users.

:m: