### PR TITLE
[medToolBox] handleDisplayError by default

### DIFF
--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
@@ -206,7 +206,6 @@ void DiffeomorphicDemonsToolBox::run()
 
     medRunnableProcess *runProcess = new medRunnableProcess;
     runProcess->setProcess (d->process);
-    connect (runProcess, SIGNAL (failure(int)), this, SLOT(handleDisplayError(int)));
     this->addConnectionsAndStartJob(runProcess);
 }
 

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -170,7 +170,6 @@ void iterativeClosestPointToolBox::run()
             medRunnableProcess *runProcess = new medRunnableProcess;
             runProcess->setProcess (d->process);
             connect (runProcess, SIGNAL (success   (QObject*)),    this, SLOT   (displayOutput()));
-            connect (runProcess, SIGNAL (failure   (int)),         this, SLOT   (handleDisplayError(int)));
             this->addConnectionsAndStartJob(runProcess);
         }
         else

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -782,7 +782,6 @@ void itkFiltersToolBox::run ( void )
 
     medRunnableProcess *runProcess = new medRunnableProcess;
     runProcess->setProcess ( d->process );
-    connect (runProcess, SIGNAL (failure(int)), this, SLOT (handleDisplayError(int)));
     this->addConnectionsAndStartJob(runProcess);
 }
 

--- a/src-plugins/itkFilters/itkMorphologicalFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersToolBox.cpp
@@ -201,7 +201,6 @@ void itkMorphologicalFiltersToolBox::run ( void )
 
                 medRunnableProcess *runProcess = new medRunnableProcess;
                 runProcess->setProcess ( d->process );
-                connect (runProcess, SIGNAL (failure(int)), this, SLOT(handleDisplayError(int)));
                 this->addConnectionsAndStartJob(runProcess);
             }
         }

--- a/src-plugins/medBinaryOperation/medBinaryOperationToolBox.cpp
+++ b/src-plugins/medBinaryOperation/medBinaryOperationToolBox.cpp
@@ -175,7 +175,6 @@ void medBinaryOperationToolBox::run()
 
     medRunnableProcess *runProcess = new medRunnableProcess;
     runProcess->setProcess (d->process);
-    connect (runProcess, SIGNAL (failure(int)), this, SLOT(handleDisplayError(int)));
     this->addConnectionsAndStartJob(runProcess);
 }
 

--- a/src-plugins/medMaskApplication/medMaskApplicationToolBox.cpp
+++ b/src-plugins/medMaskApplication/medMaskApplicationToolBox.cpp
@@ -125,7 +125,6 @@ void medMaskApplicationToolBox::run()
 
         medRunnableProcess *runProcess = new medRunnableProcess;
         runProcess->setProcess (d->process);
-        connect (runProcess, SIGNAL(failure(int)), this, SLOT(handleDisplayError(int)));
         this->addConnectionsAndStartJob(runProcess);
     }
     else

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -380,5 +380,6 @@ void medToolBox::addToolBoxConnections(medJobItem* job)
     connect (job, SIGNAL (cancelled (QObject*)),    this, SLOT   (setToolBoxOnReadyToUse()));
     connect (job, SIGNAL (success   (QObject*)),    this, SLOT   (setToolBoxOnReadyToUse()));
     connect (job, SIGNAL (failure   (QObject*)),    this, SLOT   (setToolBoxOnReadyToUse()));
+    connect (job, SIGNAL (failure   (int)),         this, SLOT   (handleDisplayError(int)));
     connect (job, SIGNAL (activate(QObject*,bool)), getProgressionStack(), SLOT(setActive(QObject*,bool)));
 }

--- a/src/medCore/process/medRunnableProcess.cpp
+++ b/src/medCore/process/medRunnableProcess.cpp
@@ -63,7 +63,7 @@ void medRunnableProcess::internalRun()
         else
         {
             emit failure (this);
-            emit failure (res); // Can be connected to medToolBox::handleDisplayError(int error)
+            emit failure (res);
         }
     }
 }


### PR DESCRIPTION
Originally used in https://github.com/Inria-Asclepios/music/pull/489

This PR adds the `handleDisplayError` function by default in `medToolBox::addToolBoxConnections`

:m: