### PR TITLE
[Diffeo] separate spacing, size errors. Rm origin error

### DIFF
--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
@@ -108,15 +108,10 @@ int DiffeomorphicDemonsProcessPrivate::update()
     typedef itk::Image< float, 3 > RegImageType;
     typedef double TransformScalarType;
 
-    // Check that the inputs are the same size/origin/spacing
-    if ( (proc->fixedImage()->GetLargestPossibleRegion().GetSize()
-          != proc->movingImages()[0]->GetLargestPossibleRegion().GetSize())
-         || (proc->fixedImage()->GetOrigin()
-             != proc->movingImages()[0]->GetOrigin())
-         || (proc->fixedImage()->GetSpacing()
-             != proc->movingImages()[0]->GetSpacing()) )
+    int testResult = proc->testInputs();
+    if (testResult != medAbstractProcess::SUCCESS)
     {
-        return medAbstractProcess::MISMATCHED_DATA_SIZES_ORIGIN_SPACING;
+        return testResult;
     }
 
     typedef rpi::DiffeomorphicDemons< RegImageType, RegImageType,
@@ -213,6 +208,29 @@ int DiffeomorphicDemonsProcessPrivate::update()
 
     if (proc->output())
         proc->output()->setData (result);
+
+    return medAbstractProcess::SUCCESS;
+}
+
+medAbstractProcess::DataError DiffeomorphicDemonsProcess::testInputs()
+{
+    if (d->proc->fixedImage()->GetLargestPossibleRegion().GetSize()
+            != d->proc->movingImages()[0]->GetLargestPossibleRegion().GetSize())
+    {
+        return medAbstractProcess::MISMATCHED_DATA_SIZE;
+    }
+
+    if (d->proc->fixedImage()->GetOrigin()
+            != d->proc->movingImages()[0]->GetOrigin())
+    {
+        return medAbstractProcess::MISMATCHED_DATA_ORIGIN;
+    }
+
+    if (d->proc->fixedImage()->GetSpacing()
+            != d->proc->movingImages()[0]->GetSpacing())
+    {
+        return medAbstractProcess::MISMATCHED_DATA_SPACING;
+    }
 
     return medAbstractProcess::SUCCESS;
 }

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.cpp
@@ -14,6 +14,7 @@
 #include <DiffeomorphicDemons/rpiDiffeomorphicDemons.hxx>
 #include <dtkCore/dtkAbstractProcessFactory.h>
 #include <diffeomorphicDemonsProcess.h>
+#include <itkChangeInformationImageFilter.h>
 #include <rpiCommonTools.hxx>
 
 // /////////////////////////////////////////////////////////////////
@@ -114,15 +115,23 @@ int DiffeomorphicDemonsProcessPrivate::update()
         return testResult;
     }
 
-    typedef rpi::DiffeomorphicDemons< RegImageType, RegImageType,
-                    TransformScalarType > RegistrationType;
+    FixedImageType* inputFixed  = (FixedImageType*)  proc->fixedImage().GetPointer();
+    FixedImageType* inputMoving = (MovingImageType*) proc->movingImages()[0].GetPointer();
+
+    // The output volume is going to located at the origin/direction of the fixed input. Needed for rpi::DiffeomorphicDemons
+    typedef itk::ChangeInformationImageFilter< FixedImageType > FilterType;
+    typename FilterType::Pointer filter = FilterType::New();
+    filter->SetOutputOrigin(inputFixed->GetOrigin());
+    filter->ChangeOriginOn();
+    filter->SetOutputDirection(inputFixed->GetDirection());
+    filter->ChangeDirectionOn();
+    filter->SetInput(inputMoving);
+
+    typedef rpi::DiffeomorphicDemons< RegImageType, RegImageType, TransformScalarType > RegistrationType;
     RegistrationType * registration = new RegistrationType;
-
     registrationMethod = registration;
-
-    registration->SetFixedImage((FixedImageType*)proc->fixedImage().GetPointer());
-    registration->SetMovingImage((MovingImageType*)proc->movingImages()[0].GetPointer());
-
+    registration->SetFixedImage(inputFixed);
+    registration->SetMovingImage(filter->GetOutput());
     registration->SetNumberOfIterations(iterations);
     registration->SetMaximumUpdateStepLength(maximumUpdateStepLength);
     registration->SetUpdateFieldStandardDeviation(updateFieldStandardDeviation);
@@ -186,7 +195,7 @@ int DiffeomorphicDemonsProcessPrivate::update()
     typedef itk::ResampleImageFilter< MovingImageType,MovingImageType,TransformScalarType >    ResampleFilterType;
     typename ResampleFilterType::Pointer resampler = ResampleFilterType::New();
     resampler->SetTransform(registration->GetTransformation());
-    resampler->SetInput((const MovingImageType*)proc->movingImages()[0].GetPointer());
+    resampler->SetInput((const MovingImageType*) inputMoving);
     resampler->SetSize( proc->fixedImage()->GetLargestPossibleRegion().GetSize() );
     resampler->SetOutputOrigin( proc->fixedImage()->GetOrigin() );
     resampler->SetOutputSpacing( proc->fixedImage()->GetSpacing() );
@@ -218,12 +227,6 @@ medAbstractProcess::DataError DiffeomorphicDemonsProcess::testInputs()
             != d->proc->movingImages()[0]->GetLargestPossibleRegion().GetSize())
     {
         return medAbstractProcess::MISMATCHED_DATA_SIZE;
-    }
-
-    if (d->proc->fixedImage()->GetOrigin()
-            != d->proc->movingImages()[0]->GetOrigin())
-    {
-        return medAbstractProcess::MISMATCHED_DATA_ORIGIN;
     }
 
     if (d->proc->fixedImage()->GetSpacing()

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.h
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsProcess.h
@@ -131,6 +131,12 @@ public:
     virtual itk::Transform<double,3,3>::Pointer getTransform();
     virtual QString getTitleAndParameters();
 
+    /**
+     * @brief testInputs() tests origin, dimension and spacing of the input
+     * @return medAbstractProcess::DataError according to the test result
+     */
+    medAbstractProcess::DataError testInputs();
+
 protected :
     /**
      * @brief Writes the transformation, in this case the displacement field,

--- a/src-plugins/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
+++ b/src-plugins/diffeomorphicDemons/diffeomorphicDemonsToolBox.cpp
@@ -44,7 +44,7 @@ DiffeomorphicDemonsToolBox::DiffeomorphicDemonsToolBox(QWidget *parent) : medAbs
 
     QVBoxLayout* layout = new QVBoxLayout();
 
-    QLabel* explanation = new QLabel("Drop 2 datasets with same size, origin and spacing.\n");
+    QLabel* explanation = new QLabel("Drop 2 datasets with same size and spacing.\n");
     explanation->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
     explanation->setWordWrap(true);
     layout->addWidget(explanation);

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -324,7 +324,16 @@ void medToolBox::handleDisplayError(int error)
         displayMessageError("Inputs must be the same type");
         break;
     case medAbstractProcess::MISMATCHED_DATA_SIZES_ORIGIN_SPACING:
-        displayMessageError("Inputs must be the same size, origin, spacing");
+        displayMessageError("Inputs must have the same size, origin, spacing");
+        break;
+    case medAbstractProcess::MISMATCHED_DATA_SIZE:
+        displayMessageError("Inputs must have the same size");
+        break;
+    case medAbstractProcess::MISMATCHED_DATA_ORIGIN:
+        displayMessageError("Inputs must have the same origin");
+        break;
+    case medAbstractProcess::MISMATCHED_DATA_SPACING:
+        displayMessageError("Inputs must have the same spacing");
         break;
     default:
         displayMessageError("This action failed (undefined error)");

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -47,7 +47,7 @@ public:
         DATA_SIZE,      //! Inputs must be the same size
         MISMATCHED_DATA_TYPES, //! Inputs must be the same type
         MISMATCHED_DATA_SIZES_ORIGIN_SPACING, //! Inputs should have the same size, origin, spacing
-        MISMATCHED_DATA_SIZE,    //! Inputs should have the same dimension
+        MISMATCHED_DATA_SIZE,    //! Inputs should have the same size
         MISMATCHED_DATA_ORIGIN,  //! Inputs should have the same origin
         MISMATCHED_DATA_SPACING, //! Inputs should have the same spacing
         UNDEFINED,      //! Miscellanous

--- a/src/medCore/process/medAbstractProcess.h
+++ b/src/medCore/process/medAbstractProcess.h
@@ -46,7 +46,10 @@ public:
         NO_MESH,        //! Input can not be a mesh
         DATA_SIZE,      //! Inputs must be the same size
         MISMATCHED_DATA_TYPES, //! Inputs must be the same type
-        MISMATCHED_DATA_SIZES_ORIGIN_SPACING, //! Inputs should have the same sizes, origins, spacings
+        MISMATCHED_DATA_SIZES_ORIGIN_SPACING, //! Inputs should have the same size, origin, spacing
+        MISMATCHED_DATA_SIZE,    //! Inputs should have the same dimension
+        MISMATCHED_DATA_ORIGIN,  //! Inputs should have the same origin
+        MISMATCHED_DATA_SPACING, //! Inputs should have the same spacing
         UNDEFINED,      //! Miscellanous
     };
 


### PR DESCRIPTION
According to this issue https://github.com/Inria-Asclepios/medInria-public/issues/341 it was not easy for the user to understand quickly if their inputs had a wrong dimension/origin or spacing.

Update: the idea is that the user just needs 2 volumes with same size and spacing (visible on the viewer). And that size and spacing errors are written separately.

:m: