### PR TITLE
[morpho filters] added kernel shape

### DIFF
--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.cpp
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.cpp
@@ -36,6 +36,8 @@ itkMorphologicalFiltersProcessBase::itkMorphologicalFiltersProcessBase(itkMorpho
 
     d->isRadiusInPixels = false;    
     d->description = "";
+
+    d->kernelShape = BallKernel;
 }
 
 itkMorphologicalFiltersProcessBase::itkMorphologicalFiltersProcessBase(const itkMorphologicalFiltersProcessBase& other) 
@@ -68,6 +70,13 @@ void itkMorphologicalFiltersProcessBase::setParameter(double data, int channel)
             d->isRadiusInPixels = false;
         }
     }
+}
+
+void itkMorphologicalFiltersProcessBase::setParameter(int data)
+{
+    DTK_D(itkMorphologicalFiltersProcessBase);
+
+    d->kernelShape = static_cast<KernelShape>(data);
 }
 
 //only called if not defined in subclasses (e.g. dilate/erodeFilter)

--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.h
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.h
@@ -24,10 +24,18 @@ class ITKFILTERSPLUGIN_EXPORT itkMorphologicalFiltersProcessBase : public itkFil
 {
     Q_OBJECT
 public:
+    enum KernelShape
+    {
+        BallKernel,
+        CrossKernel,
+        BoxKernel,
+    };
+
     itkMorphologicalFiltersProcessBase(itkMorphologicalFiltersProcessBase * parent = 0);
     itkMorphologicalFiltersProcessBase(const itkMorphologicalFiltersProcessBase& other);
     virtual ~itkMorphologicalFiltersProcessBase(void);
     void setParameter(double data, int channel);
+    void setParameter(int data);
 
 public slots:
     int tryUpdate();

--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
@@ -26,6 +26,7 @@
 #include <itkBinaryErodeImageFilter.h>
 #include <itkBinaryMorphologicalClosingImageFilter.h>
 #include <itkBinaryMorphologicalOpeningImageFilter.h>
+#include <itkFiltersProcessBase.h>
 #include <itkFlatStructuringElement.h>
 #include <itkGrayscaleMorphologicalClosingImageFilter.h>
 #include <itkGrayscaleMorphologicalOpeningImageFilter.h>
@@ -49,6 +50,7 @@ public:
     double radius[3];
     double radiusMm[3];
     bool isRadiusInPixels;
+    itkMorphologicalFiltersProcessBase::KernelShape kernelShape;
 	
     template <class ImageType> void convertMmInPixels ( void )
     {
@@ -75,7 +77,23 @@ public:
         elementRadius[0] = radius[0]; //radius (double) is truncated
         elementRadius[1] = radius[1];
         elementRadius[2] = radius[2];
-        StructuringElementType ball = StructuringElementType::Ball(elementRadius);
+
+        StructuringElementType kernel;
+
+        switch (kernelShape)
+        {
+        case itkMorphologicalFiltersProcessBase::BallKernel:
+            kernel = StructuringElementType::Ball(elementRadius);
+            break;
+        case itkMorphologicalFiltersProcessBase::CrossKernel:
+            kernel = StructuringElementType::Cross(elementRadius);
+            break;
+        case itkMorphologicalFiltersProcessBase::BoxKernel:
+            kernel = StructuringElementType::Box(elementRadius);
+            break;
+        }
+
+        kernel.SetRadiusIsParametric(true);
 
         typedef itk::MinimumMaximumImageFilter <ImageType> ImageCalculatorFilterType;
         typename ImageCalculatorFilterType::Pointer imageCalculatorFilter = ImageCalculatorFilterType::New();
@@ -143,7 +161,7 @@ public:
         }
 
         filter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( input->data() ) ) );
-        filter->SetKernel ( ball );
+        filter->SetKernel ( kernel );
 
         callback = itk::CStyleCommand::New();
         callback->SetClientData ( ( void * ) this );

--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
@@ -26,7 +26,6 @@
 #include <itkBinaryErodeImageFilter.h>
 #include <itkBinaryMorphologicalClosingImageFilter.h>
 #include <itkBinaryMorphologicalOpeningImageFilter.h>
-#include <itkFiltersProcessBase.h>
 #include <itkFlatStructuringElement.h>
 #include <itkGrayscaleMorphologicalClosingImageFilter.h>
 #include <itkGrayscaleMorphologicalOpeningImageFilter.h>

--- a/src-plugins/itkFilters/itkMorphologicalFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersToolBox.cpp
@@ -42,6 +42,7 @@ class itkMorphologicalFiltersToolBoxPrivate
 public:
     QDoubleSpinBox * kernelSize;
     QRadioButton *mmButton, *pixelButton;
+    QRadioButton *ballKernelButton, *crossKernelButton, *boxKernelButton;
     
     medComboBox * filters;
     dtkSmartPointer <itkMorphologicalFiltersProcessBase> process;
@@ -65,14 +66,14 @@ itkMorphologicalFiltersToolBox::itkMorphologicalFiltersToolBox ( QWidget *parent
     d->filters->addItems ( filtersList );
 
     // We use the same widget for all the morphological filters
-    QWidget *filterWidget = new QWidget(this);
+    QWidget *kernelSizeWidget = new QWidget(this);
     d->kernelSize = new QDoubleSpinBox;
     d->kernelSize->setMaximum ( 10 );
     d->kernelSize->setValue ( 1 );
     d->kernelSize->setObjectName("kernelSize");
 
-    QLabel * morphoFilterLabel = new QLabel ( tr ( "Kernel radius:" ) );
-    QHBoxLayout * morphoFilterLayout = new QHBoxLayout;
+    QLabel * kernelSizeLabel = new QLabel ( tr ( "Kernel radius:" ) );
+    QHBoxLayout * kernelSizeLayout = new QHBoxLayout;
     d->mmButton = new QRadioButton(tr("mm"), this);
     d->mmButton->setObjectName("mm");
     d->mmButton->setToolTip(tr("If \"mm\" is selected, the dimensions of the structuring element will be calculated in mm."));
@@ -83,12 +84,30 @@ itkMorphologicalFiltersToolBox::itkMorphologicalFiltersToolBox ( QWidget *parent
     d->pixelButton->setToolTip(tr("If \"pixels\" is selected, the dimensions of the structuring element will be calculated in pixels."));
     connect(d->pixelButton, SIGNAL(toggled(bool)), this, SLOT(roundSpinBox(bool)));
 
-    morphoFilterLayout->addWidget ( morphoFilterLabel );
-    morphoFilterLayout->addWidget ( d->kernelSize );
-    morphoFilterLayout->addWidget ( d->mmButton );
-    morphoFilterLayout->addWidget ( d->pixelButton );
-    morphoFilterLayout->addStretch ( 1 );
-    filterWidget->setLayout ( morphoFilterLayout );
+    kernelSizeLayout->addWidget ( kernelSizeLabel );
+    kernelSizeLayout->addWidget ( d->kernelSize );
+    kernelSizeLayout->addWidget ( d->mmButton );
+    kernelSizeLayout->addWidget ( d->pixelButton );
+    kernelSizeLayout->addStretch ( 1 );
+    kernelSizeWidget->setLayout ( kernelSizeLayout );
+
+    QWidget* kernelShapeWidget = new QWidget();
+    kernelShapeWidget->setLayout(new QHBoxLayout());
+
+    kernelShapeWidget->layout()->addWidget(new QLabel(tr("Kernel shape:")));
+
+    d->ballKernelButton = new QRadioButton(tr("ball"));
+    d->ballKernelButton->setObjectName("ballKernelButton");
+    d->ballKernelButton->setChecked(true);
+    kernelShapeWidget->layout()->addWidget(d->ballKernelButton);
+
+    d->boxKernelButton = new QRadioButton(tr("box"));
+    d->boxKernelButton->setObjectName("boxKernelButton");
+    kernelShapeWidget->layout()->addWidget(d->boxKernelButton);
+
+    d->crossKernelButton = new QRadioButton(tr("cross"));
+    d->crossKernelButton->setObjectName("crossKernelButton");
+    kernelShapeWidget->layout()->addWidget(d->crossKernelButton);
 
     // Run button:
     QPushButton *runButton = new QPushButton ( tr ( "Run" ) );
@@ -103,7 +122,8 @@ itkMorphologicalFiltersToolBox::itkMorphologicalFiltersToolBox ( QWidget *parent
 
     QVBoxLayout *layout = new QVBoxLayout();
     layout->addWidget ( d->filters );
-    layout->addWidget ( filterWidget );
+    layout->addWidget ( kernelSizeWidget );
+    layout->addWidget ( kernelShapeWidget );
     layout->addWidget ( runButton );
     layout->addWidget ( d->progressionStack );
     layout->addStretch ( 1 );
@@ -176,6 +196,19 @@ void itkMorphologicalFiltersToolBox::run ( void )
             {
                 d->process->setInput ( this->selectorToolBox()->data() );
                 d->process->setParameter ( (double)d->kernelSize->value(), (d->pixelButton->isChecked())? 1:0 );
+
+                if (d->ballKernelButton->isChecked())
+                {
+                    d->process->setParameter(itkMorphologicalFiltersProcessBase::BallKernel);
+                }
+                else if (d->crossKernelButton->isChecked())
+                {
+                    d->process->setParameter(itkMorphologicalFiltersProcessBase::CrossKernel);
+                }
+                else if (d->boxKernelButton->isChecked())
+                {
+                    d->process->setParameter(itkMorphologicalFiltersProcessBase::BoxKernel);
+                }
 
                 medRunnableProcess *runProcess = new medRunnableProcess;
                 runProcess->setProcess ( d->process );


### PR DESCRIPTION
The new algorithm to generate the thinning meshes requires different morphological filtering kernel shapes (ball, cross and box). I added this possibility in the process and toolbox.

I also activated the parametric mode of the structuring element. This makes the ball kernel more accurate as indicated in the ITK doc:

> Setting this flag to true will use the parametric definition of the object and will generate structuring elements with more accurate areas, which can be especially important when morphological operations are intended to remove or retain objects of particular sizes. When the mode is turned off (default), the radius is the same, but the object diameter is set to (radius*2)+1, which is the size of the neighborhood region. Thus, the original ball and annulus structuring elements have a systematic bias in the radius of +0.5 voxels in each dimension relative to the parametric definition of the radius. Thus, we recommend turning this mode on for more accurate structuring elements, but this mode is turned off by default for backward compatibility.

BUT this also means previous results are not quite correct. It means the thinning meshes we calculated were not accurate (they were really thinnings of about 1.2, 2.2 etc). @msermesant what do you think about this change?