### PR TITLE
[Theme] adjust text color in QDialog for light theme

### DIFF
--- a/app/medInria/resources/music_light.qss
+++ b/app/medInria/resources/music_light.qss
@@ -1441,3 +1441,17 @@ QScrollArea
 {
     background: $GREY_VERY_LIGHT;
 }
+
+/*******************************************************************************
+     QDialog & cie
+ *******************************************************************************/
+
+ QFileDialog
+ {
+     background: $GREY_VERY_LIGHT;
+ }
+
+ QDialog
+ {
+     background: $GREY_VERY_LIGHT;
+ }


### PR DESCRIPTION
fixes https://github.com/Inria-Asclepios/medInria-public/issues/491

The backgrounds of QDialog and QFileDialog are different from text area in it. 

For instance, it can be seen in the Metadata and Edit dialogs on a data, and in the "Open a file from your system" and "Open a scene from your system" QFileDialogs in a view.

:m: