### PR TITLE
[FIX] VTK_LIBRARIES ITK_LIBRARIES

### DIFF
--- a/src/medUtilities/CMakeLists.txt
+++ b/src/medUtilities/CMakeLists.txt
@@ -66,38 +66,8 @@ ${${PROJECT_NAME}_CFILES})
 target_link_libraries(${PROJECT_NAME}  
   ${OPENGL_LIBRARIES}
   medCore
-  vtkCommon
-  vtkFiltering 
-  vtkRendering
-  vtkWidgets
-  vtkCommon
-  vtkFiltering 
-  vtkRendering
-  vtkWidgets
-  vtkHybrid
-  vtkImaging
-  vtkVolumeRendering
-  vtkGraphics
-  vtkInfovis
-  vtkIO
-  ITKVTK
-  ITKCommon
-  ITKIOPhilipsREC # ITK4 IO libs
-  ITKIOBMP
-  ITKIOBioRad
-  ITKIOHDF5
-  ITKIOGDCM
-  ITKIOGIPL
-  ITKIOGE
-  ITKIOJPEG
-  ITKIOLSM
-  ITKIOMeta
-  ITKIONIFTI
-  ITKIONRRD
-  ITKIOPNG
-  ITKIOStimulate
-  ITKIOVTK
-  ITKIOMRC
+  ${VTK_LIBRARIES}
+  ${ITK_LIBRARIES}
   )
 
 


### PR DESCRIPTION
In MedUtilities CMakeLists.txt : Replace list of vtk & itk libraries with macro VTK_LIBRARIES ITK_LIBRARIES