### PR TITLE
[4DVolume] put back the scalar test

### DIFF
--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -694,8 +694,11 @@ double* vtkMetaDataSet::GetScalarRange(QString attributeName)
 
     if (attributeName.trimmed().isEmpty())
     {
-        QString temp (this->GetCurrentScalarArray()->GetName());
-        attributeName = temp;
+        if (this->GetCurrentScalarArray()) // 4D VTK, not 4D volume
+        {
+            QString temp (this->GetCurrentScalarArray()->GetName());
+            attributeName = temp;
+        }
     }
 
     if (this->GetDataSet())


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/385

Put back the original `if` condition which was in the function before https://github.com/Inria-Asclepios/medInria-public/pull/338 in order to visualize 4D images.