### PR TITLE
[vtkDataMeshReader] Fix empty series description when importing meshes

### DIFF
--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -97,6 +97,14 @@ bool vtkDataMeshReader::read(const QString& path) {
             return false;
         }
 
+        // Use filename as series description if no meta data could be found
+        QString seriesDescription;
+        if (medData->metadata(medMetaDataKeys::SeriesDescription.key()).isEmpty())
+        {
+            QFileInfo file(path);
+            medData->setMetaData(medMetaDataKeys::SeriesDescription.key(), file.baseName());
+        }
+
         setProgress(100);
         return true;
     }


### PR DESCRIPTION
- This PR uses the base name of the imported mesh as series description.
