### PR TITLE
Put back ITKTensor links

### DIFF
--- a/src-plugins/itkDataDiffusionGradientList/CMakeLists.txt
+++ b/src-plugins/itkDataDiffusionGradientList/CMakeLists.txt
@@ -73,6 +73,7 @@ target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   ${DTK_LIBRARIES}
   ${ITK_LIBRARIES}
+  ITKTensor
   medCore
   medLog
   )

--- a/src-plugins/itkDataTensorImage/CMakeLists.txt
+++ b/src-plugins/itkDataTensorImage/CMakeLists.txt
@@ -88,6 +88,7 @@ target_link_libraries(${PROJECT_NAME}
   ${QT_LIBRARIES}
   ${DTK_LIBRARIES}
   ${ITK_LIBRARIES}
+  ITKTensor
   medCore
   medLog
   medVtkInria


### PR DESCRIPTION
The removal of ITKTensor from the list of libraries in two plugins caused _undefined symbols_ issues with ```itk::GradientFileReader```. ITKTensor is not provided by ITK but by TTK, so it cannot be replaced with ```ITK_LIBRARIES```.