### PR TITLE
[medViewContainer] scene, allow to keep patient info

### DIFF
--- a/src/medCore/gui/viewContainers/medViewContainer.cpp
+++ b/src/medCore/gui/viewContainers/medViewContainer.cpp
@@ -896,7 +896,7 @@ QString medViewContainer::saveScene()
             layeredViewInfo.setAttribute("id",layeredView->identifier());
             root.appendChild(layeredViewInfo);
 
-            // Patient informations
+            // Patient informations added in the xml file
             QDomElement patientInfo = doc.createElement("patient");
 
             medAbstractData* dataset = layeredView->layerData(0);
@@ -948,50 +948,6 @@ void medViewContainer::addMetadataToQDomElement(medAbstractData* data, QDomEleme
     {
         patientInfo.setAttribute(metadata, data->metadata(metadata));
     }
-}
-
-void medViewContainer::addMetadataToMedAbstractData(medAbstractData* data, QString value, QString metadata)
-{
-    if (value != "")
-    {
-        if (data->hasMetaData(metadata))
-        {
-            data->setMetaData(metadata, value);
-        }
-        else
-        {
-            data->addMetaData(metadata, value);
-        }
-    }
-}
-
-bool medViewContainer::isRemoveAndAddMedAbstractDataNeeded(medAbstractData* data, QString patientName, QString studyDescription)
-{
-    if (data->hasMetaData(medMetaDataKeys::PatientName.key()))
-    {
-        if (patientName != data->metadata(medMetaDataKeys::PatientName.key()))
-        {
-            return true;
-        }
-    }
-    else
-    {
-        return true;
-    }
-
-    if (data->hasMetaData(medMetaDataKeys::StudyDescription.key()))
-    {
-        if (studyDescription != data->metadata(medMetaDataKeys::StudyDescription.key()))
-        {
-            return true;
-        }
-    }
-    else
-    {
-        return true;
-    }
-
-    return false;
 }
 
 void medViewContainer::loadScene()
@@ -1049,68 +1005,6 @@ void medViewContainer::loadScene()
                 {
                      displayMessageError("Failed to parse " + fileName);
                      return;
-                }
-            }
-
-            // Get back informations about the patient
-            QDomNodeList informationNodes = doc.elementsByTagName("patient");
-
-            QString patientName, patientID, birthDate, gender, studyDescription = "";
-
-            for(int i=0; i<informationNodes.size(); i++)
-            {
-                QDomElement infoElement = informationNodes.item(i).toElement();
-                if(infoElement.isNull())
-                {
-                    continue;
-                }
-
-                if (infoElement.hasAttribute(medMetaDataKeys::PatientName.key()))
-                {
-                    patientName      = infoElement.attribute(medMetaDataKeys::PatientName.key());
-                }
-                if (infoElement.hasAttribute(medMetaDataKeys::PatientID.key()))
-                {
-                    patientID        = infoElement.attribute(medMetaDataKeys::PatientID.key());
-                }
-                if (infoElement.hasAttribute(medMetaDataKeys::BirthDate.key()))
-                {
-                    birthDate        = infoElement.attribute(medMetaDataKeys::BirthDate.key());
-                }
-                if (infoElement.hasAttribute(medMetaDataKeys::Gender.key()))
-                {
-                    gender           = infoElement.attribute(medMetaDataKeys::Gender.key());
-                }
-                if (infoElement.hasAttribute(medMetaDataKeys::StudyDescription.key()))
-                {
-                    studyDescription = infoElement.attribute(medMetaDataKeys::StudyDescription.key());
-                }
-
-                if (!patientName.isEmpty() || !patientID.isEmpty() || !birthDate.isEmpty() || !gender.isEmpty() || !studyDescription.isEmpty() )
-                {
-                    medAbstractLayeredView* layeredView = dynamic_cast<medAbstractLayeredView*>(view());
-
-                    bool rmAddNeeded = isRemoveAndAddMedAbstractDataNeeded(layeredView->layerData(0), patientName, studyDescription);
-
-                    // Update data with informations from the xml file
-                    for(unsigned i=0; i<layeredView->layersCount(); i++)
-                    {
-                        if (rmAddNeeded)
-                        {
-                            medDataManager::instance()->removeData(layeredView->layerData(i)->dataIndex());
-                        }
-
-                        addMetadataToMedAbstractData(layeredView->layerData(i), patientName, medMetaDataKeys::PatientName.key());
-                        addMetadataToMedAbstractData(layeredView->layerData(i), patientID, medMetaDataKeys::PatientID.key());
-                        addMetadataToMedAbstractData(layeredView->layerData(i), birthDate, medMetaDataKeys::BirthDate.key());
-                        addMetadataToMedAbstractData(layeredView->layerData(i), gender, medMetaDataKeys::Gender.key());
-                        addMetadataToMedAbstractData(layeredView->layerData(i), studyDescription, medMetaDataKeys::StudyDescription.key());
-
-                        if (rmAddNeeded)
-                        {
-                            medDataManager::instance()->importData(layeredView->layerData(i));
-                        }
-                    }
                 }
             }
         }

--- a/src/medCore/gui/viewContainers/medViewContainer.cpp
+++ b/src/medCore/gui/viewContainers/medViewContainer.cpp
@@ -13,27 +13,20 @@
 
 #include <medViewContainer.h>
 
-#include <QVBoxLayout>
+
 #include <QHBoxLayout>
 #include <QPushButton>
 #include <QUuid>
-#include <QFileDialog>
+#include <QVBoxLayout>
 
 #include <medAbstractImageView.h>
-#include <medAbstractData.h>
 #include <medAbstractView.h>
-#include <medAbstractInteractor.h>
-#include <medAbstractLayeredView.h>
-#include <medBoolParameter.h>
 #include <medDataIndex.h>
 #include <medDataManager.h>
 #include <medLayoutChooser.h>
 #include <medMetaDataKeys.h>
 #include <medPoolIndicator.h>
 #include <medSettingsManager.h>
-#include <medStringListParameter.h>
-#include <medToolBox.h>
-#include <medToolBoxHeader.h>
 #include <medTriggerParameter.h>
 #include <medViewContainerManager.h>
 #include <medViewContainerSplitter.h>

--- a/src/medCore/gui/viewContainers/medViewContainer.cpp
+++ b/src/medCore/gui/viewContainers/medViewContainer.cpp
@@ -898,10 +898,23 @@ QString medViewContainer::saveScene()
 
             // Patient informations
             QDomElement patientInfo = doc.createElement("patient");
-            patientInfo.setAttribute("patientName", layeredView->layerData(0)->metadata(medMetaDataKeys::PatientName.key()));
-            patientInfo.setAttribute("patientID",   layeredView->layerData(0)->metadata(medMetaDataKeys::PatientID.key()));
-            patientInfo.setAttribute("birthDate",   layeredView->layerData(0)->metadata(medMetaDataKeys::BirthDate.key()));
-            patientInfo.setAttribute("gender",      layeredView->layerData(0)->metadata(medMetaDataKeys::Gender.key()));
+            if (layeredView->layerData(0)->hasMetaData(medMetaDataKeys::PatientName.key()))
+            {
+                patientInfo.setAttribute("patientName", layeredView->layerData(0)->metadata(medMetaDataKeys::PatientName.key()));
+            }
+            if (layeredView->layerData(0)->hasMetaData(medMetaDataKeys::PatientID.key()))
+            {
+                patientInfo.setAttribute("patientID",   layeredView->layerData(0)->metadata(medMetaDataKeys::PatientID.key()));
+            }
+            if (layeredView->layerData(0)->hasMetaData(medMetaDataKeys::BirthDate.key()))
+            {
+                patientInfo.setAttribute("birthDate",   layeredView->layerData(0)->metadata(medMetaDataKeys::BirthDate.key()));
+            }
+            if (layeredView->layerData(0)->hasMetaData(medMetaDataKeys::Gender.key()))
+            {
+                patientInfo.setAttribute("gender",      layeredView->layerData(0)->metadata(medMetaDataKeys::Gender.key()));
+            }
+
             patientInfo.setAttribute("studyDescription", "Scene");
             root.appendChild(patientInfo);
 
@@ -995,30 +1008,70 @@ void medViewContainer::loadScene()
 
             // Get back informations about the patient
             QDomNodeList informationNodes = doc.elementsByTagName("patient");
+
+            QString patientName, patientID, birthDate, gender, studyDescription = "";
+
             for(int i=0; i<informationNodes.size(); i++)
             {
                 QDomElement infoElement = informationNodes.item(i).toElement();
                 if(infoElement.isNull())
                 {
-                    printInConsole("Failed to open a view, unable to find patient element");
                     continue;
                 }
-                QString patientName      = infoElement.attribute("patientName");
-                QString patientID        = infoElement.attribute("patientID");
-                QString birthDate        = infoElement.attribute("birthDate");
-                QString gender           = infoElement.attribute("gender");
-                QString studyDescription = infoElement.attribute("studyDescription");
 
-                medAbstractLayeredView* layeredView = dynamic_cast<medAbstractLayeredView*>(view());
-                for(unsigned i=0; i<layeredView->layersCount(); i++)
+                if (infoElement.hasAttribute("patientName"))
                 {
-                    medDataManager::instance()->removeData(layeredView->layerData(i)->dataIndex());
-                    layeredView->layerData(i)->setMetaData(medMetaDataKeys::PatientName.key(),      patientName);
-                    layeredView->layerData(i)->setMetaData(medMetaDataKeys::PatientID.key(),        patientID);
-                    layeredView->layerData(i)->setMetaData(medMetaDataKeys::BirthDate.key(),        birthDate);
-                    layeredView->layerData(i)->setMetaData(medMetaDataKeys::Gender.key(),           gender);
-                    layeredView->layerData(i)->setMetaData(medMetaDataKeys::StudyDescription.key(), studyDescription);
-                    medDataManager::instance()->importData(layeredView->layerData(i));
+                    patientName      = infoElement.attribute("patientName");
+                }
+                if (infoElement.hasAttribute("patientID"))
+                {
+                    patientID        = infoElement.attribute("patientID");
+                }
+                if (infoElement.hasAttribute("birthDate"))
+                {
+                    birthDate        = infoElement.attribute("birthDate");
+                }
+                if (infoElement.hasAttribute("gender"))
+                {
+                    gender           = infoElement.attribute("gender");
+                }
+                if (infoElement.hasAttribute("studyDescription"))
+                {
+                    studyDescription = infoElement.attribute("studyDescription");
+                }
+
+                if (!patientName.isEmpty() || !patientID.isEmpty() || !birthDate.isEmpty() || !gender.isEmpty() || !studyDescription.isEmpty() )
+                {
+                    medAbstractLayeredView* layeredView = dynamic_cast<medAbstractLayeredView*>(view());
+
+                    // Update data with informations from the xml file and reset the display (for patientName and studyDescription)
+                    for(unsigned i=0; i<layeredView->layersCount(); i++)
+                    {
+                        medDataManager::instance()->removeData(layeredView->layerData(i)->dataIndex());
+
+                        if (patientName != "")
+                        {
+                            layeredView->layerData(i)->setMetaData(medMetaDataKeys::PatientName.key(),      patientName);
+                        }
+                        if (patientID != "")
+                        {
+                            layeredView->layerData(i)->setMetaData(medMetaDataKeys::PatientID.key(),        patientID);
+                        }
+                        if (birthDate != "")
+                        {
+                            layeredView->layerData(i)->setMetaData(medMetaDataKeys::BirthDate.key(),        birthDate);
+                        }
+                        if (gender != "")
+                        {
+                            layeredView->layerData(i)->setMetaData(medMetaDataKeys::Gender.key(),           gender);
+                        }
+                        if (studyDescription != "")
+                        {
+                            layeredView->layerData(i)->setMetaData(medMetaDataKeys::StudyDescription.key(), studyDescription);
+                        }
+
+                        medDataManager::instance()->importData(layeredView->layerData(i));
+                    }
                 }
             }
         }

--- a/src/medCore/gui/viewContainers/medViewContainer.h
+++ b/src/medCore/gui/viewContainers/medViewContainer.h
@@ -13,11 +13,10 @@
 
 #pragma once
 
+#include <QDomElement>
 #include <QFrame>
 
-#include <QDomElement>
 #include <medCoreExport.h>
-
 
 struct QUuid;
 class medAbstractView;

--- a/src/medCore/gui/viewContainers/medViewContainer.h
+++ b/src/medCore/gui/viewContainers/medViewContainer.h
@@ -15,6 +15,7 @@
 
 #include <QFrame>
 
+#include <QDomElement>
 #include <medCoreExport.h>
 
 
@@ -122,6 +123,9 @@ protected:
 
     void recomputeStyleSheet();
     void open(const QString & path);
+    void addMetadataToQDomElement(medAbstractData *data, QDomElement patientInfo, QString metadata);
+    void addMetadataToMedAbstractData(medAbstractData *data, QString value, QString metadata);
+    bool isRemoveAndAddMedAbstractDataNeeded(medAbstractData *data, QString patientName, QString studyDescription);
     void printInConsole(QString message);
     void displayMessageError(QString message);
 
@@ -137,5 +141,4 @@ private slots:
 
 private:
     medViewContainerPrivate *d;
-
 };

--- a/src/medCore/gui/viewContainers/medViewContainer.h
+++ b/src/medCore/gui/viewContainers/medViewContainer.h
@@ -124,8 +124,6 @@ protected:
     void recomputeStyleSheet();
     void open(const QString & path);
     void addMetadataToQDomElement(medAbstractData *data, QDomElement patientInfo, QString metadata);
-    void addMetadataToMedAbstractData(medAbstractData *data, QString value, QString metadata);
-    bool isRemoveAndAddMedAbstractDataNeeded(medAbstractData *data, QString patientName, QString studyDescription);
     void printInConsole(QString message);
     void displayMessageError(QString message);
 


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/music/issues/399 ("Imported scene has anonymous data")

It allows to keep patient name, patient ID, birthdate, gender, and create a dedicated "Scene" study description. If you save this loaded scene, it will be stored in the original patient tree.

Example:
```xml
<!DOCTYPE xml>
<scene>
 <layeredView path="view{81bfdeb6-aabd-4747-9630-d95bd6fdc056}/mapping.xml" id="medVtkView"/>
 <patient gender="M" patientID="cc6405a1-5f69-416c-a13d-f21b36514d19" birthDate="19500929" studyDescription="Scene" patientName="Belzebuth"/>
</scene>
```

I save the patient information in the `globalMapping.xml` file, as an independent `QDomElement`. @LoicCadour we'll have to check if it's ok on the Web Viewer.

Works on scene, and from the "Export to Viewer" button in pipelines.

:m: