### PR TITLE
[statsROI-metabaseView] comparison between unsigned int and int

### DIFF
--- a/src/medCore/gui/database/medDatabaseView.cpp
+++ b/src/medCore/gui/database/medDatabaseView.cpp
@@ -310,16 +310,16 @@ void medDatabaseView::onExportSelectedItemRequested(void)
 
         else if(item->dataIndex().isValidForStudy())
         {
-            for (unsigned int i = 0; i<item->childCount(); i++)
+            for (int i = 0; i<item->childCount(); i++)
                 emit exportData(item->child(i)->dataIndex());
         }
 
         if(item->dataIndex().isValidForPatient())
         {
-            for (unsigned int i = 0; i<item->childCount(); i++)
+            for (int i = 0; i<item->childCount(); i++)
             {
                 medAbstractDatabaseItem *study = item->child(i);
-                for (unsigned int j = 0; j<study->childCount(); j++)
+                for (int j = 0; j<study->childCount(); j++)
                 {
                     emit exportData(study->child(j)->dataIndex());
                 }

--- a/src/medUtilities/statsROI.cpp
+++ b/src/medUtilities/statsROI.cpp
@@ -165,11 +165,11 @@ public:
         typename ImageType::SizeType size = m_itkMask->GetLargestPossibleRegion().GetSize();
         typename ImageType::IndexType px;
         int nbPixInMask = 0;
-        for (int sl=0 ; sl<size[2] ; sl++)
+        for (unsigned int sl=0 ; sl<size[2] ; sl++)
         {
-            for (int y=0 ; y<size[1] ; y++)
+            for (unsigned int y=0 ; y<size[1] ; y++)
             {
-                for (int x=0 ; x<size[0] ; x++)
+                for (unsigned int x=0 ; x<size[0] ; x++)
                 {
                     px[0] = x;
                     px[1] = y;


### PR DESCRIPTION
A small Pull Request to remove some warning in medInria-public concerning comparison between `unsigned int` and `int` values.

:m: