### PR TITLE
[Shrink] setParameter better data type

### DIFF
--- a/src-plugins/itkFilters/itkFiltersShrinkProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersShrinkProcess.cpp
@@ -66,7 +66,7 @@ QString itkFiltersShrinkProcess::description() const
 
 //-------------------------------------------------------------------------------------------
 
-void itkFiltersShrinkProcess::setParameter(double data, int channel)
+void itkFiltersShrinkProcess::setParameter(int data, int channel)
 {     
     if (channel > 2)
         return;

--- a/src-plugins/itkFilters/itkFiltersShrinkProcess.h
+++ b/src-plugins/itkFilters/itkFiltersShrinkProcess.h
@@ -34,7 +34,7 @@ public:
     
 public slots:
 
-    void setParameter ( double  data, int channel );
+    void setParameter (int data, int channel );
     int tryUpdate();
 
 protected:

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -692,9 +692,9 @@ void itkFiltersToolBox::setupItkShrinkProcess()
         return;
     
     d->process->setInput ( this->selectorToolBox()->data() );
-    d->process->setParameter ( ( double ) d->shrink0Value->value(), 0 );
-    d->process->setParameter ( ( double ) d->shrink1Value->value(), 1 );
-    d->process->setParameter ( ( double ) d->shrink2Value->value(), 2 );
+    d->process->setParameter ( d->shrink0Value->value(), 0 );
+    d->process->setParameter ( d->shrink1Value->value(), 1 );
+    d->process->setParameter ( d->shrink2Value->value(), 2 );
 }
 
 void itkFiltersToolBox::setupItkWindowingProcess()


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/294

This PR avoids a useless conversion in `tkFiltersToolBox::setupItkShrinkProcess()` using `int` instead of `double` (`int` is the type returned by the QSpinBox).

It has a more important use: in the pipelines, the user is going to use `int` instead of `double` (which was not instinctive because the Shrink toolbox display `int` values).

:m: