### PR TITLE
[itkFilters]: add choice of neighborhood size for median filter

### DIFF
--- a/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
@@ -52,11 +52,8 @@ QString itkFiltersMedianProcess::description() const
 
 //-------------------------------------------------------------------------------------------
 
-void itkFiltersMedianProcess::setParameter(double data, int channel)
+void itkFiltersMedianProcess::setParameter(double data)
 {
-    if (channel != 0)
-        return;
-
     d->medianSize = data;
 }
 

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.cpp
@@ -20,11 +20,20 @@
 
 #include <medUtilitiesITK.h>
 
+class itkFiltersMedianProcessPrivate
+{
+public:
+    double medianSize;
+};
+
+const double itkFiltersMedianProcess::defaultMedianSize = 1.0;
+
 //-------------------------------------------------------------------------------------------
 
 itkFiltersMedianProcess::itkFiltersMedianProcess(itkFiltersMedianProcess *parent) 
-    : itkFiltersProcessBase(parent)
+    : itkFiltersProcessBase(parent), d(new itkFiltersMedianProcessPrivate)
 {
+    d->medianSize = defaultMedianSize;
 }
 
 //-------------------------------------------------------------------------------------------
@@ -39,6 +48,16 @@ bool itkFiltersMedianProcess::registered( void )
 QString itkFiltersMedianProcess::description() const
 {
     return tr("ITK median filter");
+}
+
+//-------------------------------------------------------------------------------------------
+
+void itkFiltersMedianProcess::setParameter(double data, int channel)
+{
+    if (channel != 0)
+        return;
+
+    d->medianSize = data;
 }
 
 //-------------------------------------------------------------------------------------------
@@ -62,7 +81,11 @@ int itkFiltersMedianProcess::updateProcess(medAbstractData* inputData)
 
     typedef itk::MedianImageFilter< ImageType, ImageType >  MedianFilterType;
     typename MedianFilterType::Pointer medianFilter = MedianFilterType::New();
+    typename MedianFilterType::InputSizeType radius;
 
+    radius.Fill(d->medianSize);
+
+    medianFilter->SetRadius(radius);
     medianFilter->SetInput(inputImage);
 
     itk::CStyleCommand::Pointer callback = itk::CStyleCommand::New();
@@ -75,7 +98,8 @@ int itkFiltersMedianProcess::updateProcess(medAbstractData* inputData)
     getOutputData()->setData ( medianFilter->GetOutput() );
 
     //Set output description metadata
-    medUtilities::setDerivedMetaData(getOutputData(), inputData, "median filter");
+    QString newSeriesDescription = "median filter " + QString::number(d->medianSize);
+    medUtilities::setDerivedMetaData(getOutputData(), inputData, newSeriesDescription);
 
     return DTK_SUCCEED;
 }

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.h
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.h
@@ -33,7 +33,7 @@ public:
     
 public slots:
 
-    void setParameter ( double  data, int channel );
+    void setParameter (double  data);
     int tryUpdate();
 
 protected:

--- a/src-plugins/itkFilters/itkFiltersMedianProcess.h
+++ b/src-plugins/itkFilters/itkFiltersMedianProcess.h
@@ -15,6 +15,7 @@
 
 #include <itkFiltersProcessBase.h>
 
+class itkFiltersMedianProcessPrivate;
 class medAbstractData;
 
 class ITKFILTERSPLUGIN_EXPORT itkFiltersMedianProcess : public itkFiltersProcessBase
@@ -22,6 +23,8 @@ class ITKFILTERSPLUGIN_EXPORT itkFiltersMedianProcess : public itkFiltersProcess
     Q_OBJECT
     
 public:
+    static const double defaultMedianSize;
+
     itkFiltersMedianProcess(itkFiltersMedianProcess * parent = 0);
 
     static bool registered ( void );
@@ -30,10 +33,15 @@ public:
     
 public slots:
 
+    void setParameter ( double  data, int channel );
     int tryUpdate();
 
 protected:
     template <class ImageType> int updateProcess(medAbstractData* inputData);
+
+private:
+    itkFiltersMedianProcessPrivate *d;
+
 };
 
 dtkAbstractProcess * createitkFiltersMedianProcess(void);

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -506,7 +506,7 @@ void itkFiltersToolBox::setupItkGaussianProcess()
 void itkFiltersToolBox::setupItkMedianProcess()
 {
     d->process = dtkAbstractProcessFactory::instance()->createSmartPointer ( "itkMedianProcess" );
-    d->process->setParameter ( d->medianSizeFilterValue->value(), 0 );
+    d->process->setParameter ( d->medianSizeFilterValue->value());
     
     if (!d->process)
         return;

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -27,6 +27,7 @@
 #include <itkFiltersComponentSizeThresholdProcess.h>
 #include <itkFiltersDivideProcess.h>
 #include <itkFiltersGaussianProcess.h>
+#include <itkFiltersMedianProcess.h>
 #include <itkFiltersMultiplyProcess.h>
 #include <itkFiltersShrinkProcess.h>
 #include <itkFiltersSubtractProcess.h>
@@ -65,6 +66,7 @@ public:
 
     QDoubleSpinBox * addFilterValue;
     QDoubleSpinBox * subtractFilterValue;
+    QDoubleSpinBox * medianSizeFilterValue;
     QDoubleSpinBox * multiplyFilterValue;
     QDoubleSpinBox * divideFilterValue;
     QDoubleSpinBox * gaussianFilterValue;
@@ -178,7 +180,19 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     normalizeFilterLayout->addWidget(normExplanation);
     d->normalizeFilterWidget->setLayout(normalizeFilterLayout);
 
+    //Median filter widgets
     d->medianFilterWidget = new QWidget(this);
+    d->medianSizeFilterValue = new QDoubleSpinBox;
+    d->medianSizeFilterValue->setMaximum ( 1000000000 );
+    d->medianSizeFilterValue->setValue ( itkFiltersMedianProcess::defaultMedianSize );
+    QLabel * medianSizeFilterLabel = new QLabel ( tr ( "Neighborhood size:" ) );
+    QHBoxLayout * medianSizeFilterLayout = new QHBoxLayout;
+    medianSizeFilterLayout->addWidget ( medianSizeFilterLabel );
+    medianSizeFilterLayout->addWidget ( d->medianSizeFilterValue );
+    medianSizeFilterLayout->addStretch ( 1 );
+    d->medianFilterWidget->setLayout ( medianSizeFilterLayout );
+
+
     d->invertFilterWidget = new QWidget(this);
 
     //Shrink filter widgets
@@ -492,6 +506,7 @@ void itkFiltersToolBox::setupItkGaussianProcess()
 void itkFiltersToolBox::setupItkMedianProcess()
 {
     d->process = dtkAbstractProcessFactory::instance()->createSmartPointer ( "itkMedianProcess" );
+    d->process->setParameter ( d->medianSizeFilterValue->value(), 0 );
     
     if (!d->process)
         return;


### PR DESCRIPTION
- neighborhood size was fixed to 1 it is now possible to choose it. Needed for sock segmentation pipeline 