### PR TITLE
[medSlider] handle tick list error when empty

### DIFF
--- a/src/medCore/gui/commonWidgets/medSlider.cpp
+++ b/src/medCore/gui/commonWidgets/medSlider.cpp
@@ -15,7 +15,7 @@
 
 void medSlider::addTick(int position)
 {
-    if(!ticksList.contains(position))
+    if( (tickCount() == 0) || !ticksList.contains(position))
     {
         ticksList.append(position);
     }
@@ -23,17 +23,27 @@ void medSlider::addTick(int position)
 
 int medSlider::tickCount()
 {
-   return ticksList.count();
+    if (!ticksList.toVector().isEmpty())
+    {
+        return ticksList.count();
+    }
+    return 0;
 }
 
 void medSlider::removeTick(int position)
 {
-    ticksList.removeAll(position);
+    if (tickCount() > 0)
+    {
+        ticksList.removeAll(position);
+    }
 }
 
 void medSlider::removeAllTicks()
 {
-    ticksList.clear();
+    if (tickCount() > 0)
+    {
+        ticksList.clear();
+    }
 }
 
 void medSlider::paintEvent(QPaintEvent *ev)

--- a/src/medCore/gui/commonWidgets/medSlider.cpp
+++ b/src/medCore/gui/commonWidgets/medSlider.cpp
@@ -15,7 +15,7 @@
 
 void medSlider::addTick(int position)
 {
-    if( (tickCount() == 0) || !ticksList.contains(position))
+    if( (ticksList.isEmpty()) || !ticksList.contains(position))
     {
         ticksList.append(position);
     }
@@ -33,7 +33,7 @@ int medSlider::tickCount()
 
 void medSlider::removeTick(int position)
 {
-    if (tickCount() > 0)
+    if (!ticksList.isEmpty())
     {
         ticksList.removeAll(position);
     }
@@ -41,7 +41,7 @@ void medSlider::removeTick(int position)
 
 void medSlider::removeAllTicks()
 {
-    if (tickCount() > 0)
+    if (!ticksList.isEmpty())
     {
         ticksList.clear();
     }

--- a/src/medCore/gui/commonWidgets/medSlider.cpp
+++ b/src/medCore/gui/commonWidgets/medSlider.cpp
@@ -23,10 +23,11 @@ void medSlider::addTick(int position)
 
 int medSlider::tickCount()
 {
-    if (!ticksList.toVector().isEmpty())
+    if (!ticksList.isEmpty())
     {
         return ticksList.count();
     }
+
     return 0;
 }
 
@@ -53,7 +54,7 @@ void medSlider::paintEvent(QPaintEvent *ev)
 
     QPainter painter(this);
     painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
-    for(int i = 0; i<ticksList.size(); i++)
+    for(int i = 0; i<tickCount(); i++)
     {
         int position = QStyle::sliderPositionFromValue(minimum(),
                                                        maximum(),


### PR DESCRIPTION
Needed for https://github.com/medInria/medInria-private/pull/139

Problem occured with multiple datasets, a ROI, and if you deleted the first dataset.

:m: