### PR TITLE
[Log] remove multiple quotation marks

### DIFF
--- a/app/medInria/medDataSourceManager.cpp
+++ b/app/medInria/medDataSourceManager.cpp
@@ -68,8 +68,7 @@ medDataSourceManager::medDataSourceManager(): d(new medDataSourceManagerPrivate)
 
     foreach(QString dataSourceName, medAbstractDataSourceFactory::instance()->dataSourcePlugins())
     {
-        QString fullMessage = "Factory creates dataSource: " + dataSourceName;
-        qDebug(fullMessage.toUtf8());
+        qDebug()<< "Factory creates dataSource:" << qPrintable(dataSourceName);
 
         medAbstractDataSource *dataSource = medAbstractDataSourceFactory::instance()->create(dataSourceName, 0);
         d->dataSources.push_back(dataSource);

--- a/app/medInria/medDataSourceManager.cpp
+++ b/app/medInria/medDataSourceManager.cpp
@@ -68,7 +68,9 @@ medDataSourceManager::medDataSourceManager(): d(new medDataSourceManagerPrivate)
 
     foreach(QString dataSourceName, medAbstractDataSourceFactory::instance()->dataSourcePlugins())
     {
-        qDebug()<< "factory creates dataSource:" << dataSourceName;
+        QString fullMessage = "Factory creates dataSource: " + dataSourceName;
+        qDebug(fullMessage.toUtf8());
+
         medAbstractDataSource *dataSource = medAbstractDataSourceFactory::instance()->create(dataSourceName, 0);
         d->dataSources.push_back(dataSource);
         connectDataSource(dataSource);

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -345,7 +345,8 @@ void medToolBox::handleDisplayError(int error)
 
 void medToolBox::displayMessageError(QString error)
 {
-    qDebug() << name() + ": " + error;
+    QString fullError = name() + ": " + error;
+    qDebug() << fullError;
     medMessageController::instance()->showError(error,3000);
 }
 

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -346,7 +346,7 @@ void medToolBox::handleDisplayError(int error)
 void medToolBox::displayMessageError(QString error)
 {
     QString fullError = name() + ": " + error;
-    qDebug() << fullError;
+    qDebug(fullError.toUtf8());
     medMessageController::instance()->showError(error,3000);
 }
 

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -345,8 +345,7 @@ void medToolBox::handleDisplayError(int error)
 
 void medToolBox::displayMessageError(QString error)
 {
-    QString fullError = name() + ": " + error;
-    qDebug(fullError.toUtf8());
+    qDebug() << qPrintable(name() + ": " + error);
     medMessageController::instance()->showError(error,3000);
 }
 

--- a/src/medCore/medPluginManager.cpp
+++ b/src/medCore/medPluginManager.cpp
@@ -123,8 +123,7 @@ QStringList medPluginManager::handlers(const QString& category)
 */
 void medPluginManager::onPluginLoaded(const QString& name)
 {
-    QString fullMessage = QString("Loading plugin: ") + name;
-    qDebug(fullMessage.toUtf8());
+    qDebug() << "Loading plugin:" << qPrintable(name);
 
     dtkPlugin *plug = plugin(name);
 

--- a/src/medCore/medPluginManager.cpp
+++ b/src/medCore/medPluginManager.cpp
@@ -123,7 +123,8 @@ QStringList medPluginManager::handlers(const QString& category)
 */
 void medPluginManager::onPluginLoaded(const QString& name)
 {
-    qDebug() << " Loading plugin : " << name;
+    QString fullMessage = QString("Loading plugin: ") + name;
+    qDebug(fullMessage.toUtf8());
 
     dtkPlugin *plug = plugin(name);
 


### PR DESCRIPTION
Fixes this issue https://github.com/Inria-Asclepios/medInria-public/issues/396

It removes multiple quotation marks happening with `qDebug()<< "blabla0 " << "blabla2";`

:m: