### PR TITLE
[Browser] lost metadatakey age displayed

### DIFF
--- a/src/medCore/data/medMetaDataKeys.cpp
+++ b/src/medCore/data/medMetaDataKeys.cpp
@@ -25,7 +25,7 @@ namespace medMetaDataKeys {
     // PATIENT
     MEDCORE_EXPORT const Key PatientID("PatientID");
     MEDCORE_EXPORT const Key PatientName("PatientName", "Patient Name");
-    MEDCORE_EXPORT const Key Age("Age", "Age", QVariant::UInt);
+    MEDCORE_EXPORT const Key Age("Age", "Age"); // could be "00" format, or for instance "00Y"
     MEDCORE_EXPORT const Key BirthDate("BirthDate", "Birth Date"/*, QVariant::Date*/);
     MEDCORE_EXPORT const Key Gender("Gender", "Gender", QVariant::Char);
     MEDCORE_EXPORT const Key Description("Description"); //what?


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/288

The dicom metadata concerning the age of the patient is not always a number, it can look like: "032Y". In fact, it can change from a MR/CT constructor to another. 

This PR displays the actual age given by the dicom (as a string).

:m:

