### PR TITLE
[Packaging] Fix QtDCM tomfoolery

### DIFF
--- a/src-plugins/qtdcmDataSource/CMakeLists.txt
+++ b/src-plugins/qtdcmDataSource/CMakeLists.txt
@@ -90,6 +90,11 @@ target_link_libraries(${PROJECT_NAME}
   )
   
 if(APPLE)
+  add_custom_command(TARGET ${PROJECT_NAME}
+    POST_BUILD
+    COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change @rpath/lib${QTDCM_LIBS}.dylib ${QTDCM_LIBRARY_DIRS}/lib${QTDCM_LIBS}.dylib ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.dylib
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BIN_DIR}
+  )
   FixDCMTKMacLink(${PROJECT_NAME} ${DCMTK_LIBRARIES})
 endif(APPLE)
 


### PR DESCRIPTION
- Packages on macOS did not contain the libqtdcm. This explains the failure to load the qtdcmDataSource plugin when launching MUSIC.