### PR TITLE
[itkDCMTKImageIO] Num components taken into account for slice size

### DIFF
--- a/src/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/medImageIO/itkDCMTKImageIO.cpp
@@ -745,7 +745,7 @@ void DCMTKImageIO::InternalRead (void* buffer, int slice, unsigned long pixelCou
         itkExceptionMacro("Jpeg2000 encoding not supported yet.");
     }
 
-    size_t length = pixelCount;
+    size_t length = pixelCount * GetNumberOfComponents();
     switch( this->GetComponentType() ) {
         case CHAR:
             length *= sizeof(char);


### PR DESCRIPTION
Partially adresses https://github.com/Inria-Asclepios/medInria-public/issues/318
This is needed for RGB DICOMS to be imported properly.