### PR TITLE
[vtkDataMeshInteractor] Remove ghost actors

### DIFF
--- a/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src-plugins/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -568,6 +568,11 @@ void vtkDataMeshInteractor::removeData()
         {
             d->view2d->RemoveDataSet(pointSet);
             d->view3d->RemoveDataSet(pointSet);
+            d->metaDataSet->RemoveActor(d->actor2d);
+            d->metaDataSet->RemoveActor(d->actor3d);
+            d->actor2d = 0;
+            d->actor3d = 0;
+
             d->view->render();
         }
     }


### PR DESCRIPTION
- When 'RemoveData(...)' method is called, the meta data set actors are now properly removed from
the actor collection.
- SmartPointer is reset to avoid potential memleaks.