### PR TITLE
[crop] border widget in green

### DIFF
--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -102,6 +102,7 @@ medCropToolBox::medCropToolBox(QWidget* parent)
     d->borderWidget = vtkSmartPointer<vtkBorderWidget>::New();
     d->borderWidget->CreateDefaultRepresentation();
     d->borderWidget->SelectableOff();
+    static_cast<vtkBorderRepresentation*>(d->borderWidget->GetRepresentation())->GetBorderProperty()->SetColor(0,1,0);
 
     d->applyButton = new QPushButton(applyButtonName, this);
     d->applyButton->setObjectName(applyButtonName);


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/260

The crop box is in green, allowing to see the widget over a white image.

:m: