### PR TITLE
[registrationWorkspace] rm pop-up when switch from 2d to 3d

### DIFF
--- a/app/medInria/medRegistrationWorkspace.cpp
+++ b/app/medInria/medRegistrationWorkspace.cpp
@@ -173,9 +173,6 @@ void medRegistrationWorkspace::updateFromContainer(medRegistrationWorkspace::Con
 
             if(currentData)
             {
-                d->viewGroup->addImpactedView(currentView);
-                d->viewGroup->addImpactedView(fuseView);
-
                 d->layerGroups[containerIndex]->addImpactedlayer(currentView, currentData);
                 d->layerGroups[containerIndex]->addImpactedlayer(fuseView, currentData);
             }


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/144

`addImpactedView` is not used in the other workspaces, and i did not see any changes removing these 2 lines. In addition, these views are already set in `medAbstractWorkspace::addViewstoGroup`.

This removal allows to avoid the displayed pop-up when you switch a dataset from 2D to 3D in registration views.

:m: