### PR TITLE
[DataView] rm data: view was not re-initialized

### DIFF
--- a/src/medCore/views/medAbstractLayeredView.cpp
+++ b/src/medCore/views/medAbstractLayeredView.cpp
@@ -247,10 +247,10 @@ void medAbstractLayeredView::setDataList(QList<medDataIndex> dataList)
 
     foreach(medDataIndex index, this->dataList())
     {
-        if (!dataList.contains(index)) {
-            medAbstractData *data = medDataManager::instance()->retrieveData(index);
-            if (data)
-                this->removeLayer(this->layer(data));
+        medAbstractData *data = medDataManager::instance()->retrieveData(index);
+        if (data)
+        {
+            this->removeLayer(this->layer(data));
         }
     }
 


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/224

If you add 2 datasets in a view, and remove the first one, the opacity is not initialized on the remaining dataset. Solving this problem solved the issue crash on my side.

Pauline, Mehdi, tell me if it's ok now :)

:m: