### PR TITLE
 [medUtilitiesITK] Added pixel type dispatching

### DIFF
--- a/src-plugins/itkFilters/itkFiltersAddProcess.h
+++ b/src-plugins/itkFilters/itkFiltersAddProcess.h
@@ -38,7 +38,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersAddProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.h
+++ b/src-plugins/itkFilters/itkFiltersComponentSizeThresholdProcess.h
@@ -18,11 +18,18 @@
 class itkFiltersComponentSizeThresholdProcessPrivate;
 class dtkAbstractData;
 
+namespace itk
+{
+template <typename PixelType, unsigned int Dimension> class Image;
+}
+
 class ITKFILTERSPLUGIN_EXPORT itkFiltersComponentSizeThresholdProcess : public itkFiltersProcessBase
 {
     Q_OBJECT
     
 public:
+    typedef itk::Image<unsigned short, 3> OutputImageType;
+
     static const double defaultMinimumSize;
 
     itkFiltersComponentSizeThresholdProcess(itkFiltersComponentSizeThresholdProcess * parent = 0);
@@ -38,12 +45,11 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int castToUInt3();
-    template <class PixelType> int updateProcess();
+    template <class InputImageType> dtkSmartPointer<medAbstractData> castToOutputType(medAbstractData* inputData);
+    template <class InputImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersComponentSizeThresholdProcessPrivate *d;
 };
 
 dtkAbstractProcess * createitkFiltersComponentSizeThresholdProcess(void);
-

--- a/src-plugins/itkFilters/itkFiltersDivideProcess.h
+++ b/src-plugins/itkFilters/itkFiltersDivideProcess.h
@@ -38,7 +38,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersDivideProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersGaussianProcess.h
+++ b/src-plugins/itkFilters/itkFiltersGaussianProcess.h
@@ -38,7 +38,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersGaussianProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersInvertProcess.h
+++ b/src-plugins/itkFilters/itkFiltersInvertProcess.h
@@ -32,7 +32,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 };
 
 dtkAbstractProcess * createitkFiltersInvertProcess(void);

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
@@ -18,7 +18,7 @@
 #include <itkImage.h>
 #include <itkMedianImageFilter.h>
 
-#include <medUtilities.h>
+#include <medUtilitiesITK.h>
 
 //-------------------------------------------------------------------------------------------
 
@@ -49,64 +49,21 @@ int itkFiltersMedianProcess::tryUpdate()
 
     if ( getInputData() )
     {
-        QString id = getInputData()->identifier();
-
-        if ( id == "itkDataImageChar3" )
-        {
-            res = updateProcess<char>();
-        }
-        else if ( id == "itkDataImageUChar3" )
-        {
-            res = updateProcess<unsigned char>();
-        }
-        else if ( id == "itkDataImageShort3" )
-        {
-            res = updateProcess<short>();
-        }
-        else if ( id == "itkDataImageUShort3" )
-        {
-            res = updateProcess<unsigned short>();
-        }
-        else if ( id == "itkDataImageInt3" )
-        {
-            res = updateProcess<int>();
-        }
-        else if ( id == "itkDataImageUInt3" )
-        {
-            res = updateProcess<unsigned int>();
-        }
-        else if ( id == "itkDataImageLong3" )
-        {
-            res = updateProcess<long>();
-        }
-        else if ( id== "itkDataImageULong3" )
-        {
-            res = updateProcess<unsigned long>();
-        }
-        else if ( id == "itkDataImageFloat3" )
-        {
-            res = updateProcess<float>();
-        }
-        else if ( id == "itkDataImageDouble3" )
-        {
-            res = updateProcess<double>();
-        }
-        else
-        {
-            res = medAbstractProcess::PIXEL_TYPE;
-        }
+        res = DISPATCH_ON_3D_PIXEL_TYPE(&itkFiltersMedianProcess::updateProcess, this, getInputData());
     }
 
     return res;
 }
 
-template <class PixelType> int itkFiltersMedianProcess::updateProcess()
+template <class ImageType>
+int itkFiltersMedianProcess::updateProcess(medAbstractData* inputData)
 {
-    typedef itk::Image< PixelType, 3 > ImageType;
+    typename ImageType::Pointer inputImage = static_cast<ImageType*>(inputData->data());
+
     typedef itk::MedianImageFilter< ImageType, ImageType >  MedianFilterType;
     typename MedianFilterType::Pointer medianFilter = MedianFilterType::New();
 
-    medianFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( getInputData()->data() ) ) );
+    medianFilter->SetInput(inputImage);
 
     itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
     callback->SetClientData ( ( void * ) this );
@@ -118,7 +75,7 @@ template <class PixelType> int itkFiltersMedianProcess::updateProcess()
     getOutputData()->setData ( medianFilter->GetOutput() );
 
     //Set output description metadata
-    medUtilities::setDerivedMetaData(getOutputData(), getInputData(), "median filter");
+    medUtilities::setDerivedMetaData(getOutputData(), inputData, "median filter");
 
     return DTK_SUCCEED;
 }

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.h
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.h
@@ -33,7 +33,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 };
 
 dtkAbstractProcess * createitkFiltersMedianProcess(void);

--- a/src-plugins/itkFilters/itkFiltersMultiplyProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMultiplyProcess.cpp
@@ -18,7 +18,7 @@
 #include <itkImage.h>
 #include <itkMultiplyImageFilter.h>
 
-#include <medUtilities.h>
+#include <medUtilitiesITK.h>
 
 class itkFiltersMultiplyProcessPrivate
 {
@@ -80,64 +80,21 @@ int itkFiltersMultiplyProcess::tryUpdate()
 
     if ( getInputData() )
     {
-        QString id = getInputData()->identifier();
-
-        if ( id == "itkDataImageChar3" )
-        {
-            res = updateProcess<char>();
-        }
-        else if ( id == "itkDataImageUChar3" )
-        {
-            res = updateProcess<unsigned char>();
-        }
-        else if ( id == "itkDataImageShort3" )
-        {
-            res = updateProcess<short>();
-        }
-        else if ( id == "itkDataImageUShort3" )
-        {
-            res = updateProcess<unsigned short>();
-        }
-        else if ( id == "itkDataImageInt3" )
-        {
-            res = updateProcess<int>();
-        }
-        else if ( id == "itkDataImageUInt3" )
-        {
-            res = updateProcess<unsigned int>();
-        }
-        else if ( id == "itkDataImageLong3" )
-        {
-            res = updateProcess<long>();
-        }
-        else if ( id== "itkDataImageULong3" )
-        {
-            res = updateProcess<unsigned long>();
-        }
-        else if ( id == "itkDataImageFloat3" )
-        {
-            res = updateProcess<float>();
-        }
-        else if ( id == "itkDataImageDouble3" )
-        {
-            res = updateProcess<double>();
-        }
-        else
-        {
-            res = medAbstractProcess::PIXEL_TYPE;
-        }
+        res = DISPATCH_ON_3D_PIXEL_TYPE(&itkFiltersMultiplyProcess::updateProcess, this, getInputData());
     }
 
     return res;
 }
 
-template <class PixelType> int itkFiltersMultiplyProcess::updateProcess()
+template <class ImageType>
+int itkFiltersMultiplyProcess::updateProcess(medAbstractData* inputData)
 {
-    typedef itk::Image< PixelType, 3 > ImageType;
+    typename ImageType::Pointer inputImage = static_cast<ImageType*>(inputData->data());
+
     typedef itk::MultiplyImageFilter< ImageType, itk::Image<double, ImageType::ImageDimension>, ImageType >  MultiplyFilterType;
     typename MultiplyFilterType::Pointer multiplyFilter = MultiplyFilterType::New();
 
-    multiplyFilter->SetInput ( dynamic_cast<ImageType *> ( ( itk::Object* ) ( getInputData()->data() ) ) );
+    multiplyFilter->SetInput(inputImage);
     multiplyFilter->SetConstant ( d->multiplyFactor );
 
     itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
@@ -151,7 +108,7 @@ template <class PixelType> int itkFiltersMultiplyProcess::updateProcess()
 
     //Set output description metadata
     QString newSeriesDescription = "multiply filter " + QString::number(d->multiplyFactor);
-    medUtilities::setDerivedMetaData(getOutputData(), getInputData(), newSeriesDescription);
+    medUtilities::setDerivedMetaData(getOutputData(), inputData, newSeriesDescription);
 
     return DTK_SUCCEED;
 }

--- a/src-plugins/itkFilters/itkFiltersMultiplyProcess.h
+++ b/src-plugins/itkFilters/itkFiltersMultiplyProcess.h
@@ -38,7 +38,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersMultiplyProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersNormalizeProcess.h
+++ b/src-plugins/itkFilters/itkFiltersNormalizeProcess.h
@@ -33,7 +33,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 };
 
 dtkAbstractProcess * createitkFiltersNormalizeProcess(void);

--- a/src-plugins/itkFilters/itkFiltersShrinkProcess.h
+++ b/src-plugins/itkFilters/itkFiltersShrinkProcess.h
@@ -38,7 +38,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersShrinkProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersSubtractProcess.h
+++ b/src-plugins/itkFilters/itkFiltersSubtractProcess.h
@@ -37,7 +37,7 @@ public slots:
     int tryUpdate();
     
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersSubtractProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersThresholdingProcess.h
+++ b/src-plugins/itkFilters/itkFiltersThresholdingProcess.h
@@ -40,7 +40,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersThresholdingProcessPrivate *d;

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -41,6 +41,7 @@
 #include <medRunnableProcess.h>
 #include <medSelectorToolBox.h>
 #include <medToolBoxFactory.h>
+#include <medUtilitiesITK.h>
 
 #include <QtGui>
 
@@ -384,183 +385,11 @@ void itkFiltersToolBox::update()
     }
     else
     {
-        QString identifier = data->identifier();
-
-        if ( identifier == "itkDataImageChar3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<char>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<char>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<char>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<char>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<char>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<char>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<char>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<char>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<char>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<char>::max() );
-        }
-        else if ( identifier == "itkDataImageUChar3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<unsigned char>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<unsigned char>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<unsigned char>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<unsigned char>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<unsigned char>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<unsigned char>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<unsigned char>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<unsigned char>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<unsigned char>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<unsigned char>::max() );
-        }
-        else if ( identifier == "itkDataImageShort3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<short>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<short>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<short>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<short>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<short>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<short>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<short>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<short>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<short>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<short>::max() );
-        }
-        else if ( identifier == "itkDataImageUShort3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<unsigned short>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<unsigned short>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<unsigned short>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<unsigned short>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<unsigned short>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<unsigned short>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<unsigned short>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<unsigned short>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<unsigned short>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<unsigned short>::max() );
-        }
-        else if ( identifier == "itkDataImageInt3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<int>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<int>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<int>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<int>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<int>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<int>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<int>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<int>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<int>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<int>::max() );
-        }
-        else if ( identifier == "itkDataImageUInt3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<unsigned int>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<unsigned int>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<unsigned int>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<unsigned int>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<unsigned int>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<unsigned int>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<unsigned int>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<unsigned int>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<unsigned int>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<unsigned int>::max() );
-        }
-        else if ( identifier == "itkDataImageLong3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<long>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<long>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<long>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<long>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<long>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<long>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<long>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<long>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<long>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<long>::max() );
-        }
-        else if ( identifier== "itkDataImageULong3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<unsigned long>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<unsigned long>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<unsigned long>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<unsigned long>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<unsigned long>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<unsigned long>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<unsigned long>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<unsigned long>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<unsigned long>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<unsigned long>::max() );
-        }
-        else if ( identifier == "itkDataImageFloat3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<float>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<float>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<float>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<float>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<float>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<float>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<float>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<float>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<float>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<float>::max() );
-        }
-        else if ( identifier == "itkDataImageDouble3" )
-        {
-            d->addFilterValue->setMaximum ( std::numeric_limits<double>::max() );
-            d->subtractFilterValue->setMaximum ( std::numeric_limits<double>::max() );
-
-            d->intensityMinimumValue->setMinimum ( std::numeric_limits<double>::min() );
-            d->intensityMinimumValue->setMaximum ( std::numeric_limits<double>::max() );
-
-            d->intensityMaximumValue->setMinimum ( std::numeric_limits<double>::min() );
-            d->intensityMaximumValue->setMaximum ( std::numeric_limits<double>::max() );
-
-            d->intensityOutputMinimumValue->setMinimum ( std::numeric_limits<double>::min() );
-            d->intensityOutputMinimumValue->setMaximum ( std::numeric_limits<double>::max() );
-
-            d->intensityOutputMaximumValue->setMinimum ( std::numeric_limits<double>::min() );
-            d->intensityOutputMaximumValue->setMaximum ( std::numeric_limits<double>::max() );
-        }
-        else
+        if (DISPATCH_ON_3D_PIXEL_TYPE(&itkFiltersToolBox::setupSpinBoxValues, this, data) != DTK_SUCCEED)
         {
             qWarning() << "itkFiltersToolBox Error: pixel type not yet implemented ("
-            << identifier
-            << ")";
+                       << data->identifier()
+                       << ")";
             clear();
             return;
         }
@@ -583,6 +412,25 @@ void itkFiltersToolBox::update()
         d->intensityOutputMinimumValue->setValue(m_MinValueImage);
         d->intensityOutputMaximumValue->setValue (m_MaxValueImage);
     }
+}
+
+template <typename ImageType>
+int itkFiltersToolBox::setupSpinBoxValues(medAbstractData*)
+{
+    typedef typename ImageType::PixelType PixelType;
+
+    d->addFilterValue->setMaximum(std::numeric_limits<PixelType>::max());
+    d->subtractFilterValue->setMaximum(std::numeric_limits<PixelType>::max());
+    d->intensityMinimumValue->setMinimum(std::numeric_limits<PixelType>::min());
+    d->intensityMinimumValue->setMaximum(std::numeric_limits<PixelType>::max());
+    d->intensityMaximumValue->setMinimum(std::numeric_limits<PixelType>::min());
+    d->intensityMaximumValue->setMaximum(std::numeric_limits<PixelType>::max());
+    d->intensityOutputMinimumValue->setMinimum(std::numeric_limits<PixelType>::min());
+    d->intensityOutputMinimumValue->setMaximum(std::numeric_limits<PixelType>::max());
+    d->intensityOutputMaximumValue->setMinimum(std::numeric_limits<PixelType>::min());
+    d->intensityOutputMaximumValue->setMaximum(std::numeric_limits<PixelType>::max());
+
+    return DTK_SUCCEED;
 }
 
 void itkFiltersToolBox::setupItkAddProcess()

--- a/src-plugins/itkFilters/itkFiltersToolBox.h
+++ b/src-plugins/itkFilters/itkFiltersToolBox.h
@@ -42,6 +42,8 @@ public slots:
     void run();
 
 private:
+    template <typename ImageType> int setupSpinBoxValues(medAbstractData*);
+
     void setupItkAddProcess();
     void setupItkSubtractProcess();
     void setupItkMultiplyProcess();

--- a/src-plugins/itkFilters/itkFiltersWindowingProcess.h
+++ b/src-plugins/itkFilters/itkFiltersWindowingProcess.h
@@ -39,7 +39,7 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class PixelType> int updateProcess();
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkFiltersWindowingProcessPrivate *d;

--- a/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.h
+++ b/src-plugins/itkFilters/itkMorphologicalFiltersProcessBase.h
@@ -38,8 +38,8 @@ public slots:
     int tryUpdate();
 
 protected:
-    template <class ImageType> void convertMmInPixels();
-    template <class PixelType> int updateProcess();
+    template <class ImageType> void convertMmInPixels(ImageType* image);
+    template <class ImageType> int updateProcess(medAbstractData* inputData);
 
 private:
     itkMorphologicalFiltersProcessBasePrivate *d;

--- a/src-plugins/itkN4BiasCorrection/itkN4BiasCorrection.cpp
+++ b/src-plugins/itkN4BiasCorrection/itkN4BiasCorrection.cpp
@@ -18,6 +18,7 @@
 
 #include <medAbstractProcess.h>
 #include <medAbstractDataFactory.h>
+#include <medUtilitiesITK.h>
 
 
 #include "itkN4BiasCorrection_p.h"
@@ -88,52 +89,7 @@ int itkN4BiasCorrection::update()
 
     if (d->input)
     {
-        QString id = d->input->identifier();
-
-        if ( id == "itkDataImageChar3" )
-        {
-            res = d->update<char>();
-        }
-        else if ( id == "itkDataImageUChar3" )
-        {
-            res = d->update<unsigned char>();
-        }
-        else if ( id == "itkDataImageShort3" )
-        {
-            res = d->update<short>();
-        }
-        else if ( id == "itkDataImageUShort3" )
-        {
-            res = d->update<unsigned short>();
-        }
-        else if ( id == "itkDataImageInt3" )
-        {
-            res = d->update<int>();
-        }
-        else if ( id == "itkDataImageUInt3" )
-        {
-            res = d->update<unsigned int>();
-        }
-        else if ( id == "itkDataImageLong3" )
-        {
-            res = d->update<long>();
-        }
-        else if ( id== "itkDataImageULong3" )
-        {
-            res = d->update<unsigned long>();
-        }
-        else if ( id == "itkDataImageFloat3" )
-        {
-            res = d->update<float>();
-        }
-        else if ( id == "itkDataImageDouble3" )
-        {
-            res = d->update<double>();
-        }
-        else
-        {
-            res = medAbstractProcess::PIXEL_TYPE;
-        }
+        res = DISPATCH_ON_3D_PIXEL_TYPE(&itkN4BiasCorrectionPrivate::update, d, d->input);
     }
 
     return res;

--- a/src-plugins/medBinaryOperation/itkNotOperator.h
+++ b/src-plugins/medBinaryOperation/itkNotOperator.h
@@ -30,7 +30,7 @@ public:
     static bool registered();
 
     int update();
-    template <class ImageType> int run();
+    template <class ImageType> int run(medAbstractData* inputData);
 
 public slots:
     

--- a/src-plugins/reformat/resampleProcess.h
+++ b/src-plugins/reformat/resampleProcess.h
@@ -24,7 +24,7 @@ public:
         //! The output will be available through here
         medAbstractData *output(void);
 private:
-    template <class ImageType> void resample(const char * str);
+    template <class ImageType> int resample(medAbstractData* inputData);
     resampleProcessPrivate *d;
 };
 dtkAbstractProcess *createResampleProcess();

--- a/src/medUtilities/medUtilitiesITK.cpp
+++ b/src/medUtilities/medUtilitiesITK.cpp
@@ -28,3 +28,123 @@ double medUtilitiesITK::volume(dtkSmartPointer<medAbstractData> data)
     statsProcess.update();
     return statsProcess.output().at(0);
 }
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageChar3>()
+{
+    return "itkDataImageChar3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageChar4>()
+{
+    return "itkDataImageChar4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageUChar3>()
+{
+    return "itkDataImageUChar3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageUChar4>()
+{
+    return "itkDataImageUChar4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageShort3>()
+{
+    return "itkDataImageShort3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageShort4>()
+{
+    return "itkDataImageShort4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageUShort3>()
+{
+    return "itkDataImageUShort3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageUShort4>()
+{
+    return "itkDataImageUShort4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageInt3>()
+{
+    return "itkDataImageInt3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageInt4>()
+{
+    return "itkDataImageInt4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageUInt3>()
+{
+    return "itkDataImageUInt3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageUInt4>()
+{
+    return "itkDataImageUInt4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageLong3>()
+{
+    return "itkDataImageLong3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageLong4>()
+{
+    return "itkDataImageLong4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageULong3>()
+{
+    return "itkDataImageULong3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageULong4>()
+{
+    return "itkDataImageULong4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageFloat3>()
+{
+    return "itkDataImageFloat3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageFloat4>()
+{
+    return "itkDataImageFloat4";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageDouble3>()
+{
+    return "itkDataImageDouble3";
+}
+
+template <>
+QString medUtilitiesITK::itkDataImageId<medUtilitiesITK::itkImageDouble4>()
+{
+    return "itkDataImageDouble4";
+}

--- a/src/medUtilities/medUtilitiesITK.h
+++ b/src/medUtilities/medUtilitiesITK.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <dtkCore/dtkSmartPointer>
+#include <itkImage.h>
+#include <medAbstractProcess.h>
 #include <medUtilities.h>
 #include <medUtilitiesExport.h>
 
@@ -25,4 +27,175 @@ public:
     static double maximumValue(dtkSmartPointer<medAbstractData> data);
 
     static double volume(dtkSmartPointer<medAbstractData> data);
+
+    typedef itk::Image<char, 3> itkImageChar3;
+    typedef itk::Image<unsigned char, 3> itkImageUChar3;
+    typedef itk::Image<short, 3> itkImageShort3;
+    typedef itk::Image<unsigned short, 3> itkImageUShort3;
+    typedef itk::Image<int, 3> itkImageInt3;
+    typedef itk::Image<unsigned int, 3> itkImageUInt3;
+    typedef itk::Image<long, 3> itkImageLong3;
+    typedef itk::Image<unsigned long, 3> itkImageULong3;
+    typedef itk::Image<float, 3> itkImageFloat3;
+    typedef itk::Image<double, 3> itkImageDouble3;
+    typedef itk::Image<char, 4> itkImageChar4;
+    typedef itk::Image<unsigned char, 4> itkImageUChar4;
+    typedef itk::Image<short, 4> itkImageShort4;
+    typedef itk::Image<unsigned short, 4> itkImageUShort4;
+    typedef itk::Image<int, 4> itkImageInt4;
+    typedef itk::Image<unsigned int, 4> itkImageUInt4;
+    typedef itk::Image<long, 4> itkImageLong4;
+    typedef itk::Image<unsigned long, 4> itkImageULong4;
+    typedef itk::Image<float, 4> itkImageFloat4;
+    typedef itk::Image<double, 4> itkImageDouble4;
+
+    /** Identifier of the class used to store a specific itk image type, to be used with dtkAbstractDataFactory
+     */
+    template <typename ImageType> static QString itkDataImageId();
+
+    template <typename TargetClass, typename... OtherArguments>
+    static int dispatchOn3DPixelType(int (TargetClass::*char3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*uchar3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*short3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*ushort3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*int3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*uint3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*long3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*ulong3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*float3Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*double3Function)(medAbstractData*, OtherArguments...),
+                                     TargetClass* targetInstance,
+                                     medAbstractData* inputData,
+                                     OtherArguments... otherArgs)
+    {
+        int result;
+
+        if (callPixelSpecificFunction<TargetClass, itkImageChar3, OtherArguments...>(char3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageUChar3, OtherArguments...>(uchar3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageShort3, OtherArguments...>(short3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageUShort3, OtherArguments...>(ushort3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageInt3, OtherArguments...>(int3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageUInt3, OtherArguments...>(uint3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageLong3, OtherArguments...>(long3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageULong3, OtherArguments...>(ulong3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageFloat3, OtherArguments...>(float3Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageDouble3, OtherArguments...>(double3Function, targetInstance, &result, inputData, otherArgs...))
+        {
+            return result;
+        }
+        else
+        {
+            return medAbstractProcess::PIXEL_TYPE;
+        }
+    }
+
+    template <typename TargetClass, typename... OtherArguments>
+    static int dispatchOn4DPixelType(int (TargetClass::*char4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*uchar4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*short4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*ushort4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*int4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*uint4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*long4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*ulong4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*float4Function)(medAbstractData*, OtherArguments...),
+                                     int (TargetClass::*double4Function)(medAbstractData*, OtherArguments...),
+                                     TargetClass* targetInstance,
+                                     medAbstractData* inputData,
+                                     OtherArguments... otherArgs)
+    {
+        int result;
+
+        if (callPixelSpecificFunction<TargetClass, itkImageChar4, OtherArguments...>(char4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageUChar4, OtherArguments...>(uchar4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageShort4, OtherArguments...>(short4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageUShort4, OtherArguments...>(ushort4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageInt4, OtherArguments...>(int4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageUInt4, OtherArguments...>(uint4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageLong4, OtherArguments...>(long4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageULong4, OtherArguments...>(ulong4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageFloat4, OtherArguments...>(float4Function, targetInstance, &result, inputData, otherArgs...)
+            || callPixelSpecificFunction<TargetClass, itkImageDouble4, OtherArguments...>(double4Function, targetInstance, &result, inputData, otherArgs...))
+        {
+            return result;
+        }
+        else
+        {
+            return medAbstractProcess::PIXEL_TYPE;
+        }
+    }
+
+private:
+
+    template <typename TargetClass, typename ImageType, typename... OtherArguments>
+    static bool callPixelSpecificFunction(int (TargetClass::*function)(medAbstractData*, OtherArguments...),
+                                          TargetClass* targetInstance, int* result, medAbstractData* inputData, OtherArguments... otherArgs)
+    {
+        if ((function != nullptr) && (inputData->identifier().startsWith("itkDataImage")))
+        {
+            ImageType* image = dynamic_cast<ImageType*>(static_cast<itk::ImageBase<ImageType::ImageDimension>*>(inputData->data()));
+
+            if (image)
+            {
+                *result = (targetInstance->*function)(inputData, otherArgs...);
+                return true;
+            }
+        }
+
+        return false;
+    }
 };
+
+
+/** Call a function templated over the pixel type of an ITK image
+ *  This macro will only check for 3D pixel types. The function signature must be of the form
+ *  @code
+ *  template<ImageType> int function(medAbstractData*, ...)
+ *  @endcode
+ *  where ImageType is the ITK type, the first argument is the data containing the image and ... may be zero or more arguments of any type.
+ *  @param function a pointer to a member function (see signature above)
+ *  @param instance the instance on which to invoke the function
+ *  @param ... the arguments to the function
+ *  @return the return value of the function or medAbstractProcess::PIXEL_TYPE if the pixel type was not handled
+ */
+#define DISPATCH_ON_3D_PIXEL_TYPE(function, instance, ...) \
+    medUtilitiesITK::dispatchOn3DPixelType( \
+    function<medUtilitiesITK::itkImageChar3>, \
+    function<medUtilitiesITK::itkImageUChar3>, \
+    function<medUtilitiesITK::itkImageShort3>, \
+    function<medUtilitiesITK::itkImageUShort3>, \
+    function<medUtilitiesITK::itkImageInt3>, \
+    function<medUtilitiesITK::itkImageUInt3>, \
+    function<medUtilitiesITK::itkImageLong3>, \
+    function<medUtilitiesITK::itkImageULong3>, \
+    function<medUtilitiesITK::itkImageFloat3>, \
+    function<medUtilitiesITK::itkImageDouble3>, \
+    (instance), \
+    __VA_ARGS__)
+
+
+/** Call a function templated over the pixel type of an ITK image
+ *  This macro will only check for 4D pixel types. The function signature must be of the form
+ *  @code
+ *  template<ImageType> int function(medAbstractData*, ...)
+ *  @endcode
+ *  where ImageType is the ITK type, the first argument is the data containing the image and ... may be zero or more arguments of any type.
+ *  @param function a pointer to a member function (see signature above)
+ *  @param instance the instance on which to invoke the function
+ *  @param ... the arguments to the function
+ *  @return the return value of the function or medAbstractProcess::PIXEL_TYPE if the pixel type was not handled
+ */
+#define DISPATCH_ON_4D_PIXEL_TYPE(function, instance, ...) \
+    medUtilitiesITK::dispatchOn4DPixelType( \
+    function<medUtilitiesITK::itkImageChar4>, \
+    function<medUtilitiesITK::itkImageUChar4>, \
+    function<medUtilitiesITK::itkImageShort4>, \
+    function<medUtilitiesITK::itkImageUShort4>, \
+    function<medUtilitiesITK::itkImageInt4>, \
+    function<medUtilitiesITK::itkImageUInt4>, \
+    function<medUtilitiesITK::itkImageLong4>, \
+    function<medUtilitiesITK::itkImageULong4>, \
+    function<medUtilitiesITK::itkImageFloat4>, \
+    function<medUtilitiesITK::itkImageDouble4>, \
+    (instance), \
+    __VA_ARGS__)


### PR DESCRIPTION
_(I'm currently testing all the processes affected by this PR but it can still be reviewed in the meantime)_

This PR simplifies the code that dispatches calls to functions based on the pixel type of one image (I have other ideas for the cases that dispatch on two image types).

For example, the following code:
```
    if ( getInputData() )
    {
        QString id = getInputData()->identifier();

        if ( id == "itkDataImageChar3" )
        {
            res = updateProcess<char>();
        }
        else if ( id == "itkDataImageUChar3" )
        {
            res = updateProcess<unsigned char>();
        }
        else if ( id == "itkDataImageShort3" )
        {
            res = updateProcess<short>();
        }
        else if ( id == "itkDataImageUShort3" )
        {
            res = updateProcess<unsigned short>();
        }
        else if ( id == "itkDataImageInt3" )
        {
            res = updateProcess<int>();
        }
        else if ( id == "itkDataImageUInt3" )
        {
            res = updateProcess<unsigned int>();
        }
        else if ( id == "itkDataImageLong3" )
        {
            res = updateProcess<long>();
        }
        else if ( id== "itkDataImageULong3" )
        {
            res = updateProcess<unsigned long>();
        }
        else if ( id == "itkDataImageFloat3" )
        {
            res = updateProcess<float>();
        }
        else if ( id == "itkDataImageDouble3" )
        {
            res = updateProcess<double>();
        }
        else
        {
            res = medAbstractProcess::PIXEL_TYPE;
        }
    }
```

becomes:
```
res = DISPATCH_ON_3D_PIXEL_TYPE(&itkFiltersAddProcess::updateProcess, this, getInputData());
```

(with some modifications to ```updateProcess``` too).

The two macros ```DISPATCH_ON_3D_PIXEL_TYPE``` and ```DISPATCH_ON_4D_PIXEL_TYPE``` will manually check the pixel type and call the correct function. The function must be of the form:
```
template<ImageType> int function(medAbstractData*, ...)
```

where:
- ```ImageType``` is the ITK type (e.g. ```itk::Image<char, 3>```)
- The first parameter is the data containing the image
- There may be one or more additional arguments of any type.

For example, you could write a function that multiplies the values of the pixels by a factor. The function template would be:
```
template <ImageType> multiplyPixels(medAbstractData* image, double factor)
```

and to call the function on an image stored in ```data```, you could write:
```
result = DISPATCH_ON_3D_PIXEL_TYPE(&MyClass::multiplyPixels, this, data, 3.0);
```

(In this example, the call would be made from inside ```MyClass``` which is why I put ```this```)
If the pixel type is not handled, ```medAsbtractProcess::PIXEL_TYPE``` is returned, otherwise the return value of ```multiplyPixels``` is used.