### PR TITLE
[manualRegistration] harmonize registration algo, use undo/redo

### DIFF
--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
@@ -23,11 +23,10 @@
 class DiffeomorphicDemonsProcessPrivate
 {
 public:
+
     DiffeomorphicDemonsProcess * proc;
-    template <class PixelType>
-            int update();
-    template < typename TFixedImage, typename TMovingImage >
-           bool write(const QString&);
+    template <class PixelType> int update();
+    template < typename TFixedImage, typename TMovingImage > bool write(const QString&);
     void * registrationMethod ;
 
     std::vector<unsigned int> iterations;
@@ -53,9 +52,9 @@ DiffeomorphicDemonsProcess::DiffeomorphicDemonsProcess() : itkProcessRegistratio
     d->updateFieldStandardDeviation = 0.0;
     d->displacementFieldStandardDeviation = 1.5;
     d->useHistogramMatching = false;
-    //set transform type for the exportation of the transformation to a file
-    //this->setProperty("transformType","nonRigid");
-    setOutput(NULL);
+
+    // Gives the exported file type for medRegistrationSelectorToolBox
+    this->setProperty("transformType","notText");
 }
 
 DiffeomorphicDemonsProcess::~DiffeomorphicDemonsProcess()
@@ -219,23 +218,13 @@ int DiffeomorphicDemonsProcessPrivate::update()
 
 int DiffeomorphicDemonsProcess::update(itkProcessRegistration::ImageType imgType)
 {
-    if(fixedImage().IsNull() || movingImages().isEmpty()
-            || movingImages()[0].IsNull())
+    // cast has been done in itkProcessRegistration
+    if (imgType == itkProcessRegistration::FLOAT)
     {
-        qWarning() << "Either the fixed image or the moving image is Null";
-        return 1;
+        return d->update<float>();
     }
 
-    if (imgType != itkProcessRegistration::FLOAT)
-    {
-        qWarning() << "the imageType should be float, and it's :"<<imgType;
-        return 1;
-    }
-
-    int res = d->update<float>();
-    setOutput(d->proc->output());
-
-    return res;
+    return DTK_FAILURE;
 }
 
 itk::Transform<double,3,3>::Pointer DiffeomorphicDemonsProcess::getTransform(){

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
@@ -54,7 +54,7 @@ DiffeomorphicDemonsProcess::DiffeomorphicDemonsProcess() : itkProcessRegistratio
     d->useHistogramMatching = false;
 
     // Gives the exported file type for medRegistrationSelectorToolBox
-    this->setProperty("transformType","notText");
+    this->setProperty("outputFileType","notText");
 }
 
 DiffeomorphicDemonsProcess::~DiffeomorphicDemonsProcess()

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
@@ -27,8 +27,8 @@ public:
     DiffeomorphicDemonsProcess * proc;
     template <class PixelType> int update();
     template < typename TFixedImage, typename TMovingImage > bool write(const QString&);
-    void * registrationMethod ;
 
+    void * registrationMethod;
     std::vector<unsigned int> iterations;
     unsigned char updateRule;
     unsigned char gradientType;
@@ -173,7 +173,8 @@ int DiffeomorphicDemonsProcessPrivate::update()
 
     // Run the registration
     time_t t1 = clock();
-    try {
+    try
+    {
         registration->StartRegistration();
     }
     catch( std::exception & err )
@@ -218,13 +219,13 @@ int DiffeomorphicDemonsProcessPrivate::update()
 
 int DiffeomorphicDemonsProcess::update(itkProcessRegistration::ImageType imgType)
 {
-    // cast has been done in itkProcessRegistration
+    // Cast has been done in itkProcessRegistration
     if (imgType == itkProcessRegistration::FLOAT)
     {
         return d->update<float>();
     }
 
-    return DTK_FAILURE;
+    return medAbstractProcess::FAILURE;
 }
 
 itk::Transform<double,3,3>::Pointer DiffeomorphicDemonsProcess::getTransform(){
@@ -302,13 +303,15 @@ bool DiffeomorphicDemonsProcess::writeTransform(const QString& file)
     if (rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> * registration =
             static_cast<rpi::DiffeomorphicDemons<RegImageType,RegImageType,TransformScalarType> *>(d->registrationMethod))
     {
-        try{
+        try
+        {
             rpi::writeDisplacementFieldTransformation<TransformScalarType, RegImageType::ImageDimension>(
                         registration->GetTransformation(),
                         file.toStdString());
         }
-        catch (std::exception)
+        catch (std::exception& err)
         {
+            qDebug() << "ExceptionObject caught (writeTransform): " << err.what();
             return false;
         }
         return true;

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
@@ -54,7 +54,7 @@ DiffeomorphicDemonsProcess::DiffeomorphicDemonsProcess() : itkProcessRegistratio
     d->displacementFieldStandardDeviation = 1.5;
     d->useHistogramMatching = false;
     //set transform type for the exportation of the transformation to a file
-    this->setProperty("transformType","nonRigid");
+    //this->setProperty("transformType","nonRigid");
     setOutput(NULL);
 }
 

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.h
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.h
@@ -129,6 +129,13 @@ public:
     void setUseHistogramMatching(bool useHistogramMatching);
 
     virtual itk::Transform<double,3,3>::Pointer getTransform();
+
+    /**
+     * @brief Get parameters for tooltip in undo/redo area.
+     *
+     * @param void
+     * @return QString of the algorithm title & parameters
+    */
     virtual QString getTitleAndParameters();
 
 protected :

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
@@ -155,7 +155,6 @@ void DiffeomorphicDemonsToolBox::run()
 
     if(!toolbox)
         return;
-
     
     d->process = dynamic_cast<medAbstractRegistrationProcess*> (dtkAbstractProcessFactory::instance()->create("DiffeomorphicDemonsProcess"));
     if(!d->process)

--- a/src-plugins/manualRegistration/manualRegistration.cpp
+++ b/src-plugins/manualRegistration/manualRegistration.cpp
@@ -199,9 +199,7 @@ int manualRegistration::update(itkProcessRegistration::ImageType imgType)
 
 itk::Transform<double,3,3>::Pointer manualRegistration::getTransform()
 {
-    itk::Transform<double, 3, 3>::Pointer outputTransform;
-    outputTransform = d->transform;
-    return outputTransform;
+    return d->transform.GetPointer();
 }
 
 void manualRegistration::setParameter(int data)

--- a/src-plugins/manualRegistration/manualRegistration.cpp
+++ b/src-plugins/manualRegistration/manualRegistration.cpp
@@ -52,7 +52,7 @@ manualRegistration::manualRegistration() : itkProcessRegistration(), d(new manua
     d->proc = this;
 
     // Gives the exported file type for medRegistrationSelectorToolBox
-    this->setProperty("transformType","text");
+    this->setProperty("outputFileType","text");
 }
 
 manualRegistration::~manualRegistration()

--- a/src-plugins/manualRegistration/manualRegistration.cpp
+++ b/src-plugins/manualRegistration/manualRegistration.cpp
@@ -40,7 +40,7 @@ public:
     QList<manualRegistrationLandmark*> * MovingLandmarks;
 
     TransformType_Generic::Pointer  transform;
-    TransformName::TransformNameEnum transformTypeInt;
+    manualRegistration::TransformName transformTypeInt;
 };
 
 // /////////////////////////////////////////////////////////////////
@@ -84,11 +84,11 @@ template <class PixelType> int manualRegistrationPrivate::update()
 {
     int res = medAbstractProcess::FAILURE;
 
-    if (transformTypeInt == TransformName::RIGID)
+    if (transformTypeInt == manualRegistration::RIGID)
     {
         res = applyRegistration<PixelType, TransformType_Rigid3D>();
     }
-    else if (transformTypeInt == TransformName::AFFINE)
+    else if (transformTypeInt == manualRegistration::AFFINE)
     {
         res = applyRegistration<PixelType, TransformType_Affine>();
 
@@ -206,7 +206,7 @@ itk::Transform<double,3,3>::Pointer manualRegistration::getTransform()
 
 void manualRegistration::setParameter(int data)
 {
-    d->transformTypeInt = static_cast<TransformName::TransformNameEnum>(data);
+    d->transformTypeInt = static_cast<TransformName>(data);
 }
 
 QString manualRegistration::getTitleAndParameters()
@@ -214,11 +214,11 @@ QString manualRegistration::getTitleAndParameters()
     QString titleAndParameters;
     titleAndParameters += "ManualRegistration\n  ";
 
-    if (d->transformTypeInt == TransformName::RIGID)
+    if (d->transformTypeInt == RIGID)
     {
         titleAndParameters += "Rigid method";
     }
-    else if (d->transformTypeInt == TransformName::AFFINE)
+    else if (d->transformTypeInt == AFFINE)
     {
         titleAndParameters += "Affine method";
     }

--- a/src-plugins/manualRegistration/manualRegistration.h
+++ b/src-plugins/manualRegistration/manualRegistration.h
@@ -84,6 +84,13 @@ public:
     virtual int update(ImageType);
 
     virtual itk::Transform<double,3,3>::Pointer getTransform();
+
+    /**
+     * @brief Get parameters for tooltip in undo/redo area.
+     *
+     * @param void
+     * @return QString of the algorithm title & parameters
+    */
     virtual QString getTitleAndParameters();
 
     void SetFixedLandmarks(QList<manualRegistrationLandmark*>  * fixedLandmarks);

--- a/src-plugins/manualRegistration/manualRegistration.h
+++ b/src-plugins/manualRegistration/manualRegistration.h
@@ -107,8 +107,6 @@ public:
 
     void setParameter(int data);
 
-    void displayMessageError(QString error);
-
 private:
     manualRegistrationPrivate *d;
     friend class manualRegistrationPrivate;

--- a/src-plugins/manualRegistration/manualRegistration.h
+++ b/src-plugins/manualRegistration/manualRegistration.h
@@ -19,12 +19,6 @@
 
 class manualRegistrationPrivate;
 
-class TransformName
-{
-public:
-    enum TransformNameEnum {RIGID,AFFINE};
-};
-
 /**
  * @brief Registration process using diffeomorphic demons from itk.
  *
@@ -37,6 +31,9 @@ class MANUALREGISTRATIONPLUGIN_EXPORT manualRegistration : public itkProcessRegi
     Q_OBJECT
 
 public:
+
+    enum TransformName {RIGID,AFFINE};
+
     /**
      * @brief Constructor.
      *

--- a/src-plugins/manualRegistration/manualRegistration.h
+++ b/src-plugins/manualRegistration/manualRegistration.h
@@ -85,6 +85,7 @@ public:
 
     virtual itk::Transform<double,3,3>::Pointer getTransform();
     virtual QString getTitleAndParameters();
+
     void SetFixedLandmarks(QList<manualRegistrationLandmark*>  * fixedLandmarks);
     void SetMovingLandmarks(QList<manualRegistrationLandmark*>  * movingLandmarks);
 

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -354,7 +354,7 @@ void manualRegistrationToolBox::computeRegistration()
 
             medRunnableProcess *runProcess = new medRunnableProcess;
             runProcess->setProcess (d->process);
-            connect (runProcess, SIGNAL (success  (QObject*)),  this, SLOT   (getOutputFromProcess ()));
+            connect (runProcess, SIGNAL (success(QObject*)), this, SLOT(getOutputFromProcess()));
             this->addConnectionsAndStartJob(runProcess);
         }
     }

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -115,7 +115,6 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medAbstr
     d->layerGroup2->setLinkAllParameters(true);
     d->layerGroup2->removeParameter("Slicing");
 
-
     d->regOn           = false;
     d->currentView     = 0;
     d->leftContainer   = 0;

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -377,7 +377,7 @@ void manualRegistrationToolBox::retrieveProcessOutputAndUpdateViews()
 
         synchroniseMovingFuseView();
 
-        d->process.releasePointer();
+        d->process = 0;
     }
 }
 

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.cpp
@@ -78,8 +78,8 @@ manualRegistrationToolBox::manualRegistrationToolBox(QWidget *parent) : medAbstr
     transformationLayout->addWidget(new QLabel("Transformation:"));
     d->transformType = new medComboBox(widget);
     d->transformType->setObjectName("transformType");
-    d->transformType->addItem("Rigid",  TransformName::RIGID);
-    d->transformType->addItem("Affine", TransformName::AFFINE);
+    d->transformType->addItem("Rigid",  manualRegistration::RIGID);
+    d->transformType->addItem("Affine", manualRegistration::AFFINE);
     transformationLayout->addWidget(d->transformType);
 
     // Action buttons

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -44,7 +44,7 @@ public slots:
     void stopManualRegistration();
     void computeRegistration();
     void reset();
-    void getOutputFromProcess();
+    void retrieveProcessOutputAndUpdateViews();
 
 protected:
     virtual void clear();

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -39,7 +39,6 @@ protected slots:
     void updateView();    
     void synchroniseMovingFuseView();
     void save();
-    void exportTransformation();
 
 public slots:
     void startManualRegistration();

--- a/src-plugins/manualRegistration/manualRegistrationToolBox.h
+++ b/src-plugins/manualRegistration/manualRegistrationToolBox.h
@@ -38,13 +38,13 @@ public:
 protected slots:
     void updateView();    
     void synchroniseMovingFuseView();
-    void save();
 
 public slots:
     void startManualRegistration();
     void stopManualRegistration();
     void computeRegistration();
     void reset();
+    void getOutputFromProcess();
 
 protected:
     virtual void clear();
@@ -52,7 +52,6 @@ protected:
 private:
     void displayButtons(bool);
     void constructContainers(medTabbedViewContainers *);
-    void setDisableSaveButtons(bool);
     void setDisableComputeResetButtons(bool);
     void setDisableResetButton(bool);
 

--- a/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -189,9 +189,9 @@ void medRegistrationSelectorToolBox::onSaveTrans()
     QString fileTypeSuggestion;
     QString filterSelected;
     QHash<QString,QString> suffix;
-    if (d->process->hasProperty("transformType"))
+    if (d->process->hasProperty("outputFileType"))
     {
-        if ( d->process->property("transformType") == "text")
+        if ( d->process->property("outputFileType") == "text")
         {
             suffix[ tr("Transformation (*.txt)") ] = ".txt";
         }

--- a/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medRegistrationSelectorToolBox.cpp
@@ -191,9 +191,11 @@ QString medRegistrationSelectorToolBox::getNameOfCurrentAlgorithm()
 //! Saves the transformation.
 void medRegistrationSelectorToolBox::onSaveTrans()
 {
+    qDebug()<<"## medRegistrationSelectorToolBox::onSaveTrans";
+
     if (!d->movingData)
     {
-        emit showError(tr  ("Please Select a moving image before saving"),3000);
+        emit showError(tr  ("Please select a moving image before saving"),3000);
         return;
     }
     if (!d->process )
@@ -208,19 +210,25 @@ void medRegistrationSelectorToolBox::onSaveTrans()
     QHash<QString,QString> suffix;
     if (d->process->hasProperty("transformType"))
     {
-        if ( d->process->property("transformType") == "rigid")
+        qDebug()<<"## medRegistrationSelectorToolBox::onSaveTrans -> "<<d->process->property("transformType");
+
+//        if ( d->process->property("transformType") == "text")
+//        {
             suffix[ tr("Transformation (*.txt)") ] = ".txt";
-        else
-        {
-            suffix[ tr("MetaFile (*.mha)") ] = ".mha";
-            suffix[ tr("MetaFile (*.mhd)") ] = ".mhd";
-            suffix[ tr("Nifti (*.nii)") ] = ".nii";
-            suffix[ tr("Analyse (*.hdr)") ] = ".hdr";
-            suffix[ tr("Nrrd (*.nrrd)") ] = ".nrrd";
-            suffix[ tr("VTK (*.vtk)") ] = ".vtk";
-            suffix[ tr("All supported files "
-                "(*.mha *.mhd *.nii *.hdr *.nrrd *.vtk)") ] = ".mha";
-        }
+//            qDebug()<<"## medRegistrationSelectorToolBox::onSaveTrans TXT";
+//        }
+//        else
+//        {
+//            suffix[ tr("MetaFile (*.mha)") ] = ".mha";
+//            suffix[ tr("MetaFile (*.mhd)") ] = ".mhd";
+//            suffix[ tr("Nifti (*.nii)") ] = ".nii";
+//            suffix[ tr("Analyse (*.hdr)") ] = ".hdr";
+//            suffix[ tr("Nrrd (*.nrrd)") ] = ".nrrd";
+//            suffix[ tr("VTK (*.vtk)") ] = ".vtk";
+//            suffix[ tr("All supported files "
+//                "(*.mha *.mhd *.nii *.hdr *.nrrd *.vtk)") ] = ".mha";
+//            qDebug()<<"## medRegistrationSelectorToolBox::onSaveTrans notTXT";
+//        }
         QHashIterator<QString, QString> i(suffix);
         while (i.hasNext())
         {

--- a/src/medRegistration/itkProcessRegistration.cpp
+++ b/src/medRegistration/itkProcessRegistration.cpp
@@ -344,19 +344,14 @@ int itkProcessRegistration::update(itkProcessRegistration::ImageType)
 
 int itkProcessRegistration::update()
 {
-    if (!d->mutex.tryLock())
+    int retval = medAbstractProcess::FAILURE;
+
+    if (d->mutex.tryLock())
     {
-        return DTK_FAILURE;
+        retval = update(d->fixedImageType);
+        d->mutex.unlock();
     }
 
-    if(d->fixedImage.IsNull() || d->movingImages.empty())
-    {
-        displayMessageError("Either the fixed image or the moving image is empty");
-        return DTK_FAILURE;
-    }
-
-    int retval =  update(d->fixedImageType);
-    d->mutex.unlock();
     return retval;
 }
 
@@ -405,6 +400,7 @@ bool itkProcessRegistration::write(const QStringList& files)
     {
         return writeTransform(files.at(1));
     }
+
     return false;
 }
 
@@ -454,10 +450,4 @@ bool itkProcessRegistration::write(const QString& file)
         delete dataWriter;
     }
     return writeSuccess;
-}
-
-void itkProcessRegistration::displayMessageError(QString error)
-{
-    qDebug() << this->description() + ": " + error;
-    medMessageController::instance()->showError(error, 3000);
 }

--- a/src/medRegistration/itkProcessRegistration.cpp
+++ b/src/medRegistration/itkProcessRegistration.cpp
@@ -53,7 +53,7 @@ itkProcessRegistration::itkProcessRegistration() : medAbstractRegistrationProces
     QStringList types;
 
     types << "text" << "notText";
-    this->addProperty("transformType",types);
+    this->addProperty("outputFileType",types);
     this->addMetaData("category","registration");
 }
 

--- a/src/medRegistration/itkProcessRegistration.h
+++ b/src/medRegistration/itkProcessRegistration.h
@@ -35,11 +35,11 @@ class itkProcessRegistrationPrivate;
  * published there: http://gforge.inria.fr/projects/asclepiospublic/
  * to implement the registration algorithms.
  *
- * @note The process has the following dtk property: "transformType".
+ * @note The process has the following dtk property: "outputFileType".
  * Each subclass should set accordingly to the properties described in medRegistrationSelectorToolBox::onSaveTrans
  * and itkProcessRegistration::itkProcessRegistration().
  * Example:
- * @code this->setProperty("transformType","text"); @endcode
+ * @code this->setProperty("outputFileType","text"); @endcode
  *
  *
 */

--- a/src/medRegistration/itkProcessRegistration.h
+++ b/src/medRegistration/itkProcessRegistration.h
@@ -36,9 +36,10 @@ class itkProcessRegistrationPrivate;
  * to implement the registration algorithms.
  *
  * @note The process has the following dtk property: "transformType".
- * Each subclass should set accordingly the property with either "rigid", or "nonRigid".
+ * Each subclass should set accordingly to the properties described in medRegistrationSelectorToolBox::onSaveTrans
+ * and itkProcessRegistration::itkProcessRegistration().
  * Example:
- * @code this->setProperty("transformType","rigid"); @endcode
+ * @code this->setProperty("transformType","text"); @endcode
  *
  *
 */
@@ -150,6 +151,7 @@ public:
     */
     virtual QString getTitleAndParameters() = 0;
 
+    void displayMessageError(QString error);
 
 public slots:
     /**

--- a/src/medRegistration/itkProcessRegistration.h
+++ b/src/medRegistration/itkProcessRegistration.h
@@ -62,7 +62,6 @@ public:
     */
     virtual ~itkProcessRegistration();
 
-public:
     /**
      * @brief Image types.
      *
@@ -78,7 +77,6 @@ public:
         DOUBLE
     };
 
-public:
     /**
      * @brief Runs the process.
      *
@@ -150,8 +148,6 @@ public:
     * @return QString
     */
     virtual QString getTitleAndParameters() = 0;
-
-    void displayMessageError(QString error);
 
 public slots:
     /**


### PR DESCRIPTION
1° From this issue https://github.com/Inria-Asclepios/medInria-public/issues/244
2° Will be rebased with https://github.com/Inria-Asclepios/medInria-public/pull/245 [edit: rebased]
3° Will be rebased with https://github.com/Inria-Asclepios/medInria-public/pull/216 [edit: rebased]
4° To be used with https://github.com/Inria-Asclepios/music/pull/493

So, this harmonized PR does:
 * Manual Registration uses the undo/redo area

:m: