### PR TITLE
[Closing] add a pop-up to validate exit

### DIFF
--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -706,8 +706,6 @@ int medMainWindow::saveModifiedAndOrValidateClosing()
         saveDialog->exec();
         return saveDialog->result();
     }
-
-    return QDialog::Rejected;
 }
 
 void medMainWindow::availableSpaceOnStatusBar()

--- a/app/medInria/medMainWindow.cpp
+++ b/app/medInria/medMainWindow.cpp
@@ -674,18 +674,40 @@ void medMainWindow::hideShortcutAccess()
     this->activateWindow();
 }
 
-int medMainWindow::saveModified( void )
+int medMainWindow::saveModifiedAndOrValidateClosing()
 {
     QList<medDataIndex> indexes = medDatabaseNonPersistentController::instance()->availableItems();
 
     if(indexes.isEmpty())
-        return QDialog::Accepted;
+    {
+        // No data to save, pop-up window to validate the closing
 
-    medSaveModifiedDialog *saveDialog = new medSaveModifiedDialog(this);
-    saveDialog->show();
-    saveDialog->exec();
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Closing");
+        msgBox.setText("Do you really want to exit?");
+        msgBox.setStandardButtons(QMessageBox::Yes);
+        msgBox.addButton(QMessageBox::No);
+        msgBox.setDefaultButton(QMessageBox::No);
+        if(msgBox.exec() == QMessageBox::Yes)
+        {
+            return QDialog::Accepted;
+        }
+        else
+        {
+            return QDialog::Rejected;
+        }
+    }
+    else
+    {
+        // User is asked to save, cancel or exit without saving temporary data
 
-    return saveDialog->result();
+        medSaveModifiedDialog *saveDialog = new medSaveModifiedDialog(this);
+        saveDialog->show();
+        saveDialog->exec();
+        return saveDialog->result();
+    }
+
+    return QDialog::Rejected;
 }
 
 void medMainWindow::availableSpaceOnStatusBar()
@@ -725,7 +747,7 @@ void medMainWindow::closeEvent(QCloseEvent *event)
             QThreadPool::globalInstance()->waitForDone();
         }
     }
-    if(this->saveModified() != QDialog::Accepted)
+    if(this->saveModifiedAndOrValidateClosing() != QDialog::Accepted)
     {
         event->ignore();
         return;

--- a/app/medInria/medMainWindow.h
+++ b/app/medInria/medMainWindow.h
@@ -116,7 +116,7 @@ private slots:
 protected:
     void closeEvent(QCloseEvent *event);
     void mousePressEvent(QMouseEvent * event);
-    int saveModified();
+    int saveModifiedAndOrValidateClosing();
     bool event(QEvent * e);
 
 private:


### PR DESCRIPTION
Fixes https://github.com/Inria-Asclepios/medInria-public/issues/486

If the user clicks on one of the exit buttons, a message dialog is display to validate the exit. If the database has temporary data, the classic `medSaveModifiedDialog` pop-up is displayed instead.

:m: