### PR TITLE
[MPEG2] rm : library not stable

### DIFF
--- a/src-plugins/mscExportVideo/mscExportVideo.cpp
+++ b/src-plugins/mscExportVideo/mscExportVideo.cpp
@@ -6,7 +6,6 @@
 #include <vtkImageCanvasSource2D.h>
 #include <vtkImageData.h>
 #include <vtkJPEGWriter.h>
-#include <vtkMPEG2Writer.h>
 #include <vtkOggTheoraWriter.h>
 #include <vtkQImageToImageSource.h>
 #include <vtkSmartPointer.h>
@@ -227,14 +226,6 @@ int ExportVideo::exportAsVideo()
 
         writerVideo = writerVideoTmp;
     }
-    else if (d->format == MPEG2)
-    {
-        vtkSmartPointer<vtkMPEG2Writer> writerVideoTmp = vtkSmartPointer<vtkMPEG2Writer>::New();
-        writerVideoTmp->SetInputConnection(source->GetOutputPort());
-        writerVideoTmp->SetFileName(d->filename.toStdString().c_str());
-
-        writerVideo = writerVideoTmp;
-    }
 
     writerVideo->Start();
 
@@ -284,7 +275,6 @@ int ExportVideo::displayFileDialog()
     d->formatComboBox->addItem("Ogg Vorbis (.ogv)", 0);
     d->formatComboBox->addItem("JPEG (.jpg .jpeg)", 1);
     d->formatComboBox->addItem("FFMPEG (.avi)", 2);
-    d->formatComboBox->addItem("MPEG2 (.avi)", 3);
     d->formatComboBox->setCurrentIndex(d->format);
     gridbox->addWidget(new QLabel("Format", d->exportDialog), gridbox->rowCount()-1, 0);
     gridbox->addWidget(d->formatComboBox, gridbox->rowCount()-1, 1);
@@ -378,18 +368,6 @@ void ExportVideo::handleWidgetDisplayAccordingToType(int index)
         d->exportDialog->selectFile("video.avi");
         d->frameRateSpinBox->show();
         d->frameRateLabel->show();
-        d->subsamplingComboBox->hide();
-        d->subsamplingLabel->hide();
-        d->qualityComboBox->hide();
-        d->qualityLabel->hide();
-        break;
-    }
-    case MPEG2:
-    {
-        // Video
-        d->exportDialog->selectFile("video.avi");
-        d->frameRateSpinBox->hide();
-        d->frameRateLabel->hide();
         d->subsamplingComboBox->hide();
         d->subsamplingLabel->hide();
         d->qualityComboBox->hide();

--- a/src-plugins/mscExportVideo/mscExportVideo.h
+++ b/src-plugins/mscExportVideo/mscExportVideo.h
@@ -25,8 +25,7 @@ public:
     {
         OGGVORBIS,
         JPGBATCH,
-        FFMPEG,
-        MPEG2
+        FFMPEG
     };
 
 public slots:


### PR DESCRIPTION
Need https://github.com/Inria-Asclepios/medinria-superproject/pull/51

Problem seen by @paulineMig here https://github.com/Inria-Asclepios/medInria-public/pull/461 and on Jenkins for linux Ubuntu14 job - at least.

Removal of MPEG2 library which is not stable. FFMPEG works well on several OS.

:m: