### PR TITLE
[medAbstractWorkspace] Layer selection changed

### DIFF
--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -293,17 +293,20 @@ void medAbstractWorkspace::updateMouseInteractionToolBox()
     }
 }
 
-void medAbstractWorkspace::handleLayerSelectionChange()
+QList<int> medAbstractWorkspace::getSelectedLayerIndices()
 {
-    this->updateInteractorsToolBox();
-
-    // retrieve selected layer indices
     QList<int> layerIndices;
     foreach (QListWidgetItem* item, d->selectedLayers)
     {
         layerIndices.append(item->data(Qt::UserRole).toInt());
     }
-    emit layerSelectionChanged(layerIndices);
+    return layerIndices;
+}
+
+void medAbstractWorkspace::handleLayerSelectionChange()
+{
+    this->updateInteractorsToolBox();
+    emit layerSelectionChanged(getSelectedLayerIndices());
 }
 
 void medAbstractWorkspace::updateLayersToolBox()

--- a/src/medCore/gui/medAbstractWorkspace.cpp
+++ b/src/medCore/gui/medAbstractWorkspace.cpp
@@ -293,6 +293,19 @@ void medAbstractWorkspace::updateMouseInteractionToolBox()
     }
 }
 
+void medAbstractWorkspace::handleLayerSelectionChange()
+{
+    this->updateInteractorsToolBox();
+
+    // retrieve selected layer indices
+    QList<int> layerIndices;
+    foreach (QListWidgetItem* item, d->selectedLayers)
+    {
+        layerIndices.append(item->data(Qt::UserRole).toInt());
+    }
+    emit layerSelectionChanged(layerIndices);
+}
+
 void medAbstractWorkspace::updateLayersToolBox()
 {
     d->layerListToolBox->body()->clear();
@@ -309,7 +322,7 @@ void medAbstractWorkspace::updateLayersToolBox()
     d->layerListWidget->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
 
     connect(d->layerListWidget, SIGNAL(currentRowChanged(int)), this, SLOT(changeCurrentLayer(int)));
-    connect(d->layerListWidget, SIGNAL(itemSelectionChanged()), this, SLOT(updateInteractorsToolBox()));
+    connect(d->layerListWidget, SIGNAL(itemSelectionChanged()), this, SLOT(handleLayerSelectionChange()));
 
     foreach(QUuid uuid, d->viewContainerStack->containersSelected())
     {

--- a/src/medCore/gui/medAbstractWorkspace.h
+++ b/src/medCore/gui/medAbstractWorkspace.h
@@ -78,6 +78,8 @@ public:
     bool isUserLayerClosable() const;
     virtual void setInitialGroups();
 
+    QList<int> getSelectedLayerIndices();
+
     medProgressionStack *getProgressionStack();
 
 public slots:

--- a/src/medCore/gui/medAbstractWorkspace.h
+++ b/src/medCore/gui/medAbstractWorkspace.h
@@ -94,6 +94,7 @@ public slots:
     virtual void open(const medDataIndex& index);
 
 protected slots:
+    void handleLayerSelectionChange();
     void changeCurrentLayer(int row);
     void removeLayer();
 
@@ -118,6 +119,9 @@ private slots:
 
     void changeViewGroupColor(QString group, QColor color);
     void changeLayerGroupColor(QString group, QColor color);
+
+signals:
+    void layerSelectionChanged(QList<int> selectedLayersIndices);
 
 private:
     QWidget* buildViewLinkMenu();


### PR DESCRIPTION
- Emits a signal when the layer selection changes in medAbstractWorkspace
- Add a public method to retrieve the currently selected layers.

This PR enables toolboxes to connect to this new signal and handle layer selections.

Required by https://github.com/Inria-Asclepios/music/pull/621