### PR TITLE
[close] no need of a close button

### DIFF
--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -90,7 +90,6 @@ public:
     QToolButton*              adjustSizeButton;
     QToolButton*              screenshotButton;
     QToolButton*              fullscreenButton;
-    QToolButton*              quitButton;
 
     QList<QString>            importUuids;
     medQuickAccessMenu * quickAccessWidget;
@@ -176,15 +175,6 @@ medMainWindow::medMainWindow ( QWidget *parent ) : QMainWindow ( parent ), d ( n
     d->shortcutAccessVisible = false;
     d->controlPressed = false;
 
-    //Add quit button
-    QIcon quitIcon;
-    quitIcon.addPixmap(QPixmap(":/icons/quit.png"), QIcon::Normal);
-    d->quitButton = new QToolButton(this);
-    d->quitButton->setIcon(quitIcon);
-    d->quitButton->setObjectName("quitButton");
-    connect(d->quitButton, SIGNAL( pressed()), this, SLOT (close()));
-    d->quitButton->setToolTip(tr("Close MUSIC"));
-
     //  Setup Fullscreen Button
     QIcon fullscreenIcon ;
     fullscreenIcon.addPixmap(QPixmap(":icons/fullscreenExpand.png"),QIcon::Normal,QIcon::Off);
@@ -240,7 +230,6 @@ medMainWindow::medMainWindow ( QWidget *parent ) : QMainWindow ( parent ), d ( n
     rightEndButtonsLayout->addWidget( d->adjustSizeButton );
     rightEndButtonsLayout->addWidget( d->screenshotButton );
     rightEndButtonsLayout->addWidget( d->fullscreenButton );
-    rightEndButtonsLayout->addWidget( d->quitButton );
 
     //  Setting up status bar
     d->statusBarLayout = new QHBoxLayout;


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/113

Small PR to remove the close button at bottom-right of the app. Indeed, it calls `medMainWindow::closeEvent` but the native close buttons are doing the same.

:m: