### PR TITLE
[Search] add a search toolbox tool

### DIFF
--- a/app/medInria/medMainWindow.h
+++ b/app/medInria/medMainWindow.h
@@ -77,6 +77,7 @@ private slots:
     void captureScreenshot();
     void captureVideo();
 
+    void switchToSearchArea();
     void switchToBrowserArea();
     void switchToWorkspaceArea();
     void switchToHomepageArea();

--- a/app/medInria/mscSearchToolboxDialog.cpp
+++ b/app/medInria/mscSearchToolboxDialog.cpp
@@ -1,0 +1,124 @@
+#include <QtGui>
+#include "mscSearchToolboxDialog.h"
+
+class mscSearchToolboxDialogPrivate
+{
+public:
+    QPushButton *findButton;
+    QLineEdit *lineEdit;
+    QStringList findText;
+    QTreeWidget* tree;
+    QHash<QString, QStringList> toolboxDataHash;
+};
+
+mscSearchToolboxDialog::mscSearchToolboxDialog(QWidget *parent, QHash<QString, QStringList> toolboxDataHash)
+    : QDialog(parent), d (new mscSearchToolboxDialogPrivate)
+{
+    d->findText.clear();
+    d->toolboxDataHash = toolboxDataHash;
+
+    QVBoxLayout *layout = new QVBoxLayout;
+    setLayout(layout);
+
+    setWindowTitle(tr("Find a Toolbox"));
+
+    // Search Bar
+    QHBoxLayout *findLayout = new QHBoxLayout;
+
+    QLabel *findLabel = new QLabel(tr("Enter the name of a toolbox, or a tag"));
+    findLayout->addWidget(findLabel);
+
+    d->lineEdit = new QLineEdit;
+    findLayout->addWidget(d->lineEdit);
+    connect(d->lineEdit, SIGNAL(textChanged(const QString&)), this, SLOT(searchTextChanged(const QString&)));
+
+    layout->addLayout(findLayout);
+
+    // Propositions tree
+    QLabel *propositionLabel = new QLabel(tr("Searching list (double-click on a toolbox to open it)"));
+    layout->addWidget(propositionLabel);
+
+    d->tree = new QTreeWidget();
+    d->tree->setFrameStyle(QFrame::NoFrame);
+    d->tree->setAttribute(Qt::WA_MacShowFocusRect, false);
+    d->tree->setUniformRowHeights(true);
+    d->tree->setAlternatingRowColors(true);
+    d->tree->setAnimated(true);
+    d->tree->setSelectionBehavior(QAbstractItemView::SelectRows);
+    d->tree->setSelectionMode(QAbstractItemView::SingleSelection);
+    d->tree->header()->setStretchLastSection(true);
+    d->tree->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    d->tree->setColumnCount(4);
+    layout->addWidget(d->tree);
+
+    // Create tree columns
+    QStringList treeColumns;
+    treeColumns << tr("Name") << tr("Description") << tr("Workspace") << tr("Internal Name");
+    d->tree->setHeaderLabels(treeColumns);
+    d->tree->setColumnWidth(0, 200);
+    d->tree->setColumnWidth(1, 400);
+    d->tree->setColumnWidth(2, 100);
+    d->tree->setColumnWidth(3, 100);
+    layout->addWidget(d->tree);
+
+    // Populate the tree
+    int cpt = 0;
+    foreach (auto current, toolboxDataHash)
+    {
+        QTreeWidgetItem * item = new QTreeWidgetItem(d->tree);
+        item->setText(0, current.at(0));
+        item->setText(1, current.at(1));
+        item->setText(2, current.at(2));
+        item->setText(3, current.at(3));
+        d->tree->addTopLevelItem(item);
+        cpt++;
+    }
+
+    d->tree->setSortingEnabled(true);
+    d->tree->sortByColumn(0, Qt::AscendingOrder);
+    d->tree->setFixedSize(700,600);
+
+    connect(d->tree, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(searchItemDoubleClicked(QTreeWidgetItem*, int)));
+}
+
+mscSearchToolboxDialog::~mscSearchToolboxDialog()
+{
+    delete d;
+}
+
+void mscSearchToolboxDialog::searchTextChanged(const QString& text)
+{
+    // List of items which match the search text
+    QList<QTreeWidgetItem*> clist = d->tree->findItems(text, Qt::MatchContains|Qt::MatchRecursive, 0);
+
+    // First we hide every item from the list
+    QList<QTreeWidgetItem *> allItems = d->tree->findItems(
+                QString("*"), Qt::MatchWrap | Qt::MatchWildcard | Qt::MatchRecursive);
+    foreach(QTreeWidgetItem* item, allItems)
+    {
+        item->setHidden(true);
+    }
+
+    // Then we show only matching items
+    foreach(QTreeWidgetItem* item, clist)
+    {
+        item->setHidden(false);
+    }
+}
+
+void mscSearchToolboxDialog::searchItemDoubleClicked(QTreeWidgetItem* item, int column)
+{
+    Q_UNUSED(column);
+    QStringList res;
+    res.append(item->text(0));
+    res.append(item->text(1));
+    res.append(item->text(2));
+    res.append(item->text(3));
+    d->findText = res;
+    accept();
+}
+
+QStringList mscSearchToolboxDialog::getFindText()
+{
+    return d->findText;
+}

--- a/app/medInria/mscSearchToolboxDialog.h
+++ b/app/medInria/mscSearchToolboxDialog.h
@@ -1,0 +1,36 @@
+#ifndef mscSearchToolboxDialog_H
+#define mscSearchToolboxDialog_H
+
+#include <QDialog>
+#include <QTreeWidget>
+
+class QLineEdit;
+class QPushButton;
+class mscSearchToolboxDialogPrivate;
+
+class mscSearchToolboxDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    mscSearchToolboxDialog(QWidget *parent, QHash<QString, QStringList> toolboxDataHash);
+    virtual ~mscSearchToolboxDialog();
+    QStringList getFindText();
+
+protected slots:
+    /**
+     * @brief searchTextChanged is called when the user write something in the search bar.
+     * The according items are hidden and shown in the tree.
+     */
+    void searchTextChanged(const QString& text);
+
+    /**
+     * @brief searchItemDoubleClicked is called when the user double-click on an item.
+     * The according workspace is opened.
+     */
+    void searchItemDoubleClicked(QTreeWidgetItem* item, int column);
+
+private:
+    mscSearchToolboxDialogPrivate *d;
+};
+#endif

--- a/app/medInria/resources/music_light.qss
+++ b/app/medInria/resources/music_light.qss
@@ -545,6 +545,11 @@ QComboBox QAbstractItemView
     outline: 0px;
 }
 
+QComboBox QAbstractItemView::disabled
+{
+    color:$BLUE_VERY_LIGHT;
+}
+
 /*******************************************************************************
      QCheckBox
  *******************************************************************************/

--- a/src/medCore/gui/commonWidgets/medQuickAccessMenu.h
+++ b/src/medCore/gui/commonWidgets/medQuickAccessMenu.h
@@ -32,6 +32,8 @@ public:
     
     void switchToCurrentlySelected ();
     
+    void manuallyClickOnWorkspaceButton(QString workspaceName);
+
 protected:
     void focusOutEvent(QFocusEvent * event);
     
@@ -50,6 +52,7 @@ signals:
     void homepageSelected();
     void browserSelected();
     void workspaceSelected(QString);
+    void searchSelected();
 
 private:
     int currentSelected;

--- a/src/medCore/gui/settingsWidgets/medStartupSettingsWidget.cpp
+++ b/src/medCore/gui/settingsWidgets/medStartupSettingsWidget.cpp
@@ -51,6 +51,8 @@ medStartupSettingsWidget::medStartupSettingsWidget(QWidget *parent) :
     QList<medWorkspaceFactory::Details*> workspaceDetails = medWorkspaceFactory::instance()->workspaceDetailsSortedByName();
 
     d->defaultStartingArea = new QComboBox(this);
+    d->defaultStartingArea->addItem(tr("Search"));
+    d->defaultStartingArea->setItemData(0, 0, Qt::UserRole - 1); // Search is disabled
     d->defaultStartingArea->addItem(tr("Homepage"));
     d->defaultStartingArea->addItem(tr("Browser"));
     foreach ( medWorkspaceFactory::Details* detail, workspaceDetails )
@@ -84,8 +86,8 @@ void medStartupSettingsWidget::read()
     medSettingsManager * mnger = medSettingsManager::instance();
     d->startInFullScreen->setChecked(mnger->value("startup", "fullscreen").toBool());
 
-    //if nothing is configured then Browser is the default area
-    int index = mnger->value("startup", "default_starting_area", 0).toInt();
+    //if nothing is configured then Homepage is the default area
+    int index = mnger->value("startup", "default_starting_area", 1).toInt();
 
     // clamp range
     if (index < 0)

--- a/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medSelectorToolBox.cpp
@@ -152,6 +152,18 @@ void medSelectorToolBox::changeCurrentToolBox(const QString &identifier)
     }
 }
 
+int medSelectorToolBox::getIndexOfToolBox(const QString &toolboxName)
+{
+    for (int i=0; i<d->chooseComboBox->count(); ++i)
+    {
+        if(d->chooseComboBox->itemText(i) == toolboxName)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
 medAbstractData* medSelectorToolBox::data()
 {
     return d->inputData;

--- a/src/medCore/gui/toolboxes/medSelectorToolBox.h
+++ b/src/medCore/gui/toolboxes/medSelectorToolBox.h
@@ -42,6 +42,8 @@ public:
      */
     medComboBox* comboBox();
 
+    int getIndexOfToolBox(const QString &toolboxName);
+
 signals:
     void inputChanged();
     void currentToolBoxChanged();


### PR DESCRIPTION
For https://github.com/Inria-Asclepios/music/issues/673

Add a tool in the quickAccessMenu to choose a toolbox, then display the workspace and the toolbox. Easier for user to find a tool.

The button clicked:
![capture d ecran_2019-01-10_16-44-48](https://user-images.githubusercontent.com/3910352/50979804-91605d00-14f7-11e9-962f-cb4a5972af93.png)

The search window. The user has written "hi" and the tool is update automatically with the list of toolboxes which contain "hi" in their name/description/workspace/internal name. If the user double-click on the "Histogram Matching" line for instance here, the Filtering is opened with this toolbox.

![capture d ecran_2019-01-10_16-46-02](https://user-images.githubusercontent.com/3910352/50979809-93c2b700-14f7-11e9-8f20-cceda82708dc.png)

:m: