### PR TITLE
[medUtilities] getArrayIndex variable uninitialized warning

### DIFF
--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -290,7 +290,8 @@ int medUtilities::getArrayIndex(medAbstractData* data,
                                 DataArrayType* arrayType)
 {
     int arrayId = -1;
-    DataArrayType type;
+    DataArrayType type = DataArrayType::POINT_ARRAY; // Init
+
     if (data->identifier().contains("vtkDataMesh") ||
         data->identifier().contains("EPMap"))
     {
@@ -318,11 +319,11 @@ int medUtilities::getArrayIndex(medAbstractData* data,
         {
             type = DataArrayType::POINT_ARRAY;
         }
-    }
 
-    if (arrayType)
-    {
-        *arrayType = type;
+        if (arrayType)
+        {
+            *arrayType = type;
+        }
     }
 
     return arrayId;


### PR DESCRIPTION
From this issue https://github.com/Inria-Asclepios/medInria-public/issues/429

Remove a small warning with an uninitialized variable.

@mjuhoor it's your code, maybe you could look at this PR? ^^

:m: