### PR TITLE
[medAbstractView] Add dockable widgets

### DIFF
--- a/src-plugins/medVtkView/medVtkView.cpp
+++ b/src-plugins/medVtkView/medVtkView.cpp
@@ -86,6 +86,8 @@ public:
     QScopedPointer<medVtkViewBackend> backend;
 
     QPointer<medClutEditorToolBox> transFun;
+
+    QMainWindow* mainWindow;
 };
 
 medVtkView::medVtkView(QObject* parent): medAbstractImageView(parent),
@@ -141,6 +143,9 @@ medVtkView::medVtkView(QObject* parent): medAbstractImageView(parent),
     d->viewWidget->setFocusPolicy(Qt::ClickFocus );
     d->viewWidget->SetRenderWindow(d->renWin);
     d->viewWidget->setCursor(QCursor(Qt::CrossCursor));
+
+    d->mainWindow = new QMainWindow();
+    d->mainWindow->setCentralWidget(d->viewWidget);
 
     d->backend.reset(new medVtkViewBackend(d->view2d, d->view3d, d->renWin));
 
@@ -238,6 +243,11 @@ QString medVtkView::description() const
 QWidget* medVtkView::viewWidget()
 {
     return d->viewWidget;
+}
+
+QMainWindow* medVtkView::mainWindow()
+{
+    return d->mainWindow;
 }
 
 void medVtkView::reset()

--- a/src-plugins/medVtkView/medVtkView.h
+++ b/src-plugins/medVtkView/medVtkView.h
@@ -37,6 +37,8 @@ public:
     virtual medViewBackend * backend() const;
     virtual QString description() const;
     virtual QWidget *viewWidget();
+    virtual QMainWindow* mainWindow();
+
     virtual QPointF mapWorldToDisplayCoordinates(const QVector3D & worldVec );
     virtual QVector3D mapDisplayToWorldCoordinates(const QPointF & scenePoint );
     virtual QVector3D viewCenter();

--- a/src/medCore/gui/viewContainers/medViewContainer.cpp
+++ b/src/medCore/gui/viewContainers/medViewContainer.cpp
@@ -420,7 +420,14 @@ void medViewContainer::setView(medAbstractView *view)
 {
     if(d->view)
     {
-        d->view->viewWidget()->hide();
+        if (d->view->mainWindow())
+        {
+            d->view->mainWindow()->hide();
+        }
+        else
+        {
+            d->view->viewWidget()->hide();
+        }
         this->removeInternView();
     }
     if(view)
@@ -452,9 +459,15 @@ void medViewContainer::setView(medAbstractView *view)
 
         d->saveSceneAction->setEnabled(true);
         d->defaultWidget->hide();
-        d->mainLayout->addWidget(d->view->viewWidget(), 2, 0, 1, 1);
-        d->view->viewWidget()->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::MinimumExpanding);
-        d->view->viewWidget()->show();
+
+        QWidget* mainWidget = d->view->mainWindow();
+        if (!mainWidget)
+        {
+            mainWidget = d->view->viewWidget();
+        }
+        d->mainLayout->addWidget(mainWidget, 2, 0, 1, 1);
+        mainWidget->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::MinimumExpanding);
+        mainWidget->show();
 
         emit viewChanged();
     }
@@ -500,6 +513,11 @@ void medViewContainer::highlight(QString color)
     this->setStyleSheet(styleSheet);
     if(d->view)
     {
+        if (d->view->mainWindow())
+        {
+            d->view->mainWindow()->updateGeometry();
+            d->view->mainWindow()->update();
+        }
         d->view->viewWidget()->updateGeometry();
         d->view->viewWidget()->update();
     }
@@ -512,6 +530,11 @@ void medViewContainer::unHighlight()
     this->setStyleSheet("medViewContainer {border:1px solid #909090;}");
     if(d->view)
     {
+        if (d->view->mainWindow())
+        {
+            d->view->mainWindow()->updateGeometry();
+            d->view->mainWindow()->update();
+        }
         d->view->viewWidget()->updateGeometry();
         d->view->viewWidget()->update();
     }

--- a/src/medCore/views/medAbstractView.cpp
+++ b/src/medCore/views/medAbstractView.cpp
@@ -451,3 +451,8 @@ QUndoStack* medAbstractView::undoStack() const
 }
 
 void medAbstractView::restoreState(QDomElement* element){}
+
+QMainWindow* medAbstractView::mainWindow()
+{
+    return nullptr;
+}

--- a/src/medCore/views/medAbstractView.h
+++ b/src/medCore/views/medAbstractView.h
@@ -59,6 +59,8 @@ public:
 
     virtual QWidget* navigatorWidget();
     virtual QWidget *viewWidget() = 0;
+    virtual QMainWindow* mainWindow();
+
     virtual QWidget *mouseInteractionWidget();
     virtual QWidget* toolBarWidget();
 


### PR DESCRIPTION
- medVtkView widget is set as the main widget of a new QMainWindow.
 This allows QDockWidgets to be created around the medVtkView.