### PR TITLE
[LIB] standardize libraries in cmakelists

### DIFF
--- a/src-plugins/diffeomorphicDemons/CMakeLists.txt
+++ b/src-plugins/diffeomorphicDemons/CMakeLists.txt
@@ -72,9 +72,8 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_CFILES})
 target_link_libraries(${PROJECT_NAME}
   ${RPI_LIBRARIES}
   ${QT_LIBRARIES}
-  dtkCore
-  dtkLog
-  ITKCommon  
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medRegistration
   )

--- a/src-plugins/iterativeClosestPoint/CMakeLists.txt
+++ b/src-plugins/iterativeClosestPoint/CMakeLists.txt
@@ -78,13 +78,9 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
+  ${VTK_LIBRARIES}
   medCore
-  vtkFiltering
-  vtkCommon
-  vtkHybrid
-  vtkGraphics
   medUtilities
   medVtkInria
   )

--- a/src-plugins/itkDataDiffusionGradientList/CMakeLists.txt
+++ b/src-plugins/itkDataDiffusionGradientList/CMakeLists.txt
@@ -71,9 +71,8 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_CFILES})
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore  
-  ITKTensor
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medLog
   )

--- a/src-plugins/itkDataImage/CMakeLists.txt
+++ b/src-plugins/itkDataImage/CMakeLists.txt
@@ -87,32 +87,14 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_CFILES})
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkCore
-  dtkLog
-  ITKIOBioRad
-  ITKIOBMP
-  ITKIOGDCM
-  ITKIOGIPL
-  ITKIOHDF5
-  ITKIOJPEG
-  ITKIOLSM
-  ITKIOMeta
-  ITKIONIFTI
-  ITKIONRRD
-  ITKIOPhilipsREC
-  ITKIOPNG
-  ITKIOStimulate
-  ITKIOVTK
-  ITKStatistics
-  ${ITKReview_LIBRARIES} #TODO Get rid of this ASAP
+  ${DTK_LIBRARIES}
+  ${VTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medImageIO
   medLog
   medVtkInria
   QVTK
-  vtkCommon
-  vtkRendering
-  vtkVolumeRendering
   )
 
 # needed because of link  with medImageIO

--- a/src-plugins/itkDataSHImage/CMakeLists.txt
+++ b/src-plugins/itkDataSHImage/CMakeLists.txt
@@ -83,24 +83,9 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkCore
-  ITKIOBMP
-  ITKIOBioRad
-  ITKIOGDCM
-  ITKIOGIPL
-  ITKIOHDF5
-  ITKIOJPEG
-  ITKIOLSM
-  ITKIOMRC
-  ITKIOMeta
-  ITKIONIFTI
-  ITKIONRRD
-  ITKIOPNG
-  ITKIOStimulate
-  ITKIOVTK
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   QVTK
-  dtkCore
-  dtkLog
   medCore
   medLog
   medVtkInria

--- a/src-plugins/itkDataTensorImage/CMakeLists.txt
+++ b/src-plugins/itkDataTensorImage/CMakeLists.txt
@@ -86,23 +86,8 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkCore
-  dtkLog
-  ITKIOBioRad
-  ITKIOBMP
-  ITKIOGDCM
-  ITKIOGIPL
-  ITKIOHDF5
-  ITKIOJPEG
-  ITKIOLSM
-  ITKIOMeta
-  ITKIOMRC
-  ITKIONIFTI
-  ITKIONRRD
-  ITKIOPNG
-  ITKIOStimulate
-  ITKIOVTK
-  ITKTensor
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medLog
   medVtkInria

--- a/src-plugins/itkFilters/CMakeLists.txt
+++ b/src-plugins/itkFilters/CMakeLists.txt
@@ -67,9 +67,8 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_CFILES})
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkCore
-  dtkLog
-  ITKCommon  
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medUtilities
   )

--- a/src-plugins/itkN4BiasCorrection/CMakeLists.txt
+++ b/src-plugins/itkN4BiasCorrection/CMakeLists.txt
@@ -77,12 +77,10 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
   medCore
   medUtilities
-  ITKBiasCorrection
-  ITKStatistics
+  ${ITK_LIBRARIES}
   )
 
 

--- a/src-plugins/manualRegistration/CMakeLists.txt
+++ b/src-plugins/manualRegistration/CMakeLists.txt
@@ -84,8 +84,7 @@ target_link_libraries(${PROJECT_NAME}
   ${ITK_LIBRARIES}
   ${VTK_LIBRARIES}
   ${RPI_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
   medCore
   medRegistration
   medUtilities

--- a/src-plugins/medBinaryOperation/CMakeLists.txt
+++ b/src-plugins/medBinaryOperation/CMakeLists.txt
@@ -79,8 +79,7 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   ${ITK_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
   medCore
   medUtilities
   )

--- a/src-plugins/medClut/CMakeLists.txt
+++ b/src-plugins/medClut/CMakeLists.txt
@@ -79,8 +79,7 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   ${VTK_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
   medCore
   medVtkInria
   )

--- a/src-plugins/medMaskApplication/CMakeLists.txt
+++ b/src-plugins/medMaskApplication/CMakeLists.txt
@@ -79,8 +79,7 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   ${ITK_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
   medCore
   medUtilities
   )

--- a/src-plugins/medSegmentation/CMakeLists.txt
+++ b/src-plugins/medSegmentation/CMakeLists.txt
@@ -80,14 +80,11 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkCore
-  dtkLog
-  ITKCommon
+  ${VTK_LIBRARIES}
+  ${ITK_LIBRARIES}
+  ${DTK_LIBRARIES}
   medCore
   medVtkInria
-  vtkCommon
-  vtkRendering
-  vtkVolumeRendering
   QVTK
   )
 

--- a/src-plugins/medVtkFibersData/CMakeLists.txt
+++ b/src-plugins/medVtkFibersData/CMakeLists.txt
@@ -86,11 +86,8 @@ add_library(${PROJECT_NAME} SHARED
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   QVTK
-  dtkCore
-  dtkLog
-  vtkCommon
-  vtkFiltering
-  vtkRendering
+  ${DTK_LIBRARIES}
+  ${VTK_LIBRARIES}
   medCore
   medLog
   medVtkInria

--- a/src-plugins/medVtkView/CMakeLists.txt
+++ b/src-plugins/medVtkView/CMakeLists.txt
@@ -87,11 +87,8 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkCore
-  dtkLog
-  vtkCommon
-  vtkRendering
-  vtkVolumeRendering
+  ${DTK_LIBRARIES}
+  ${VTK_LIBRARIES}
   QVTK
   medCore
   medVtkInria

--- a/src-plugins/mscAlgorithmPaint/CMakeLists.txt
+++ b/src-plugins/mscAlgorithmPaint/CMakeLists.txt
@@ -78,12 +78,11 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medVtkInria
   QVTK
-  ITKReview
   medUtilities
   )
 

--- a/src-plugins/mscExportVideo/CMakeLists.txt
+++ b/src-plugins/mscExportVideo/CMakeLists.txt
@@ -76,13 +76,11 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medVtkInria
   QVTK
-  ITKCommon
-  ITKIOTransformBase
   medUtilities
   )
 

--- a/src-plugins/qtdcmDataSource/CMakeLists.txt
+++ b/src-plugins/qtdcmDataSource/CMakeLists.txt
@@ -85,8 +85,7 @@ target_link_libraries(${PROJECT_NAME}
   ${QTDCM_LIBS}
   ${DCMTK_LIBRARIES}
   ${WIN_LINK_LIBRARIES}
-  dtkCore
-  dtkLog
+  ${DTK_LIBRARIES}
   medCore
   )
   

--- a/src-plugins/reformat/CMakeLists.txt
+++ b/src-plugins/reformat/CMakeLists.txt
@@ -76,13 +76,11 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   medCore
   medVtkInria
   QVTK
-  ITKCommon
-  ITKIOTransformBase
   medUtilities
   )
 

--- a/src-plugins/undoRedoRegistration/CMakeLists.txt
+++ b/src-plugins/undoRedoRegistration/CMakeLists.txt
@@ -83,8 +83,7 @@ add_library(${PROJECT_NAME} SHARED
 
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
-  dtkLog
-  dtkCore
+  ${DTK_LIBRARIES}
   medCore
   medRegistration
   )

--- a/src-plugins/vtkDataMesh/CMakeLists.txt
+++ b/src-plugins/vtkDataMesh/CMakeLists.txt
@@ -76,16 +76,12 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_CFILES})
 target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   QVTK
-  dtkCore
-  dtkLog
-  itksys
+  ${DTK_LIBRARIES}
+  ${ITK_LIBRARIES}
+  ${VTK_LIBRARIES}
   medCore
   medLog
   medVtkInria
-  vtkCommon
-  vtkFiltering
-  vtkIO
-  vtkRendering
   )
 
 


### PR DESCRIPTION
From the issue https://github.com/Inria-Asclepios/medInria-public/issues/406

standardize in CMakeLists
```
 ${QT_LIBRARIES}
  ${VTK_LIBRARIES}
  ${ITK_LIBRARIES}
etc
```
:m: