### PR TITLE
[Switch] medToolBox clear is ... cleared

### DIFF
--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -24,6 +24,7 @@
 #include <medTabbedViewContainers.h>
 #include <medAbstractView.h>
 #include <medAbstractLayeredView.h>
+#include <medToolBoxBody.h>
 #include <medToolBoxHeader.h>
 #include <medAbstractInteractor.h>
 #include <medMetaDataKeys.h>
@@ -202,7 +203,9 @@ bool medAbstractWorkspace::areToolBoxesVisible() const
 void medAbstractWorkspace::clearWorkspaceToolBoxes()
 {
     foreach(medToolBox* tb,d->toolBoxes)
-        tb->clear();
+    {
+        tb->body()->clear();
+    }
 }
 
 void medAbstractWorkspace::addNewTab()
@@ -213,7 +216,7 @@ void medAbstractWorkspace::addNewTab()
 
 void medAbstractWorkspace::updateNavigatorsToolBox()
 {
-    d->navigatorToolBox->clear();
+    d->navigatorToolBox->body()->clear();
 
     medAbstractView* view = NULL;
     QList<QWidget*>  navigators;
@@ -257,7 +260,7 @@ void medAbstractWorkspace::updateNavigatorsToolBox()
 
 void medAbstractWorkspace::updateMouseInteractionToolBox()
 {
-    d->mouseInteractionToolBox->clear();
+    d->mouseInteractionToolBox->body()->clear();
 
     QList<QWidget*>  navigators;
     QStringList viewType;
@@ -287,7 +290,7 @@ void medAbstractWorkspace::updateMouseInteractionToolBox()
 
 void medAbstractWorkspace::updateLayersToolBox()
 {
-    d->layerListToolBox->clear();
+    d->layerListToolBox->body()->clear();
     d->containerForLayerWidgetsItem.clear();
     d->selectedLayers.clear();
     d->poolIndicators.clear();
@@ -437,7 +440,7 @@ void medAbstractWorkspace::updateInteractorsToolBox()
         containerMng->container(uuid)->highlight();
     }
     d->interactorToolBox->hide();
-    d->interactorToolBox->clear();
+    d->interactorToolBox->body()->clear();
 
     if(!d->layerListWidget)
         return;

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -134,18 +134,6 @@ medToolBoxBody *medToolBox::body(void) const
 }
 
 /**
- * @brief Clears the toolbox.
- *
- * Resets the parameters within the tolbox,
- * for instance when the current patient changed or the view.
- *
-*/
-void medToolBox::clear(void)
-{
-    d->body->clear();
-}
-
-/**
  * @brief Switches from a minimized state to an extended one and vice versa.
  *
 */

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -102,7 +102,7 @@ signals:
     void failure();
 
 public slots:
-    virtual void clear();
+    virtual void clear(){}
     void switchMinimize();
     void setValidDataTypes(const QStringList & dataTypes);
     const QStringList ValidDataTypes();


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/212

`medToolBox::clear()` only called `medToolBoxBody::clear()`. This function is used in `medAbstractWorkspace.cpp` only. So, in this file, now, we directly call `medToolBoxBody::clear()`. `medToolBox::clear()` becomes empty (and was already virtual). In this way, `medToolBox::clear()` is called by toolboxes which don't need to do a dedicated clear function. So, we do not need to change anything in toolboxes.

:m: