### PR TITLE
[DB] remove old study after moving its series does not rm thumb

### DIFF
--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -663,10 +663,9 @@ medDataIndex medDatabaseController::moveSerie( const medDataIndex& indexSerie, c
             newIndex.setStudyId(toStudy.studyId());
         }
     }
-    
-    emit metadataModified(indexSerie, medMetaDataKeys::PatientID.key(), QString::number(toStudy.patientId()));
-    emit metadataModified(indexSerie, medMetaDataKeys::StudyID.key(), QString::number(toStudy.studyId()));
-    emit metadataModified(newIndex);
+
+    emit metadataModified(indexSerie); // to signal the serie has been removed
+    emit metadataModified(newIndex);   // to signal the serie has been added
 
     return newIndex;
 }
@@ -816,7 +815,7 @@ QList<medDataIndex> medDatabaseController::studies( const medDataIndex& index ) 
     return ret;
 }
 
-/** Enumerate all series for given patient*/
+/** Enumerate all series for given study*/
 QList<medDataIndex> medDatabaseController::series( const medDataIndex& index) const
 {
     QList<medDataIndex> ret;
@@ -840,7 +839,7 @@ QList<medDataIndex> medDatabaseController::series( const medDataIndex& index) co
     return ret;
 }
 
-/** Enumerate all images for given patient*/
+/** Enumerate all images for given serie*/
 QList<medDataIndex> medDatabaseController::images( const medDataIndex& index) const
 {
     QList<medDataIndex> ret;

--- a/src/medCore/database/medDatabaseImporter.cpp
+++ b/src/medCore/database/medDatabaseImporter.cpp
@@ -221,18 +221,12 @@ int medDatabaseImporter::getOrCreatePatient ( const medAbstractData* medData, QS
     }
     else
     {
-        QString refThumbPath   = medMetaDataKeys::ThumbnailPath.getFirstValue(medData);
         QString birthdate      = medMetaDataKeys::BirthDate.getFirstValue(medData);
         QString gender         = medMetaDataKeys::Gender.getFirstValue(medData);
 
         query.prepare ( "INSERT INTO patient (name, thumbnail, birthdate, gender, patientId) VALUES (:name, :thumbnail, :birthdate, :gender, :patientId)" );
         query.bindValue ( ":name", patientName );
-
-        // actually, in the database preview, thumbnails are retrieved from the series and not from this field
-        // when this field is set, it can causes problems when moving studies or series and deleting a patient
-        //query.bindValue ( ":thumbnail", refThumbPath );
         query.bindValue ( ":thumbnail", QString("") );
-
         query.bindValue ( ":birthdate", birthdate );
         query.bindValue ( ":gender",    gender );
         query.bindValue ( ":patientId", patientId);


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/231

Moving and/or deleting a serie/study/patient handle ref.png, its directory, and the patient directory if needed.

After each `removeThumbnailIfNeeded` we check if the ref directory is empty, or the patient one.

[A so much clean database...](https://images.duckduckgo.com/iu/?u=http%3A%2F%2Fwww.factinate.com%2Fwp-content%2Fuploads%2F2017%2F01%2FFantasia-Broom.gif&f=1)  :)

:m: