### PR TITLE
Use popup for error messages

### DIFF
--- a/app/medInria/medDataSourceManager.cpp
+++ b/app/medInria/medDataSourceManager.cpp
@@ -147,7 +147,7 @@ void medDataSourceManager::indexFile(QString path)
 
 void medDataSourceManager::emitDataReceivingFailed(QString fileName)
 {
-  medMessageController::instance()->showError(tr("Unable to get from source the data named ") + fileName, 3000);
+  medMessageController::instance()->showError(tr("Unable to get from source the data named ") + fileName);
 }
 
 medDataSourceManager * medDataSourceManager::instance( void )

--- a/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
+++ b/src-plugins/iterativeClosestPoint/iterativeClosestPointToolBox.cpp
@@ -174,12 +174,12 @@ void iterativeClosestPointToolBox::run()
         }
         else
         {
-            medMessageController::instance()->showError(tr("Choose two meshes"),3000);
+            medMessageController::instance()->showError(tr("Choose two meshes"));
         }
     }
     else
     {
-        medMessageController::instance()->showError(tr("Drop two meshes in the view"),3000);
+        medMessageController::instance()->showError(tr("Drop two meshes in the view"));
     }
 }
 

--- a/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
+++ b/src-plugins/manualRegistration/manualRegistrationLandmarkController.cpp
@@ -217,7 +217,7 @@ void manualRegistrationLandmarkController::AddPoint(manualRegistrationLandmark *
 
     if (size>=128)
     {
-        medMessageController::instance()->showError("You cannot add any more landmarks.",3000);
+        medMessageController::instance()->showError("You cannot add any more landmarks.");
         return;
     }
 
@@ -265,13 +265,13 @@ int manualRegistrationLandmarkController::checkLandmarks()
 {
     if (Points_Fixed->size()!=Points_Moving->size())
     {
-        medMessageController::instance()->showError("The number of landmarks is not the same on both views",3000);
+        medMessageController::instance()->showError("The number of landmarks is not the same on both views");
         return DTK_FAILURE;
     }
 
     if (!Points_Fixed->size())
     {
-        medMessageController::instance()->showError("You didn't put any landmark !",3000);
+        medMessageController::instance()->showError("You didn't put any landmark !");
         return DTK_FAILURE;
     }
 

--- a/src-plugins/medMaskApplication/medMaskApplicationToolBox.cpp
+++ b/src-plugins/medMaskApplication/medMaskApplicationToolBox.cpp
@@ -129,7 +129,7 @@ void medMaskApplicationToolBox::run()
     }
     else
     {
-        medMessageController::instance()->showError(tr("Drop a volume in the view and a mask in the drop area"),3000);
+        medMessageController::instance()->showError(tr("Drop a volume in the view and a mask in the drop area"));
     }
 }
 

--- a/src-plugins/medVtkFibersData/interactors/medVtkFibersDataInteractor.cpp
+++ b/src-plugins/medVtkFibersData/interactors/medVtkFibersDataInteractor.cpp
@@ -525,8 +525,7 @@ void medVtkFibersDataInteractor::setBoxVisibility(bool visible)
 {
     if (d->view && d->view->orientation() != medImageView::VIEW_ORIENTATION_3D)
     {
-        medMessageController::instance()->showError("View must be in 3D mode to activate the bundling box",
-                                                    3000);
+        medMessageController::instance()->showError("View must be in 3D mode to activate the bundling box");
         d->manager->SetBoxWidget(false);
         return;
     }
@@ -1149,7 +1148,7 @@ void medVtkFibersDataInteractor::importROI(const medDataIndex& index)
              data->identifier() != "itkDataImageFloat3" &&
              data->identifier() != "itkDataImageDouble3"))
     {
-        medMessageController::instance()->showError(tr("Unable to load ROI, format not supported yet"), 3000);
+        medMessageController::instance()->showError(tr("Unable to load ROI, format not supported yet"));
         return;
     }
 

--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -991,7 +991,7 @@ void AlgorithmPaintToolBox::updateWandRegion(medAbstractImageView * view, QVecto
             (m_imageData->identifier().contains("Vector"))||
             (m_imageData->identifier().contains("2")))
     {
-        medMessageController::instance()->showError(tr("Magic wand option is only available for 3D images"),3000);
+        medMessageController::instance()->showError(tr("Magic wand option is only available for 3D images"));
         return;
     }
 

--- a/src-plugins/reformat/medCropToolBox.cpp
+++ b/src-plugins/reformat/medCropToolBox.cpp
@@ -434,7 +434,7 @@ void medCropToolBoxPrivate::generateOutput()
         }
         else
         {
-            medMessageController::instance()->showError("Drop a 3D volume in the view",3000);
+            medMessageController::instance()->showError("Drop a 3D volume in the view");
             qDebug()<<"medCropToolBoxPrivate::generateOutput id "<<imageData->identifier();
         }
     }

--- a/src-plugins/reformat/resliceToolBox.cpp
+++ b/src-plugins/reformat/resliceToolBox.cpp
@@ -176,12 +176,12 @@ void resliceToolBox::startReformat()
         }
         else
         {
-            medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
+            medMessageController::instance()->showError(tr("Drop a 3D volume in the view"));
         }
     }
     else
     {
-        medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
+        medMessageController::instance()->showError(tr("Drop a 3D volume in the view"));
     }
 }
 

--- a/src/medCore/database/medDatabaseController.cpp
+++ b/src/medCore/database/medDatabaseController.cpp
@@ -446,7 +446,7 @@ void medDatabaseController::importData( medAbstractData *data, const QUuid & imp
 
 void medDatabaseController::showOpeningError(QObject *sender)
 {
-    medMessageController::instance()->showError("Opening item failed.", 3000);
+    medMessageController::instance()->showError("Opening item failed.");
 }
 
 void medDatabaseController::createPatientTable(void)

--- a/src/medCore/gui/toolboxes/medDiffusionSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medDiffusionSelectorToolBox.cpp
@@ -397,7 +397,7 @@ void medDiffusionSelectorToolBox::setInputGradientFile()
         QString gradCount, imDims;
         gradCount.setNum(gradientList.count()/3);
         imDims.setNum(input->tDimension());
-        medMessageController::instance()->showError("Mismatch between gradient length (" +gradCount + ") and image dimension (" + imDims + ").",3000);
+        medMessageController::instance()->showError("Mismatch between gradient length (" +gradCount + ") and image dimension (" + imDims + ").");
     }
 }
 
@@ -411,7 +411,7 @@ void medDiffusionSelectorToolBox::createProcess()
 
     if ((d->selectorType == Estimation) && (!input->hasMetaData("DiffusionGradientList")))
     {
-        medMessageController::instance()->showError("No diffusion gradient data provided for estimation",3000);
+        medMessageController::instance()->showError("No diffusion gradient data provided for estimation");
         return;
     }
 

--- a/src/medCore/gui/toolboxes/medToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medToolBox.cpp
@@ -352,7 +352,7 @@ void medToolBox::handleDisplayError(int error)
 void medToolBox::displayMessageError(QString error)
 {
     qDebug() << qPrintable(name() + ": " + error);
-    medMessageController::instance()->showError(error,3000);
+    medMessageController::instance()->showError(error);
 }
 
 void medToolBox::setToolBoxOnWaitStatus()

--- a/src/medCore/gui/viewContainers/medViewContainer.cpp
+++ b/src/medCore/gui/viewContainers/medViewContainer.cpp
@@ -1118,5 +1118,5 @@ void medViewContainer::printInConsole(QString message)
 void medViewContainer::displayMessageError(QString message)
 {
     printInConsole(message);
-    medMessageController::instance()->showError(message,3000);
+    medMessageController::instance()->showError(message);
 }

--- a/src/medCore/medMessageController.cpp
+++ b/src/medCore/medMessageController.cpp
@@ -191,18 +191,9 @@ void medMessageController::showInfo(const QString& text,unsigned int timeout)
     }
 }
 
-void medMessageController::showError(const QString& text,unsigned int timeout)
+void medMessageController::showError(const QString& brief, const QString& detailed)
 {
-    if ( dynamic_cast<QApplication *>(QCoreApplication::instance()) ) 
-    {
-        // GUI
-        medMessageError *message = new medMessageError(
-                text,0,timeout);
-        emit addMessage(message);
-
-    } else {
-        dtkError() << text;
-    }
+    emit error(brief, detailed);
 }
 
 medMessageProgress* medMessageController::showProgress(const QString& text)
@@ -226,8 +217,27 @@ void medMessageController::remove(medMessage *message)
     }
 }
 
+void medMessageController::displayPopup(const QString& brief, const QString& detailed)
+{
+    QMessageBox messsageBox;
+
+    // To facilitate the reading of multiline error descriptions, we make sure the
+    // box is wide enough to avoid breaking up the lines.
+    QFontMetrics fontMetrics(messsageBox.font());
+    int textWidth = fontMetrics.boundingRect(detailed).width();
+    QSpacerItem* horizontalSpacer = new QSpacerItem(textWidth, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    QGridLayout* layout = static_cast<QGridLayout*>(messsageBox.layout());
+    layout->addItem(horizontalSpacer, layout->rowCount(), 0, 1, layout->columnCount());
+
+    messsageBox.setText(brief);
+    messsageBox.setInformativeText(detailed);
+    messsageBox.setStandardButtons(QMessageBox::Ok);
+    messsageBox.exec();
+}
+
 medMessageController::medMessageController(void) : QObject()
 {
+    connect(this, SIGNAL(error(QString, QString)), this, SLOT(displayPopup(QString, QString)));
 }
 
 medMessageController::~medMessageController(void)

--- a/src/medCore/medMessageController.h
+++ b/src/medCore/medMessageController.h
@@ -113,15 +113,19 @@ public:
     static medMessageController *instance();
 
 public slots:
-    void     showInfo(const QString& text,unsigned int timeout=0);
-    void     showError(const QString& text,unsigned int timeout=0);
-    medMessageProgress * showProgress(const QString& text);
+    void showInfo(const QString& text,unsigned int timeout=0);
+    void showError(const QString& brief, const QString& detailed = QString());
+    medMessageProgress* showProgress(const QString& text);
 
     void remove(medMessage *message);
 
 signals:
   void addMessage(medMessage * message);
   void removeMessage(medMessage * message);
+  void error(const QString& brief, const QString& detailed);
+
+protected slots:
+  void displayPopup(const QString& brief, const QString& detailed);
 
 protected:
      medMessageController();


### PR DESCRIPTION
I think the way errors are displayed to the users is not clear enough in MUSIC. Many times, while testing, I do not see the red message at the bottom of the window, and I have noticed that clinicians have the same problem. Also, errors are much more important than warnings because they prevent the user from advancing, so the user should not be able to "miss" seeing the error or else they will not understand why things aren't working as expected.
This PR (and the associated changes on other repos) transforms all visible error messages into popups, such as this:

<img width="1680" alt="screen shot 2018-12-10 at 17 19 03" src="https://user-images.githubusercontent.com/7769799/49745974-730d0480-fca0-11e8-83bb-3c7e0207efba.png">

This change may have the consequence that too many popups appear, but that only means that some messages are displayed as errors when they should really be warnings. We can refine things after trying it out.
