### PR TITLE
[Diffeo] solve error not displayed

### DIFF
--- a/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/itkProcessRegistrationDiffeomorphicDemons/itkProcessRegistrationDiffeomorphicDemonsToolBox.cpp
@@ -206,6 +206,7 @@ void itkProcessRegistrationDiffeomorphicDemonsToolBox::run()
 
     medRunnableProcess *runProcess = new medRunnableProcess;
     runProcess->setProcess (d->process);
+    connect (runProcess, SIGNAL (failure(int)), this, SLOT(handleDisplayError(int)));
     this->addConnectionsAndStartJob(runProcess);
 }
 


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/313

1-line PR. Add the display of error message.

I think it should be merged on 2.0.0 since it's an error in a 2.0.0 PR.

:m: