### PR TITLE
[medToolBox] standardize on process success

### DIFF
--- a/app/medInria/medFilteringWorkspace.cpp
+++ b/app/medInria/medFilteringWorkspace.cpp
@@ -94,7 +94,7 @@ void medFilteringWorkspace::changeToolBoxInput()
 /**
  * @brief adds metadata to the output and emits a signal outputDataChanged(medAbstractData *)
  */
-void medFilteringWorkspace::onProcessSuccess()
+void medFilteringWorkspace::importProcessOutput()
 {
     if(selectorToolBox()->data())
     {

--- a/app/medInria/medFilteringWorkspace.h
+++ b/app/medInria/medFilteringWorkspace.h
@@ -51,7 +51,7 @@ signals:
 protected slots:
 
     void changeToolBoxInput();
-    void onProcessSuccess();
+    void importProcessOutput();
 
 private:
     medFilteringWorkspacePrivate *d;

--- a/app/medInria/medSegmentationWorkspace.cpp
+++ b/app/medInria/medSegmentationWorkspace.cpp
@@ -13,8 +13,6 @@
 
 #include <medSegmentationWorkspace.h>
 
-#include <medAbstractSelectableToolBox.h>
-#include <medDataManager.h>
 #include <medSelectorToolBox.h>
 #include <medTabbedViewContainers.h>
 #include <medToolBoxFactory.h>
@@ -30,10 +28,4 @@ bool medSegmentationWorkspace::isUsable()
 {
     medToolBoxFactory * tbFactory = medToolBoxFactory::instance();
     return (tbFactory->toolBoxesFromCategory("Segmentation").size()!=0);
-}
-
-void medSegmentationWorkspace::onProcessSuccess()
-{
-    medAbstractData* output = selectorToolBox()->currentToolBox()->processOutput();
-    medDataManager::instance()->importData(output);
 }

--- a/app/medInria/medSegmentationWorkspace.h
+++ b/app/medInria/medSegmentationWorkspace.h
@@ -30,9 +30,6 @@ public:
     medSegmentationWorkspace(QWidget * parent);
 
     static bool isUsable();
-
-protected slots:
-    void onProcessSuccess();
 };
 
 

--- a/src-plugins/reformat/medReformatWorkspace.cpp
+++ b/src-plugins/reformat/medReformatWorkspace.cpp
@@ -1,7 +1,5 @@
 #include "medReformatWorkspace.h"
 
-#include <medAbstractSelectableToolBox.h>
-#include <medDataManager.h>
 #include <medSelectorToolBox.h>
 #include <medTabbedViewContainers.h>
 #include <medToolBoxFactory.h>
@@ -23,10 +21,3 @@ bool medReformatWorkspace::registered()
 {
     return medWorkspaceFactory::instance()->registerWorkspace <medReformatWorkspace>();
 }
-
-void medReformatWorkspace::onProcessSuccess()
-{
-    medAbstractData * output = selectorToolBox()->currentToolBox()->processOutput();
-    medDataManager::instance()->importData(output);
-}
-

--- a/src-plugins/reformat/medReformatWorkspace.h
+++ b/src-plugins/reformat/medReformatWorkspace.h
@@ -28,7 +28,4 @@ public:
 
     static bool isUsable();
     static bool registered();
-
-protected slots:
-    void onProcessSuccess();
 };

--- a/src/medCore/gui/medSelectorWorkspace.cpp
+++ b/src/medCore/gui/medSelectorWorkspace.cpp
@@ -11,6 +11,8 @@
 
 =========================================================================*/
 
+#include <medAbstractSelectableToolBox.h>
+#include <medDataManager.h>
 #include <medSelectorToolBox.h>
 #include <medSelectorWorkspace.h>
 
@@ -36,8 +38,6 @@ medSelectorWorkspace::medSelectorWorkspace(QWidget * parent, QString name, medSe
         d->selectorToolBox = toolbox;
     }
 
-    connect(d->selectorToolBox,SIGNAL(success()),this,SLOT(onProcessSuccess()));
-
     this->addToolBox(d->selectorToolBox);
     d->selectorToolBox->setTitle(name); // get workspace name
 }
@@ -51,4 +51,10 @@ medSelectorWorkspace::~medSelectorWorkspace(void)
 medSelectorToolBox* medSelectorWorkspace::selectorToolBox()
 {
     return d->selectorToolBox;
+}
+
+void medSelectorWorkspace::importProcessOutput()
+{
+    medAbstractData* output = selectorToolBox()->currentToolBox()->processOutput();
+    medDataManager::instance()->importData(output);
 }

--- a/src/medCore/gui/medSelectorWorkspace.h
+++ b/src/medCore/gui/medSelectorWorkspace.h
@@ -35,7 +35,7 @@ public:
     medSelectorToolBox *selectorToolBox();
 
 protected slots:
-    virtual void onProcessSuccess(){}
+    void importProcessOutput();
 
 private:
     medSelectorWorkspacePrivate *d;

--- a/src/medCore/gui/medSelectorWorkspace.h
+++ b/src/medCore/gui/medSelectorWorkspace.h
@@ -35,7 +35,7 @@ public:
     medSelectorToolBox *selectorToolBox();
 
 protected slots:
-    void importProcessOutput();
+    virtual void importProcessOutput();
 
 private:
     medSelectorWorkspacePrivate *d;

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -13,8 +13,10 @@
 
 #include <medAbstractData.h>
 #include <medAbstractProcess.h>
+#include <medAbstractSelectableToolBox.h>
 #include <medAbstractView.h>
 #include <medButton.h>
+#include <medDataManager.h>
 #include <medJobManager.h>
 #include <medMessageController.h>
 #include <medTabbedViewContainers.h>
@@ -383,6 +385,11 @@ void medToolBox::addConnectionsAndStartJob(medJobItem* job)
 
 void medToolBox::addToolBoxConnections(medJobItem* job)
 {
+    // If you want to deactivate the automatic import of process output, add:
+    // "enableOnProcessSuccessImportOutput(runProcess, false);"
+    // in your toolbox, after "addConnectionsAndStartJob(runProcess);"
+    enableOnProcessSuccessImportOutput(job, true);
+
     connect (job, SIGNAL (success   (QObject*)),    this, SIGNAL (success ()));
     connect (job, SIGNAL (failure   (QObject*)),    this, SIGNAL (failure ()));
     connect (job, SIGNAL (cancelled (QObject*)),    this, SIGNAL (failure ()));
@@ -391,4 +398,16 @@ void medToolBox::addToolBoxConnections(medJobItem* job)
     connect (job, SIGNAL (failure   (QObject*)),    this, SLOT   (setToolBoxOnReadyToUse()));
     connect (job, SIGNAL (failure   (int)),         this, SLOT   (handleDisplayError(int)));
     connect (job, SIGNAL (activate(QObject*,bool)), getProgressionStack(), SLOT(setActive(QObject*,bool)));
+}
+
+void medToolBox::enableOnProcessSuccessImportOutput(medJobItem* job, bool enable)
+{
+    if (enable)
+    {
+        connect(job, SIGNAL(success(QObject*)), this->getWorkspace(), SLOT(importProcessOutput()));
+    }
+    else
+    {
+        disconnect(job, SIGNAL(success(QObject*)), this->getWorkspace(), SLOT(importProcessOutput()));
+    }
 }

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -404,7 +404,7 @@ void medToolBox::enableOnProcessSuccessImportOutput(medJobItem* job, bool enable
 {
     if (enable)
     {
-        connect(job, SIGNAL(success(QObject*)), this->getWorkspace(), SLOT(importProcessOutput()));
+        connect(job, SIGNAL(success(QObject*)), this->getWorkspace(), SLOT(importProcessOutput()), Qt::UniqueConnection);
     }
     else
     {

--- a/src/medCore/gui/toolboxes/medToolBox.h
+++ b/src/medCore/gui/toolboxes/medToolBox.h
@@ -76,6 +76,9 @@ public:
     //! Get back progress bar from workspace
     medProgressionStack *getProgressionStack();
 
+    //! enable or disable the output automatic import after a process success
+    void enableOnProcessSuccessImportOutput(medJobItem *job, bool enable);
+
 signals:
     /**
      * @brief Tells the world to add a new toolbox to the medToolboxContainer.


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/331

Allow to easily connect and disconnect the automatic import of output from processes. It's not anymore defined by each workspace but by each process/toolbox.

By default the import is done, but you can easily stop the import in your toolboxes.

:m: