### PR TITLE
[Database] Hack to avoid memleak when reading files.

### DIFF
--- a/src/medCore/database/medAbstractDatabaseImporter.cpp
+++ b/src/medCore/database/medAbstractDatabaseImporter.cpp
@@ -722,10 +722,12 @@ dtkSmartPointer<dtkAbstractDataReader> medAbstractDatabaseImporter::getSuitableR
     }
 
     dtkSmartPointer<dtkAbstractDataReader> dataReader;
-    for (int i=0; i<readers.size(); i++) {
+    for (int i=0; i<readers.size(); i++)
+    {
         dataReader = medAbstractDataFactory::instance()->readerSmartPointer(readers[i]);
+        dataReader->enableDeferredDeletion(false);
+
         if (dataReader->canRead(filename)) {
-            dataReader->enableDeferredDeletion(false);
             return dataReader;
         }
     }


### PR DESCRIPTION
- Force the deletion of allocated readers once the pointer gets out of scope. This does not solve the underlying problem, probably related to the event loop of the import job.

- Related to #505 