### PR TITLE
when no SeriesDescription use Series Instance UID

### DIFF
--- a/src/medCore/database/medAbstractDatabaseImporter.cpp
+++ b/src/medCore/database/medAbstractDatabaseImporter.cpp
@@ -218,7 +218,7 @@ void medAbstractDatabaseImporter::importFile ( void )
             }
 
             // 2.2) Fill missing metadata
-            populateMissingMetadata ( medData, med::smartBaseName(fileInfo.fileName()) );
+            populateMissingMetadata ( medData, medMetaDataKeys::SeriesID.getFirstValue(medData));
             QString patientName = medMetaDataKeys::PatientName.getFirstValue(medData).simplified();
             QString birthDate = medMetaDataKeys::BirthDate.getFirstValue(medData);
             tmpPatientId = patientName + birthDate;
@@ -358,8 +358,8 @@ void medAbstractDatabaseImporter::importFile ( void )
         if ( imagemedData )
         {
             // 3.3) a) re-populate missing metadata
-            // as files might be aggregated we use the aggregated file name as SeriesDescription (if not provided, of course)
-            populateMissingMetadata ( imagemedData, med::smartBaseName(imagefileInfo.fileName()) );
+            // if there is no SeriesDescription, we use the tag Series Instance UID (specific and required)
+            populateMissingMetadata ( imagemedData, medMetaDataKeys::SeriesDicomID.getFirstValue(imagemedData));
             imagemedData->setMetaData ( medMetaDataKeys::PatientID.key(), QStringList() << patientID );
             imagemedData->setMetaData ( medMetaDataKeys::SeriesID.key(), QStringList() << seriesID );
 


### PR DESCRIPTION
From https://github.com/Inria-Asclepios/medInria-public/issues/285 (I copy-pasted the text, but check for comments)

## Problem
When importing the CT or MR, each slice becomes a a file in the db, i.e MUSIC cannot generate the volume.

## Closer look
These dcm data don't have a *SeriesDescription* tag, which is used to generate a VolumeID. And as the ```medAbstractDatabaseImporter``` code says:
> // 2.3) Generate an unique id for each volume
    // all images of the same volume should share the same id

When MUSIC can't find the *SeriesDescription* tag, it sets to the filename; which is annoying because : 1 slice = 1 file = 1 VolumeID.

## Solution
When there is no *SeriesDescription* tag, we have to set the series description to something that can always be found and that exclusively describes the series.Like a required tag describing the series. 
SeriesInstanceUID? It's dirty ("1.3.12.2.1107.5.1.4.75439.xxx....xxx") but it's required and unique to the series.
I'll keep thinking. If you have ideas, don't hesitate.

Please do some checking with your own DICOM files.