### PR TITLE
[DB] load button -> temporary import button

### DIFF
--- a/app/medInria/medFileSystemDataSource.cpp
+++ b/app/medInria/medFileSystemDataSource.cpp
@@ -66,7 +66,7 @@ medFileSystemDataSource::medFileSystemDataSource( QWidget* parent ): medAbstract
     QAction *indexAction = new QAction(tr("Index"), this);
     indexAction->setIconVisibleInMenu(true);
     indexAction->setIcon(QIcon(":icons/finger.png"));
-    QAction *loadAction = new QAction(tr("Load"), this);
+    QAction *loadAction = new QAction(tr("Temporary Import"), this);
     loadAction->setIconVisibleInMenu(true);
     loadAction->setIcon(QIcon(":icons/document-open.png"));
     QAction *viewAction = new QAction(tr("View"), this);

--- a/src/medCore/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medActionsToolBox.cpp
@@ -61,7 +61,7 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
     d->viewBt = new QPushButton(d->buttonsWidget);
     d->viewBt->setAccessibleName("View");
     d->viewBt->setText(tr("View"));
-    d->viewBt->setToolTip(tr("Temporary import (if the data is not already in the database)\nand visualize the currently selected item."));
+    d->viewBt->setToolTip(tr("Temporarily import (if the data is not already in the database)\nand visualize the currently selected item."));
     d->viewBt->setIcon(QIcon(":/icons/eye.png"));
     connect(d->viewBt, SIGNAL(clicked()), this, SIGNAL(viewClicked()));
 
@@ -70,7 +70,7 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
         d->loadBt = new QPushButton(d->buttonsWidget);
         d->loadBt->setAccessibleName("Temporary Import");
         d->loadBt->setText(tr("Temporary Import"));
-        d->loadBt->setToolTip(tr("Temporary import the item(s) so as they can be used inside the application,\nbut do not include them in the database."));
+        d->loadBt->setToolTip(tr("Temporarily import the item(s) so as they can be used inside the application,\nbut do not include them in the database."));
         d->loadBt->setIcon(QIcon(":/icons/document-open.png"));
 
         d->importBt = new QPushButton(d->buttonsWidget);

--- a/src/medCore/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medActionsToolBox.cpp
@@ -61,16 +61,16 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
     d->viewBt = new QPushButton(d->buttonsWidget);
     d->viewBt->setAccessibleName("View");
     d->viewBt->setText(tr("View"));
-    d->viewBt->setToolTip(tr("Load and visualize the currently selected item."));
+    d->viewBt->setToolTip(tr("Temporary import (if the data is not already in the database)\nand visualize the currently selected item."));
     d->viewBt->setIcon(QIcon(":/icons/eye.png"));
     connect(d->viewBt, SIGNAL(clicked()), this, SIGNAL(viewClicked()));
 
     if (FILE_SYSTEM)
     {
         d->loadBt = new QPushButton(d->buttonsWidget);
-        d->loadBt->setAccessibleName("Load");
-        d->loadBt->setText(tr("Load"));
-        d->loadBt->setToolTip(tr("Temporary load the item(s) so as they can be used inside the application,\nbut do not include them in the database."));
+        d->loadBt->setAccessibleName("Temporary Import");
+        d->loadBt->setText(tr("Temporary Import"));
+        d->loadBt->setToolTip(tr("Temporary import the item(s) so as they can be used inside the application,\nbut do not include them in the database."));
         d->loadBt->setIcon(QIcon(":/icons/document-open.png"));
 
         d->importBt = new QPushButton(d->buttonsWidget);
@@ -148,7 +148,7 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
         d->buttonsList << d->newPatientBt << d->newStudyBt << d->editBt;
     }
 
-    int COLUMNS = 4; // we will use 3 rows of 4 buttons each
+    int COLUMNS = 3; // we will use 3 rows of 3 buttons each
     int i = 0;
     QGridLayout *gridLayout = new QGridLayout(d->buttonsWidget);
     gridLayout->setHorizontalSpacing(4);
@@ -332,16 +332,16 @@ void medActionsToolBox::initializeItemToActionsMap()
     d->itemToActions.insert("Folders", "Bookmark");
     d->itemToActions.insert("Folders", "Import");
     d->itemToActions.insert("Folders", "Index");
-    d->itemToActions.insert("Folders", "Load");
+    d->itemToActions.insert("Folders", "Temporary Import");
     d->itemToActions.insert("Folders", "View");
 
     d->itemToActions.insert("Files", "Import");
     d->itemToActions.insert("Files", "Index");
-    d->itemToActions.insert("Files", "Load");
+    d->itemToActions.insert("Files", "Temporary Import");
     d->itemToActions.insert("Files", "View");
 
     d->itemToActions.insert("Files & Folders", "Import");
     d->itemToActions.insert("Files & Folders", "Index");
-    d->itemToActions.insert("Files & Folders", "Load");
+    d->itemToActions.insert("Files & Folders", "Temporary Import");
     d->itemToActions.insert("Files & Folders", "View");
 }

--- a/src/medCore/gui/toolboxes/medCompositeDataSetImporterSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medCompositeDataSetImporterSelectorToolBox.cpp
@@ -139,7 +139,7 @@ void medCompositeDataSetImporterSelectorToolBox::initialize()
     connect(d->import,SIGNAL(clicked()),this,SLOT(onImportClicked()));
 
     //  Load button
-    d->load = new QPushButton (tr("Load"),mainwidget);
+    d->load = new QPushButton (tr("Temporary Import"),mainwidget);
     d->load->setMaximumWidth(buttonWidth);
     connect(d->load,SIGNAL(clicked()),this,SLOT(onLoadClicked()));
 


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/363

* "Load" button becomes "Temporary Import" button.
* "View" button has a better explanation tooltip.

:m: