### PR TITLE
[diffeoDemon] solve physical space failure

### DIFF
--- a/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemons.cpp
+++ b/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemons.cpp
@@ -108,16 +108,6 @@ int itkProcessRegistrationDiffeomorphicDemonsPrivate::update()
     //unfortunately diffeomorphic demons only work with double or float types...
     // so we need to use a cast filter.
     typedef itk::Image< float, 3 > RegImageType;
-    typedef itk::CastImageFilter< FixedImageType, RegImageType > FixedCastFilterType;
-    typedef itk::CastImageFilter< MovingImageType, RegImageType > MovingCastFilterType;
-    typename FixedCastFilterType::Pointer fixedCastFilter = FixedCastFilterType::New();
-    fixedCastFilter->SetInput((FixedImageType*)proc->fixedImage().GetPointer());
-    fixedCastFilter->Update();
-    typename MovingCastFilterType::Pointer movingCastFilter = MovingCastFilterType::New();
-    movingCastFilter->SetInput((MovingImageType*)proc->movingImages()[0].GetPointer());
-    movingCastFilter->Update();
-
-
     typedef double TransformScalarType;
     typedef rpi::DiffeomorphicDemons< RegImageType, RegImageType,
                     TransformScalarType > RegistrationType;
@@ -125,8 +115,8 @@ int itkProcessRegistrationDiffeomorphicDemonsPrivate::update()
 
     registrationMethod = registration;
 
-    registration->SetFixedImage(fixedCastFilter->GetOutput());
-    registration->SetMovingImage(movingCastFilter->GetOutput());
+    registration->SetFixedImage((FixedImageType*)proc->fixedImage().GetPointer());
+    registration->SetMovingImage((MovingImageType*)proc->movingImages()[0].GetPointer());
 
     registration->SetNumberOfIterations(iterations);
     registration->SetMaximumUpdateStepLength(maximumUpdateStepLength);

--- a/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
@@ -14,23 +14,14 @@
 #include <itkProcessRegistrationDiffeomorphicDemons.h>
 #include <itkProcessRegistrationDiffeomorphicDemonsToolBox.h>
 
-#include <medAbstractDataFactory.h>
-#include <medAbstractData.h>
-#include <medAbstractImageData.h>
 #include <dtkCore/dtkAbstractProcessFactory.h>
-#include <dtkCore/dtkAbstractProcess.h>
-#include <dtkCore/dtkAbstractViewFactory.h>
 #include <dtkCore/dtkSmartPointer.h>
-
-#include <medAbstractView.h>
-#include <medRunnableProcess.h>
 #include <medJobManager.h>
 #include <medPluginManager.h>
-
-#include <medToolBoxFactory.h>
-#include <medRegistrationSelectorToolBox.h>
 #include <medProgressionStack.h>
-
+#include <medRegistrationSelectorToolBox.h>
+#include <medRunnableProcess.h>
+#include <medToolBoxFactory.h>
 #include <rpiCommonTools.hxx>
 
 class itkProcessRegistrationDiffeomorphicDemonsToolBoxPrivate
@@ -52,16 +43,20 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
 {
     QWidget *widget = new QWidget(this);
 
-    QPushButton *runButton = new QPushButton(tr("Run"), this);
-    runButton->setToolTip(tr("Start Registration"));
+    QVBoxLayout* layout = new QVBoxLayout();
 
-    QFormLayout *layout = new QFormLayout(widget);
+    QLabel* explanation = new QLabel("Drop 2 datasets with same size, origin and spacing.\n");
+    explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    explanation->setWordWrap(true);
+    layout->addWidget(explanation);
 
-    d->iterationsBox = new QLineEdit(this);
+    QFormLayout* formLayout = new QFormLayout();
+
+    d->iterationsBox = new QLineEdit();
     d->iterationsBox->setText("15x10x5");
     d->iterationsBox->setToolTip(tr("Each number of iteration per level must be separated by \"x\". From coarser to finest levels"));
 
-    d->maxStepLengthBox = new QDoubleSpinBox(this);
+    d->maxStepLengthBox = new QDoubleSpinBox();
     d->maxStepLengthBox->setMinimum(0);
     d->maxStepLengthBox->setMaximum(1000);
     d->maxStepLengthBox->setSingleStep(0.01);
@@ -71,7 +66,7 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
                 " Setting it to 0 implies no restrictions will be made"
                 " on the step length."));
 
-    d->updateFieldStdDevBox = new QDoubleSpinBox(this);
+    d->updateFieldStdDevBox = new QDoubleSpinBox();
     d->updateFieldStdDevBox->setMinimum(0);
     d->updateFieldStdDevBox->setMaximum(1000);
     d->updateFieldStdDevBox->setSingleStep(0.01);
@@ -81,7 +76,7 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
                 "of the update field (voxel units). Setting it below 0.1"
                 "means no smoothing will be performed (default 0.0)."));
 
-    d->disFieldStdDevBox = new QDoubleSpinBox(this);
+    d->disFieldStdDevBox = new QDoubleSpinBox();
     d->disFieldStdDevBox->setMinimum(0);
     d->disFieldStdDevBox->setMaximum(1000);
     d->disFieldStdDevBox->setSingleStep(0.01);
@@ -90,7 +85,7 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
                 "Standard deviation of the Gaussian smoothing of "
                 "the displacement field (voxel units). Setting it below 0.1 "
                 "means no smoothing will be performed (default 1.5)."));
-    d->updateRuleBox = new medComboBox(this);
+    d->updateRuleBox = new medComboBox();
     QStringList updateRules;
     updateRules<< tr("Diffeomorphic") << tr ("Additive") << tr("Compositive");
     d->updateRuleBox->addItems(updateRules);
@@ -99,7 +94,7 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
     d->updateRuleBox->setItemData(1,"s <- s + u",Qt::ToolTipRole);
     d->updateRuleBox->setItemData(2,"s <- s o (Id+u)",Qt::ToolTipRole);
 
-    d->gradientTypeBox = new medComboBox(this);
+    d->gradientTypeBox = new medComboBox();
     d->gradientTypeBox->setToolTip(tr(
                 "Type of gradient used for computing the demons force."));
     QStringList gradientTypes;
@@ -107,29 +102,33 @@ itkProcessRegistrationDiffeomorphicDemonsToolBox::itkProcessRegistrationDiffeomo
                  << tr("Warped Moving Image")
                  << tr("Mapped Moving Image");
     d->gradientTypeBox->addItems(gradientTypes);
-    d->useHistogramBox =  new QCheckBox(this);
+    d->useHistogramBox =  new QCheckBox();
     d->useHistogramBox->setChecked(false);
     d->useHistogramBox->setToolTip(tr(
                 "Use histogram matching before processing?"));
 
-    layout->addRow(new QLabel(tr("Iterations per level of res."),this),d->iterationsBox);
-    layout->addRow(new QLabel(tr("Update Rule"),this),d->updateRuleBox);
-    layout->addRow(new QLabel(tr("Gradient Type"),this),d->gradientTypeBox);
-    layout->addRow(new QLabel(tr("Max. Update Step Length"),this),d->maxStepLengthBox);
-    layout->addRow(new QLabel(tr("Update Field Std. Deviation"),this),
+    formLayout->addRow(new QLabel(tr("Iterations per level of res."),this),d->iterationsBox);
+    formLayout->addRow(new QLabel(tr("Update Rule"),this),d->updateRuleBox);
+    formLayout->addRow(new QLabel(tr("Gradient Type"),this),d->gradientTypeBox);
+    formLayout->addRow(new QLabel(tr("Max. Update Step Length"),this),d->maxStepLengthBox);
+    formLayout->addRow(new QLabel(tr("Update Field Std. Deviation"),this),
                    d->updateFieldStdDevBox);
-    layout->addRow(new QLabel(tr("Displ. Field Std. Deviation"),this),
+    formLayout->addRow(new QLabel(tr("Displ. Field Std. Deviation"),this),
                    d->disFieldStdDevBox);
-    layout->addRow(new QLabel(tr("Histogram Matching"),this),d->useHistogramBox);
+    formLayout->addRow(new QLabel(tr("Histogram Matching"),this),d->useHistogramBox);
+    layout->addLayout(formLayout);
+
+    // Run button
+    QPushButton *runButton = new QPushButton(tr("Run"));
+    runButton->setToolTip(tr("Start Registration"));
+    layout->addWidget(runButton);
 
     // progression stack
     d->progressionStack = new medProgressionStack(widget);
-//    QHBoxLayout *progressStackLayout = new QHBoxLayout;
-//    progressStackLayout->addWidget(d->progressionStack);
+    layout->addWidget(d->progressionStack);
 
+    widget->setLayout(layout);
     this->addWidget(widget);
-    this->addWidget(runButton);
-    this->addWidget(d->progressionStack);
 
     //enable about plugin. Constructor called after the plugin has been registered, go ahead call it.
     medPluginManager* pm = medPluginManager::instance();

--- a/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
@@ -222,6 +222,7 @@ void itkProcessRegistrationDiffeomorphicDemonsToolBox::run()
     connect (runProcess, SIGNAL (success  (QObject*)),  this, SIGNAL (success ()));
     connect (runProcess, SIGNAL (failure  (QObject*)),  this, SIGNAL (failure ()));
     connect (runProcess, SIGNAL (cancelled (QObject*)), this, SIGNAL (failure ()));
+    connect (runProcess, SIGNAL (failure  (int)),       this, SLOT   (handleDisplayError(int)));
     //First have the moving progress bar,
     //and then display the remaining % when known
     connect (runProcess, SIGNAL(activate(QObject*,bool)),

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -297,28 +297,33 @@ void medToolBox::toXMLNode(QDomDocument* doc, QDomElement* currentNode)
 
 void medToolBox::handleDisplayError(int error)
 {
+    // Handle volume(s)/mesh(es) error
+
     switch (error)
     {
-    case medAbstractProcess::PIXEL_TYPE:   //! Handle volume errors: pixel type
+    case medAbstractProcess::PIXEL_TYPE:
         displayMessageError("Pixel type not yet implemented");
         break;
-    case medAbstractProcess::DIMENSION_3D: //! Handle volume errors: dimension
+    case medAbstractProcess::DIMENSION_3D:
         displayMessageError("This toolbox is designed to be used with 3D volumes");
         break;
-    case medAbstractProcess::DIMENSION_4D: //! Handle volume errors: dimension
+    case medAbstractProcess::DIMENSION_4D:
         displayMessageError("This toolbox is designed to be used with 4D volumes");
         break;
-    case medAbstractProcess::MESH_TYPE:    //! Handle mesh errors: data type
+    case medAbstractProcess::MESH_TYPE:
         displayMessageError("This toolbox is designed to be used with meshes");
         break;
-    case medAbstractProcess::NO_MESH:    //! Handle mesh errors: data type
+    case medAbstractProcess::NO_MESH:
         displayMessageError("This toolbox is not designed to be used with meshes");
         break;
-    case medAbstractProcess::DATA_SIZE:    //! Handle volume errors: size
+    case medAbstractProcess::DATA_SIZE:
         displayMessageError("Inputs must be the same size");
         break;
     case medAbstractProcess::MISMATCHED_DATA_TYPES:
         displayMessageError("Inputs must be the same type");
+        break;
+    case medAbstractProcess::MISMATCHED_DATA_SIZES_ORIGIN_SPACING:
+        displayMessageError("Inputs must be the same size, origin, spacing");
         break;
     default:
         displayMessageError("This action failed (undefined error)");

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -36,13 +36,17 @@ public:
 
     enum DataError
     {
-        PIXEL_TYPE = 2, //! Pixel type not yet implemented
+        SUCCESS = DTK_SUCCEED,
+        FAILURE = DTK_FAILURE,
+
+        PIXEL_TYPE = 1 + SUCCESS * SUCCESS + FAILURE * FAILURE, //! Pixel type not yet implemented
         DIMENSION_3D,   //! Not a 3D volume
         DIMENSION_4D,   //! Not a 4D volume
         MESH_TYPE,      //! Not a mesh
         NO_MESH,        //! Input can not be a mesh
         DATA_SIZE,      //! Inputs must be the same size
         MISMATCHED_DATA_TYPES, //! Inputs must be the same type
+        MISMATCHED_DATA_SIZES_ORIGIN_SPACING, //! Inputs should have the same sizes, origins, spacings
         UNDEFINED,      //! Miscellanous
     };
 


### PR DESCRIPTION
Following this old issue: https://github.com/Inria-Asclepios/medInria-public/issues/60

This toolbox wasn't working because: 
 * the cast filter wasn't done in case of datasets not in `double` or `float`,
 * we needed to resample datasets to have the same spacing, etc, before the registration method.

:m: