### PR TITLE
[vtkDataManagement] Fix .mesh reading bug

### DIFF
--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -575,7 +575,7 @@ void vtkMetaDataSet::ReadCSVData(const char* filename)
             array->SetNumberOfComponents(1);
 
             float* tuple = new float[1];
-            for (unsigned int t=0; t<numberOfLines; t++)
+            for (int t=0; t<numberOfLines; t++)
             {
                 tuple[0]=(csvReader->GetOutput()->GetValue(t,i)).ToFloat();
                 array->InsertNextTupleValue (tuple);
@@ -596,7 +596,7 @@ void vtkMetaDataSet::ReadCSVData(const char* filename)
             array->SetNumberOfComponents(1);
 
             float* tuple = new float[1];
-            for (unsigned int t=0; t<numberOfLines; t++)
+            for (int t=0; t<numberOfLines; t++)
             {
                 tuple[0]=(csvReader->GetOutput()->GetValue(t,i)).ToFloat();
                 array->InsertNextTupleValue (tuple);

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -943,11 +943,7 @@ bool vtkMetaDataSet::IsMeditFormat(const char* filename)
       return false;
     }
     // Find medit header
-    if (vtkMetaDataSet::PlaceStreamCursor(file, "MeshVersionFormatted"))
-    {
-      return true;
-    }
-    return false;
+    return PlaceStreamCursor(file, "MeshVersionFormatted");
 }
 
 //----------------------------------------------------------------------------

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -935,6 +935,21 @@ bool vtkMetaDataSet::PlaceStreamCursor(std::ifstream& file, const char* token)
   return false;
 }
 
+bool vtkMetaDataSet::IsMeditFormat(const char* filename)
+{
+    std::ifstream file(filename);
+    if(file.fail())
+    {
+      return false;
+    }
+    // Find medit header
+    if (vtkMetaDataSet::PlaceStreamCursor(file, "MeshVersionFormatted"))
+    {
+      return true;
+    }
+    return false;
+}
+
 //----------------------------------------------------------------------------
 void vtkMetaDataSet::PrintSelf(ostream& os, vtkIndent indent)
 {

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -912,6 +912,28 @@ vtkDataArray* vtkMetaDataSet::GetArray (const char* name)
   return ret;
 }
 
+void vtkMetaDataSet::ClearInputStream(std::ifstream& file)
+{
+  file.clear();
+  file.seekg(0, file.beg);
+}
+
+bool vtkMetaDataSet::PlaceStreamCursor(std::ifstream& file, const char* token)
+{
+  char buf[256];
+  file >> buf;
+
+  while ((strcmp(buf, token) != 0) && file.good())
+  {
+    file >> buf;
+  }
+
+  if (file.good())
+  {
+    return true;
+  }
+  return false;
+}
 
 //----------------------------------------------------------------------------
 void vtkMetaDataSet::PrintSelf(ostream& os, vtkIndent indent)

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.h
@@ -410,12 +410,17 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSet: public vtkDataObject
      Internal use : resets parameter input file stream.
      Used by reading methods.
   */
-  virtual void ClearInputStream(std::ifstream& file);
+  static void ClearInputStream(std::ifstream& file);
 
   /**
      Internal use : find token in input stream
   */
-  virtual bool PlaceStreamCursor(std::ifstream& file, const char* token);
+  static bool PlaceStreamCursor(std::ifstream& file, const char* token);
+
+  /**
+     Internal use : return true if the file is a medit mesh
+  */
+  static bool IsMeditFormat(const char* filename);
 
   unsigned int Type;
 

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.h
@@ -406,7 +406,17 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSet: public vtkDataObject
   */
   virtual void ReadDataInternal(const char* filename);
 
-  
+  /**
+     Internal use : resets parameter input file stream.
+     Used by reading methods.
+  */
+  virtual void ClearInputStream(std::ifstream& file);
+
+  /**
+     Internal use : find token in input stream
+  */
+  virtual bool PlaceStreamCursor(std::ifstream& file, const char* token);
+
   unsigned int Type;
 
   int PickedPointId;

--- a/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
@@ -727,7 +727,14 @@ void vtkMetaSurfaceMesh::ReadMeditCells(std::ifstream& file, vtkPolyData* mesh, 
       file >> id;
       idlist->InsertNextId(id-1);
     }
-    file >> ref;
+    if (nbCellPoints == 1)
+    {
+      ref = 0;
+    }
+    else
+    {
+      file >> ref;
+    }
 
     cells->InsertNextCell(idlist);
     attrArray->InsertNextTuple1(ref);

--- a/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
@@ -391,7 +391,15 @@ unsigned int vtkMetaSurfaceMesh::CanReadFile (const char* filename)
 {
 
   if (vtkMetaSurfaceMesh::IsMeshExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
-    return vtkMetaSurfaceMesh::FILE_IS_MESH;
+  {
+    // medit .mesh format must have 'MeshVersionFormatted'
+    // as a header
+    if (vtkMetaDataSet::IsMeditFormat(filename))
+    {
+      return vtkMetaSurfaceMesh::FILE_IS_MESH;
+    }
+    return 0;
+  }
 
   if (vtkMetaSurfaceMesh::IsOBJExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
   {
@@ -470,7 +478,7 @@ void vtkMetaSurfaceMesh::ReadMeshFile (const char* filename)
   unsigned short ref = 0;
 
   // Find vertices in file
-  if (this->PlaceStreamCursor(file, "Vertices"))
+  if (vtkMetaDataSet::PlaceStreamCursor(file, "Vertices"))
   {
     // read all vertices
     unsigned int NVertices = 0;
@@ -487,7 +495,7 @@ void vtkMetaSurfaceMesh::ReadMeshFile (const char* filename)
       points->SetPoint(i, pos[0], pos[1], pos[2]);
       pointarray->InsertNextValue(ref);
     }
-    this->ClearInputStream(file);
+    vtkMetaDataSet::ClearInputStream(file);
   }
   else
   {
@@ -519,30 +527,30 @@ void vtkMetaSurfaceMesh::ReadMeshFile (const char* filename)
 
   // in medit format, "Corners" and "Required vertices" are
   // the vertices
-  if (this->PlaceStreamCursor(file, "Corners"))
+  if (vtkMetaDataSet::PlaceStreamCursor(file, "Corners"))
   {
     // read vertices
     this->ReadMeditCells(file, outputmesh, 1, cellarray);
   }
-  this->ClearInputStream(file);
+  vtkMetaDataSet::ClearInputStream(file);
 
-  if (this->PlaceStreamCursor(file, "RequiredVertices"))
+  if (vtkMetaDataSet::PlaceStreamCursor(file, "RequiredVertices"))
   {
     // read another kind of vertices
     this->ReadMeditCells(file, outputmesh, 1, cellarray);
   }
-  this->ClearInputStream(file);
+  vtkMetaDataSet::ClearInputStream(file);
 
   // find all edges
-  if (this->PlaceStreamCursor(file, "Edges"))
+  if (vtkMetaDataSet::PlaceStreamCursor(file, "Edges"))
   {
     // read all edges
     this->ReadMeditCells(file, outputmesh, 2, cellarray);
   }
-  this->ClearInputStream(file);
+  vtkMetaDataSet::ClearInputStream(file);
 
   // read all triangles
-  if (this->PlaceStreamCursor(file, "Triangles"))
+  if (vtkMetaDataSet::PlaceStreamCursor(file, "Triangles"))
   {
     this->ReadMeditCells(file, outputmesh, 3, cellarray);
   }

--- a/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
@@ -706,12 +706,8 @@ void vtkMetaSurfaceMesh::ReadMeditCells(std::ifstream& file, vtkPolyData* mesh, 
       cells = mesh->GetPolys();
       break;
     default:
-      cells = NULL;
-  }
-
-  if (!cells)
-  {
-    vtkErrorMacro("Invalid cell type for medit format.");
+      vtkErrorMacro("Invalid cell type for medit format.");
+      return;
   }
 
   // read stream

--- a/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.h
@@ -103,7 +103,12 @@ class MEDVTKINRIA_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
      Method called everytime the dataset changes for initialization
   */
   virtual void Initialize();
-  
+
+  /**
+     Internal method to read all medit format cells of a particular type
+  */
+  void ReadMeditCells(std::ifstream& file, vtkPolyData* mesh, int nbCellPoints, vtkDataArray* attrArray);
+ 
  private:
   
   vtkMetaSurfaceMesh(const vtkMetaSurfaceMesh&);       // Not implemented.

--- a/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.cxx
@@ -546,12 +546,19 @@ void vtkMetaVolumeMesh::ReadMeditCells(std::ifstream& file, vtkUnstructuredGrid*
       file >> id;
       idlist->InsertNextId(id-1);
     }
-    file >> ref;
+    if (cellType == VTK_VERTEX)
+    {
+      ref = 0;
+    }
+    else
+    {
+      file >> ref;
+    }
     
     mesh->InsertNextCell(cellType, idlist);
     attrArray->InsertNextTuple1(ref);
   }
-    
+
   if (i != nbCells)
   {
     vtkErrorMacro("Unexpected end of file.");

--- a/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.cxx
@@ -231,10 +231,6 @@ unsigned int vtkMetaVolumeMesh::CanReadFile (const char* filename)
       {
         return vtkMetaVolumeMesh::FILE_IS_MESH;
       }
-      else
-      {
-        return 0;
-      }
     }
     return 0;
   }
@@ -529,8 +525,8 @@ void vtkMetaVolumeMesh::ReadMeditCells(std::ifstream& file, vtkUnstructuredGrid*
       cellType = VTK_VERTEX;
       break;
     default:
-        vtkErrorMacro("Invalid cell type for medit format");
-        return;
+      vtkErrorMacro("Invalid cell type for medit format");
+      return;
   }
 
   // read stream

--- a/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.h
@@ -77,6 +77,10 @@ class MEDVTKINRIA_EXPORT vtkMetaVolumeMesh: public vtkMetaDataSet
   virtual void ReadGMeshFile(const char* filename);
   virtual void WriteVtkFile (const char* filename);
 
+  /**
+     Internal method to read cells in medit format.
+  */
+  void ReadMeditCells(std::ifstream& file, vtkUnstructuredGrid* mesh, int nbCellPoints, vtkDataArray* attrArray);
 
  private:
   


### PR DESCRIPTION
- Fix reader methods in vtkMetaSurfaceMesh and vtkMetaVolumeMesh for .mesh format, as those were incomplete:
 - In volume meshes, triangles and edges are now properly read.
 - In surface meshes, edges are now properly read.
- Fix signed/unsigned comparison warning in vtkMetaDataSet