### PR TITLE
Revert "[close] no need of a close button"

### DIFF
--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -90,6 +90,7 @@ public:
     QToolButton*              adjustSizeButton;
     QToolButton*              screenshotButton;
     QToolButton*              fullscreenButton;
+    QToolButton*              quitButton;
 
     QList<QString>            importUuids;
     medQuickAccessMenu * quickAccessWidget;
@@ -175,6 +176,15 @@ medMainWindow::medMainWindow ( QWidget *parent ) : QMainWindow ( parent ), d ( n
     d->shortcutAccessVisible = false;
     d->controlPressed = false;
 
+    //Add quit button
+    QIcon quitIcon;
+    quitIcon.addPixmap(QPixmap(":/icons/quit.png"), QIcon::Normal);
+    d->quitButton = new QToolButton(this);
+    d->quitButton->setIcon(quitIcon);
+    d->quitButton->setObjectName("quitButton");
+    connect(d->quitButton, SIGNAL( pressed()), this, SLOT (close()));
+    d->quitButton->setToolTip(tr("Close MUSIC"));
+
     //  Setup Fullscreen Button
     QIcon fullscreenIcon ;
     fullscreenIcon.addPixmap(QPixmap(":icons/fullscreenExpand.png"),QIcon::Normal,QIcon::Off);
@@ -230,6 +240,7 @@ medMainWindow::medMainWindow ( QWidget *parent ) : QMainWindow ( parent ), d ( n
     rightEndButtonsLayout->addWidget( d->adjustSizeButton );
     rightEndButtonsLayout->addWidget( d->screenshotButton );
     rightEndButtonsLayout->addWidget( d->fullscreenButton );
+    rightEndButtonsLayout->addWidget( d->quitButton );
 
     //  Setting up status bar
     d->statusBarLayout = new QHBoxLayout;


### PR DESCRIPTION
Reverts Inria-Asclepios/medInria-public#277
This poses an ergonomic problem as currently the mac menu bar does not show on fullscreen mode, forcing the user to exit fullscreen in order to quit the application which is very annoying.