### PR TITLE
[Metadata] add a QDialog displaying data metadata

### DIFF
--- a/src-plugins/itkDataImage/readers/itkDCMTKDataImageReader.cpp
+++ b/src-plugins/itkDataImage/readers/itkDCMTKDataImageReader.cpp
@@ -400,7 +400,7 @@ bool itkDCMTKDataImageReader::readInformation (const QStringList& paths)
         medData->setMetaData(medMetaDataKeys::SliceThickness.key(),  d->io->GetSliceThickness().c_str());
         //ImportationDate
         medData->setMetaData(medMetaDataKeys::AcquisitionDate.key(), d->io->GetAcquisitionDate().c_str());
-        //AcquisitionTime
+        medData->setMetaData(medMetaDataKeys::AcquisitionTime.key(), d->io->GetAcquisitionTime().c_str());
         medData->setMetaData(medMetaDataKeys::Comments.key(),        d->io->GetAcquisitionComments().c_str());
 
         QStringList filePaths;
@@ -429,6 +429,11 @@ bool itkDCMTKDataImageReader::readInformation (const QStringList& paths)
         //PreferredDataReader
         //ImageID
         //ThumbnailPath
+
+        // MR Image
+        medData->setMetaData(medMetaDataKeys::FlipAngle.key(),      d->io->GetFlipAngle().c_str());
+        medData->setMetaData(medMetaDataKeys::EchoTime.key(),       d->io->GetEchoTime().c_str());
+        medData->setMetaData(medMetaDataKeys::RepetitionTime.key(), d->io->GetRepetitionTime().c_str());
     }
     else {
         qDebug() << "Unsupported pixel type";

--- a/src/medCore/data/medMetaDataKeys.cpp
+++ b/src/medCore/data/medMetaDataKeys.cpp
@@ -82,5 +82,10 @@ namespace medMetaDataKeys {
     MEDCORE_EXPORT const Key PreferredDataReader("PreferredDataReader", "Preferred Data Reader");
     MEDCORE_EXPORT const Key ImageID("ImageID");
     MEDCORE_EXPORT const Key ThumbnailPath("ThumbnailPath", "Thumbnail Path");
+
+    // MR Image
+    MEDCORE_EXPORT const Key FlipAngle("FlipAngle");
+    MEDCORE_EXPORT const Key EchoTime("EchoTime");
+    MEDCORE_EXPORT const Key RepetitionTime("RepetitionTime");
 };
 

--- a/src/medCore/data/medMetaDataKeys.h
+++ b/src/medCore/data/medMetaDataKeys.h
@@ -149,6 +149,11 @@ namespace medMetaDataKeys {
     extern MEDCORE_EXPORT const Key PreferredDataReader;
     extern MEDCORE_EXPORT const Key ImageID;
     extern MEDCORE_EXPORT const Key ThumbnailPath;
+
+    // MR Image
+    extern MEDCORE_EXPORT const Key FlipAngle;
+    extern MEDCORE_EXPORT const Key EchoTime;
+    extern MEDCORE_EXPORT const Key RepetitionTime;
 };
 
 

--- a/src/medCore/gui/database/medDatabaseView.cpp
+++ b/src/medCore/gui/database/medDatabaseView.cpp
@@ -11,6 +11,8 @@
 
 =========================================================================*/
 
+#include "mscDatabaseMetadataItemDialog.h"
+
 #include <medDatabaseView.h>
 #include <medDataManager.h>
 #include <medAbstractDatabaseItem.h>
@@ -91,6 +93,7 @@ public:
     QAction *addPatientAction;
     QAction *addStudyAction;
     QAction *editAction;
+    QAction *metadataAction;
     QMenu *contextMenu;
 };
 
@@ -158,6 +161,11 @@ medDatabaseView::medDatabaseView(QWidget *parent) : QTreeView(parent), d(new med
     d->editAction->setIconVisibleInMenu(true);
     d->editAction->setIcon(QIcon(":icons/page_edit.png"));
     connect(d->editAction, SIGNAL(triggered()), this, SLOT(onEditRequested()));
+
+    d->metadataAction = new QAction(tr("Metadata"), this);
+    d->metadataAction->setIconVisibleInMenu(true);
+    d->metadataAction->setIcon(QIcon(":icons/information.png"));
+    connect(d->metadataAction, SIGNAL(triggered()), this, SLOT(onMetadataRequested()));
 }
 
 medDatabaseView::~medDatabaseView(void)
@@ -220,6 +228,7 @@ void medDatabaseView::updateContextMenu(const QPoint& point)
             d->editAction->setIcon(QIcon(":icons/page_edit.png"));
             d->contextMenu->addAction(d->viewAction);
             d->contextMenu->addAction(d->exportAction);
+            d->contextMenu->addAction(d->metadataAction);
             d->contextMenu->addAction(d->removeAction);
             if( !(medDataManager::instance()->controllerForDataSource(item->dataIndex().dataSourceId())->isPersistent()) )
                 d->contextMenu->addAction(d->saveAction);
@@ -614,5 +623,42 @@ void medDatabaseView::onOpeningFailed(const medDataIndex& index)
     {
 
         delegate->append(index);
+    }
+}
+
+/** Display metadata of selected item */
+void medDatabaseView::onMetadataRequested(void)
+{
+    QModelIndexList indexes = this->selectedIndexes();
+    if(indexes.count())
+    {
+        QModelIndex index = indexes.at(0);
+
+        medAbstractDatabaseItem *item = nullptr;
+
+        if(QSortFilterProxyModel *proxy = dynamic_cast<QSortFilterProxyModel *>(this->model()))
+        {
+            item = static_cast<medAbstractDatabaseItem *>(proxy->mapToSource(index).internalPointer());
+        }
+
+        if (item)
+        {
+            QVariant metadata;
+            QList<QString> keyList;
+            QList<QVariant> metadataList;
+
+            // Get back keys and metadata from the selected data
+            foreach (const medMetaDataKeys::Key* key, medMetaDataKeys::Key::all())
+            {
+                metadata = medDataManager::instance()->getMetaData(item->dataIndex(), key->key());
+
+                keyList.push_back(key->key());
+                metadataList.push_back(metadata);
+            }
+
+            // Create the information dialog
+            mscDatabaseMetadataItemDialog metadataDialog(keyList, metadataList, this);
+            metadataDialog.exec();
+        }
     }
 }

--- a/src/medCore/gui/database/medDatabaseView.h
+++ b/src/medCore/gui/database/medDatabaseView.h
@@ -66,6 +66,7 @@ public slots:
     void onCreatePatientRequested();
     void onCreateStudyRequested();
     void onEditRequested();
+    void onMetadataRequested();
 
 protected slots:
     virtual void updateContextMenu(const QPoint&);

--- a/src/medCore/gui/database/mscDatabaseMetadataItemDialog.cpp
+++ b/src/medCore/gui/database/mscDatabaseMetadataItemDialog.cpp
@@ -33,13 +33,15 @@ mscDatabaseMetadataItemDialog::mscDatabaseMetadataItemDialog(QList<QString> keyL
     setLayout(dialogLayout);
     setModal(true);
 
+    QLabel* explanation = new QLabel(tr("Non-empty metadata from the selected data:"));
+    dialogLayout->addWidget(explanation);
+
     d->tree = new QTreeWidget();
     d->tree->setFrameStyle(QFrame::NoFrame);
     d->tree->setAttribute(Qt::WA_MacShowFocusRect, false);
     d->tree->setUniformRowHeights(true);
     d->tree->setAlternatingRowColors(true);
     d->tree->setAnimated(true);
-    d->tree->setSortingEnabled(true);
     d->tree->setSelectionBehavior(QAbstractItemView::SelectRows);
     d->tree->setSelectionMode(QAbstractItemView::SingleSelection);
     d->tree->header()->setStretchLastSection(true);
@@ -59,12 +61,19 @@ mscDatabaseMetadataItemDialog::mscDatabaseMetadataItemDialog(QList<QString> keyL
     int cpt = 0;
     foreach (QString key, keyList)
     {
-        QTreeWidgetItem * item = new QTreeWidgetItem(d->tree);
-        item->setText(0, key);
-        item->setText(1, metadataList.at(cpt).toString());
-        d->tree->addTopLevelItem(item);
+        // Only keep non empty metadata values
+        if (!metadataList.at(cpt).toString().isEmpty())
+        {
+            QTreeWidgetItem * item = new QTreeWidgetItem(d->tree);
+            item->setText(0, key);
+            item->setText(1, metadataList.at(cpt).toString());
+            d->tree->addTopLevelItem(item);
+        }
         cpt++;
     }
+
+    d->tree->setSortingEnabled(true);
+    d->tree->sortByColumn(0, Qt::AscendingOrder);
 }
 
 mscDatabaseMetadataItemDialog::~mscDatabaseMetadataItemDialog()

--- a/src/medCore/gui/database/mscDatabaseMetadataItemDialog.cpp
+++ b/src/medCore/gui/database/mscDatabaseMetadataItemDialog.cpp
@@ -1,0 +1,74 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#include "mscDatabaseMetadataItemDialog.h"
+
+#include <medAbstractDatabaseItem.h>
+#include <medDataIndex.h>
+
+#include <QtGui>
+#include <QVariant>
+
+class mscDatabaseMetadataItemDialogPrivate
+{
+public:
+    QTreeWidget* tree;
+};
+
+
+mscDatabaseMetadataItemDialog::mscDatabaseMetadataItemDialog(QList<QString> keyList, QList<QVariant> metadataList, QWidget *parent):
+    QDialog(parent, Qt::Dialog | Qt::WindowCloseButtonHint), d (new mscDatabaseMetadataItemDialogPrivate)
+
+{
+    QVBoxLayout *dialogLayout = new QVBoxLayout;
+    setLayout(dialogLayout);
+    setModal(true);
+
+    d->tree = new QTreeWidget();
+    d->tree->setFrameStyle(QFrame::NoFrame);
+    d->tree->setAttribute(Qt::WA_MacShowFocusRect, false);
+    d->tree->setUniformRowHeights(true);
+    d->tree->setAlternatingRowColors(true);
+    d->tree->setAnimated(true);
+    d->tree->setSortingEnabled(true);
+    d->tree->setSelectionBehavior(QAbstractItemView::SelectRows);
+    d->tree->setSelectionMode(QAbstractItemView::SingleSelection);
+    d->tree->header()->setStretchLastSection(true);
+    d->tree->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    d->tree->setColumnCount(2);
+
+    // Create tree columns
+    QStringList treeColumns;
+    treeColumns << tr("Key") << tr("Value");
+    d->tree->setHeaderLabels(treeColumns);
+    d->tree->setColumnWidth(0, 200);
+    d->tree->setColumnWidth(1, 400);
+    dialogLayout->addWidget(d->tree);
+    this->resize(700, 700);
+
+    // Populate the tree
+    int cpt = 0;
+    foreach (QString key, keyList)
+    {
+        QTreeWidgetItem * item = new QTreeWidgetItem(d->tree);
+        item->setText(0, key);
+        item->setText(1, metadataList.at(cpt).toString());
+        d->tree->addTopLevelItem(item);
+        cpt++;
+    }
+}
+
+mscDatabaseMetadataItemDialog::~mscDatabaseMetadataItemDialog()
+{
+    delete d;
+}

--- a/src/medCore/gui/database/mscDatabaseMetadataItemDialog.cpp
+++ b/src/medCore/gui/database/mscDatabaseMetadataItemDialog.cpp
@@ -25,7 +25,6 @@ public:
     QTreeWidget* tree;
 };
 
-
 mscDatabaseMetadataItemDialog::mscDatabaseMetadataItemDialog(QList<QString> keyList, QList<QVariant> metadataList, QWidget *parent):
     QDialog(parent, Qt::Dialog | Qt::WindowCloseButtonHint), d (new mscDatabaseMetadataItemDialogPrivate)
 

--- a/src/medCore/gui/database/mscDatabaseMetadataItemDialog.h
+++ b/src/medCore/gui/database/mscDatabaseMetadataItemDialog.h
@@ -29,8 +29,6 @@ public:
     mscDatabaseMetadataItemDialog(QList<QString> keyList, QList<QVariant> metadataList, QWidget* parent);
 
     virtual ~mscDatabaseMetadataItemDialog();
-
-public slots:
     
 private:
 

--- a/src/medCore/gui/database/mscDatabaseMetadataItemDialog.h
+++ b/src/medCore/gui/database/mscDatabaseMetadataItemDialog.h
@@ -1,0 +1,40 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013 - 2014. All rights reserved.
+ See LICENSE.txt for details.
+ 
+  This software is distributed WITHOUT ANY WARRANTY; without even
+  the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  PURPOSE.
+
+=========================================================================*/
+
+#pragma once
+
+#include <QDialog>
+
+class medAbstractDatabaseItem;
+class mscDatabaseMetadataItemDialogPrivate;
+
+/**
+ * @brief Dialog displaying metadata from the selected data
+ */
+class mscDatabaseMetadataItemDialog: public QDialog
+{
+    Q_OBJECT
+
+public:
+    mscDatabaseMetadataItemDialog(QList<QString> keyList, QList<QVariant> metadataList, QWidget* parent);
+
+    virtual ~mscDatabaseMetadataItemDialog();
+
+public slots:
+    
+private:
+
+    mscDatabaseMetadataItemDialogPrivate *d;
+};
+
+

--- a/src/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/medImageIO/itkDCMTKImageIO.cpp
@@ -1001,6 +1001,27 @@ std::string DCMTKImageIO::GetPatientStatus() const
     return this->GetMetaDataValueString ( "(0011,1010)", 0 );
 }
 
+// MUSIC
+std::string DCMTKImageIO::GetAcquisitionTime() const
+{
+    return this->GetMetaDataValueString ( "(0008,0032)", 0 );
+}
+
+std::string DCMTKImageIO::GetFlipAngle() const
+{
+    return this->GetMetaDataValueString ( "(0018,1314)", 0 );
+}
+
+std::string DCMTKImageIO::GetEchoTime() const
+{
+    return this->GetMetaDataValueString ( "(0018,0081)", 0 );
+}
+
+std::string DCMTKImageIO::GetRepetitionTime() const
+{
+    return this->GetMetaDataValueString ( "(0018,0080)", 0 );
+}
+
 void
 DCMTKImageIO
 ::SwapBytesIfNecessary( void* buffer, unsigned long numberOfPixels )

--- a/src/medImageIO/itkDCMTKImageIO.h
+++ b/src/medImageIO/itkDCMTKImageIO.h
@@ -115,6 +115,12 @@ public:
     std::string GetRows() const;
     std::string GetColumns() const;
 
+    // msc
+    std::string GetAcquisitionTime() const;
+    std::string GetFlipAngle() const;
+    std::string GetEchoTime() const;
+    std::string GetRepetitionTime() const;
+
     const StringVectorType& GetOrderedFileNames() const
     { return m_OrderedFileNames; }
 


### PR DESCRIPTION
From https://github.com/Inria-Asclepios/music/issues/500 and https://github.com/Inria-Asclepios/medInria-public/issues/433

Display a QDialog with a QTreeWidget listing the metadata from the selected data in the database. Right-click on a series : Information button.

Future metadata will be automatically added in it. It would be interesting for echoes time, and other metadata from Dicom that we do not save for now. Edit: added Echo & Repetition time, and flip Angle

:m:
