### PR TITLE
[Paint] remove a crash in pip if Next on undone step

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -450,7 +450,7 @@ AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
 medAbstractData* AlgorithmPaintToolBox::processOutput()
 {
     // Check if painted data on the volume
-    if (!m_undoStacks->value(currentView)->isEmpty())
+    if (!m_undoStacks->empty() && !m_undoStacks->value(currentView)->isEmpty())
     {
         copyMetaDataToPaintedData();
         return m_maskData; // return output data


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/music/issues/343
Following this PR https://github.com/Inria-Asclepios/music/pull/450

Solves crash in pipelines if users click on Next on an undone Paint step.

:m: