### PR TITLE
[DB] rm datasets remove ref.png

### DIFF
--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -716,7 +716,7 @@ QString medDatabaseController::metaData(const medDataIndex& index,const QString&
     }
 
     if ( ret.isNull() ){
-        dtkDebug() << "medDatabaseControllerImpl : Failed to get metadata " << key << " for index " << index.asString();
+        dtkDebug() << "medDatabaseControllerImpl: Failed to get metadata " << key << " for index " << index.asString();
     }
 
     if ( !ret.isEmpty() && isPath )

--- a/src/medCore/database/medDatabaseRemover.cpp
+++ b/src/medCore/database/medDatabaseRemover.cpp
@@ -345,7 +345,8 @@ void medDatabaseRemover::removeThumbnailIfNeeded(QSqlQuery query)
     QString thumbnail = query.value(0).toString();
 
     medAbstractDbController * dbc = medDataManager::instance()->controllerForDataSource(d->index.dataSourceId());
-    if (thumbnail == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
+
+    if ((medStorage::dataLocation()+thumbnail) == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
     {
         this->removeFile ( thumbnail );
     }

--- a/src/medCore/database/medDatabaseRemover.cpp
+++ b/src/medCore/database/medDatabaseRemover.cpp
@@ -346,7 +346,7 @@ void medDatabaseRemover::removeThumbnailIfNeeded(QSqlQuery query)
 
     medAbstractDbController * dbc = medDataManager::instance()->controllerForDataSource(d->index.dataSourceId());
 
-    if ((medStorage::dataLocation()+thumbnail) == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
+    if ((medStorage::dataLocation() + thumbnail) == dbc->metaData(d->index,  medMetaDataKeys::ThumbnailPath.key()))
     {
         this->removeFile ( thumbnail );
     }


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/222

In the database directory, with this PR, ref.png files are realy removed when their dataset is removed.

:m: