### PR TITLE
Added debug message to all SQL queries

### DIFF
--- a/src/medCore/database/medDatabaseController.h
+++ b/src/medCore/database/medDatabaseController.h
@@ -19,6 +19,8 @@
 #include <medCoreExport.h>
 #include <medAbstractDbController.h>
 
+#define EXEC_QUERY(q) medDatabaseController::instance()->execQuery(q, __FILE__ , __LINE__ )
+
 class medAbstractData;
 class medDatabaseControllerPrivate;
 class medJobItem;
@@ -68,6 +70,8 @@ public:
     virtual bool setMetaData(const medDataIndex& index, const QString& key, const QString& value);
 
     virtual bool isPersistent() const;
+
+    bool execQuery(QSqlQuery& query, const char* file = NULL, int line = -1) const;
 
 public slots:
 

--- a/src/medCore/database/medDatabaseImporter.cpp
+++ b/src/medCore/database/medDatabaseImporter.cpp
@@ -66,7 +66,7 @@ QString medDatabaseImporter::getPatientID(QString patientName, QString birthDate
     query.bindValue ( ":name", patientName );
     query.bindValue ( ":birthdate", birthDate );
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     if ( query.first() )
@@ -99,7 +99,7 @@ bool medDatabaseImporter::checkIfExists ( medAbstractData* medData, QString imag
     query.bindValue ( ":name", patientName );
     query.bindValue ( ":birthdate", birthDate );
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     if ( query.first() )
@@ -115,7 +115,7 @@ bool medDatabaseImporter::checkIfExists ( medAbstractData* medData, QString imag
         query.bindValue ( ":name", studyName );
         query.bindValue ( ":studyUid", studyUid );
 
-        if ( !query.exec() )
+        if ( !EXEC_QUERY(query) )
             qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
         if ( query.first() )
@@ -142,7 +142,7 @@ bool medDatabaseImporter::checkIfExists ( medAbstractData* medData, QString imag
             query.bindValue ( ":rows", rows );
             query.bindValue ( ":columns", columns );
 
-            if ( !query.exec() )
+            if ( !EXEC_QUERY(query) )
                 qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
             if ( query.first() )
@@ -155,7 +155,7 @@ bool medDatabaseImporter::checkIfExists ( medAbstractData* medData, QString imag
                 query.bindValue ( ":series", seriesDbId );
                 query.bindValue ( ":name", imageName );
 
-                if ( !query.exec() )
+                if ( !EXEC_QUERY(query) )
                     qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
                 if ( query.first() )
@@ -212,7 +212,7 @@ int medDatabaseImporter::getOrCreatePatient ( const medAbstractData* medData, QS
     query.bindValue ( ":name", patientName );
     query.bindValue ( ":birthdate", birthDate );
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     if ( query.first() )
@@ -230,7 +230,7 @@ int medDatabaseImporter::getOrCreatePatient ( const medAbstractData* medData, QS
         query.bindValue ( ":birthdate", birthdate );
         query.bindValue ( ":gender",    gender );
         query.bindValue ( ":patientId", patientId);
-        query.exec();
+        EXEC_QUERY(query);
 
         patientDbId = query.lastInsertId().toInt();
     }
@@ -263,7 +263,7 @@ int medDatabaseImporter::getOrCreateStudy ( const medAbstractData* medData, QSql
     query.bindValue ( ":studyName", studyName );
     query.bindValue ( ":studyUid", studyUid );
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     if ( query.first() )
@@ -281,7 +281,7 @@ int medDatabaseImporter::getOrCreateStudy ( const medAbstractData* medData, QSql
         query.bindValue ( ":thumbnail", refThumbPath );
         query.bindValue ( ":studyId", studyId);
 
-        query.exec();
+        EXEC_QUERY(query);
 
         studyDbId = query.lastInsertId().toInt();
     }
@@ -328,7 +328,7 @@ int medDatabaseImporter::getOrCreateSeries ( const medAbstractData* medData, QSq
     if( seriesName=="EmptySeries" )
         return seriesDbId;
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     if ( query.first() )
@@ -389,7 +389,7 @@ int medDatabaseImporter::getOrCreateSeries ( const medAbstractData* medData, QSq
         query.bindValue ( ":institution",    institution );
         query.bindValue ( ":report",         report );
 
-        if ( !query.exec() )
+        if ( !EXEC_QUERY(query) )
           qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
         seriesDbId = query.lastInsertId().toInt();
@@ -419,7 +419,7 @@ void medDatabaseImporter::createMissingImages ( medAbstractData* medData, QSqlDa
             query.bindValue ( ":series", seriesDbId );
             query.bindValue ( ":name", fileInfo.fileName() + QString().setNum ( i ) );
 
-            if ( !query.exec() )
+            if ( !EXEC_QUERY(query) )
                 qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
             if ( query.first() )
@@ -442,7 +442,7 @@ void medDatabaseImporter::createMissingImages ( medAbstractData* medData, QSqlDa
                 QString relativeFilePath = medData->metaDataValues ( "FileName" ) [0];
                 query.bindValue ( ":instance_path", indexWithoutImporting() ? "" : relativeFilePath );
 
-                if ( !query.exec() )
+                if ( !EXEC_QUERY(query) )
                     qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
             }
         }
@@ -457,7 +457,7 @@ void medDatabaseImporter::createMissingImages ( medAbstractData* medData, QSqlDa
             query.bindValue ( ":series", seriesDbId );
             query.bindValue ( ":name", fileInfo.fileName() );
 
-            if ( !query.exec() )
+            if ( !EXEC_QUERY(query) )
                 qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
             if ( query.first() )
@@ -483,7 +483,7 @@ void medDatabaseImporter::createMissingImages ( medAbstractData* medData, QSqlDa
                 else
                     query.bindValue ( ":thumbnail", "" );
 
-                if ( !query.exec() )
+                if ( !EXEC_QUERY(query) )
                     qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
             }
         }
@@ -505,7 +505,7 @@ QString medDatabaseImporter::ensureUniqueSeriesName ( const QString seriesName )
     QSqlQuery query ( db );
     query.prepare ( "SELECT name FROM series WHERE name LIKE '" + seriesName + "%'" );
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     QStringList seriesNames;

--- a/src/medCore/database/medDatabaseReader.cpp
+++ b/src/medCore/database/medDatabaseReader.cpp
@@ -61,7 +61,7 @@ medAbstractData* medDatabaseReader::run()
 
     query.prepare ( "SELECT name, birthdate, gender, patientId FROM patient WHERE id = :id" );
     query.bindValue ( ":id", patientDbId );
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
     if ( query.first() )
     {
@@ -73,7 +73,7 @@ medAbstractData* medDatabaseReader::run()
 
     query.prepare ( "SELECT name, uid, studyId FROM study WHERE id = :id" );
     query.bindValue ( ":id", studyDbId );
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
     if ( query.first() )
     {
@@ -88,7 +88,7 @@ medAbstractData* medDatabaseReader::run()
                      FROM series WHERE id = :id" );
 
     query.bindValue ( ":id", seriesDbId );
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
     if ( query.first() )
     {
@@ -115,7 +115,7 @@ medAbstractData* medDatabaseReader::run()
 
     query.prepare ( "SELECT name, id, path, instance_path, isIndexed FROM image WHERE series = :series" );
     query.bindValue ( ":series", seriesDbId );
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     // now we might have both indexed and imported images in the same series
@@ -164,7 +164,7 @@ medAbstractData* medDatabaseReader::run()
 
         seriesQuery.prepare ( "SELECT thumbnail FROM series WHERE id = :id" );
         seriesQuery.bindValue ( ":id", seriesDbId );
-        if (!seriesQuery.exec())
+        if (!EXEC_QUERY(seriesQuery))
             qDebug() << DTK_COLOR_FG_RED << seriesQuery.lastError() << DTK_NO_COLOR;
 
         if(seriesQuery.first())
@@ -234,7 +234,7 @@ QString medDatabaseReader::getFilePath()
     query.prepare ( "SELECT path, instance_path, isIndexed FROM image WHERE series = :series" );
     query.bindValue ( ":series", seriesDbId );
 
-    if ( !query.exec() )
+    if ( !EXEC_QUERY(query) )
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
 
     // indexed files have an empty string in 'instance_path' column

--- a/src/medCore/database/medDatabaseRemover.cpp
+++ b/src/medCore/database/medDatabaseRemover.cpp
@@ -28,20 +28,6 @@
 #include <medDatabaseController.h>
 #include <medStorage.h>
 
-#define EXEC_QUERY(q) execQuery(q, __FILE__ , __LINE__ )
-namespace
-{
-    inline bool execQuery ( QSqlQuery & query, const char *file, int line )
-    {
-        if ( ! query.exec() )
-        {
-            qDebug() << file << "(" << line << ") :" << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
-            return false;
-        }
-        return true;
-    }
-}
-
 class medDatabaseRemoverPrivate
 {
 public:


### PR DESCRIPTION
I needed this for the current work I'm doing with the database, so might as well keep it.

This generalizes the use of an ```EXEC_QUERY``` macro to be used in place of ```QSqlQuery::exec()```(it was done in some places, not everywhere). I improved the macro a bit by printing out the actual query that caused the error.