### PR TITLE
[Video/Screen] def video/screen name, hide widgets, overwrite

### DIFF
--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -441,9 +441,11 @@ void medMainWindow::captureScreenshot()
 
     if (!screenshot.isNull())
     {
-        QString fileName = QFileDialog::getSaveFileName(this, tr("Save screenshot as"),
-                                                        QDir::home().absolutePath(),
-                                                        QString(), 0, QFileDialog::HideNameFilterDetails);
+        QString fileName = QFileDialog::getSaveFileName(this,
+                                                        tr("Save screenshot as"),
+                                                        QString(QDir::home().absolutePath() + "/screen.png"),
+                                                        "Image files (*.png *.jpeg *jpg);;All files (*.*)",
+                                                        0);
 
         QByteArray format = fileName.right(fileName.lastIndexOf('.')).toUpper().toAscii();
         if ( ! QImageWriter::supportedImageFormats().contains(format) )

--- a/src-plugins/mscExportVideo/mscExportVideo.h
+++ b/src-plugins/mscExportVideo/mscExportVideo.h
@@ -24,6 +24,7 @@ public:
     enum VideoFormat
     {
         OGGVORBIS,
+        JPGBATCH
     };
 
 public slots:
@@ -36,6 +37,9 @@ public slots:
 
     //! The output function is needed in medAbstractProcess even if not used
     medAbstractData *output();
+
+    //! Adapt widgets in FileDialog according to the format type chosen
+    void handleWidgetDisplayAccordingToType(int index);
 
 protected:
 


### PR DESCRIPTION
From this issue: https://github.com/Inria-Asclepios/medInria-public/issues/404
 
* default names for screenshot and video export have been put.
* widgets in video export dialog file are hidden or shown according to the current export type (ogv or batch of jpeg for now).
* overwrite of jpeg batch have been developed.

:m:
