### PR TITLE
[Dilate] add default behavior for kernels

### DIFF
--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.cpp
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.cpp
@@ -36,14 +36,12 @@ itkMorphologicalFiltersProcessBase::itkMorphologicalFiltersProcessBase(itkMorpho
 
     d->isRadiusInPixels = false;    
     d->description = "";
-
-    d->kernelShape = BallKernel;
 }
 
 itkMorphologicalFiltersProcessBase::itkMorphologicalFiltersProcessBase(const itkMorphologicalFiltersProcessBase& other) 
     : itkFiltersProcessBase(*new itkMorphologicalFiltersProcessBasePrivate(*other.d_func()), other)
 {
-    
+
 }
 
 itkMorphologicalFiltersProcessBase::~itkMorphologicalFiltersProcessBase()

--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
@@ -81,7 +81,7 @@ public:
 
         switch (kernelShape)
         {
-        case itkMorphologicalFiltersProcessBase::BallKernel:
+        case itkMorphologicalFiltersProcessBase::BallKernel: default:
             kernel = StructuringElementType::Ball(elementRadius);
             break;
         case itkMorphologicalFiltersProcessBase::CrossKernel:

--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase_p.h
@@ -41,7 +41,10 @@ class itkMorphologicalFiltersProcessBase;
 class ITKFILTERSPLUGIN_EXPORT itkMorphologicalFiltersProcessBasePrivate : public itkFiltersProcessBasePrivate
 {
 public:
-    itkMorphologicalFiltersProcessBasePrivate(itkMorphologicalFiltersProcessBase *q = 0) : itkFiltersProcessBasePrivate(q) {}
+    itkMorphologicalFiltersProcessBasePrivate(itkMorphologicalFiltersProcessBase *q = 0) : itkFiltersProcessBasePrivate(q)
+    {
+        kernelShape = itkMorphologicalFiltersProcessBase::BallKernel;
+    }
     itkMorphologicalFiltersProcessBasePrivate(const itkMorphologicalFiltersProcessBasePrivate& other) : itkFiltersProcessBasePrivate(other) {}
 
     virtual ~itkMorphologicalFiltersProcessBasePrivate(void) {}
@@ -81,7 +84,7 @@ public:
 
         switch (kernelShape)
         {
-        case itkMorphologicalFiltersProcessBase::BallKernel: default:
+        case itkMorphologicalFiltersProcessBase::BallKernel:
             kernel = StructuringElementType::Ball(elementRadius);
             break;
         case itkMorphologicalFiltersProcessBase::CrossKernel:


### PR DESCRIPTION
This PR solves the VT pipeline problem that @LoicCadour explained by email. The first mask and mesh of THINNING in `VTPipeline::endWTmmVOICutterStep` was empty. We did not set the kernel parameter in medPipelineUtils::dilate.

:m: