### PR TITLE
[VideoExport] avi export choose according to OS

### DIFF
--- a/src-plugins/mscExportVideo/mscExportVideo.cpp
+++ b/src-plugins/mscExportVideo/mscExportVideo.cpp
@@ -251,9 +251,9 @@ int ExportVideo::exportAsVideo()
         {
             return medAbstractProcess::FAILURE;
         }
-    }
 #endif
-
+    }
+	
     writerVideo->Start();
 
     foreach (QImage qimage, d->imagesArray)

--- a/src-plugins/mscExportVideo/mscExportVideo.cpp
+++ b/src-plugins/mscExportVideo/mscExportVideo.cpp
@@ -158,7 +158,7 @@ int ExportVideo::update()
                 res = this->exportAsVideo();
             }
 
-            qDebug()<<"### ExportVideo::update END OF ENCODING";
+            qDebug()<<"### ExportVideo::update END OF ENCODING -- "<<res;
 
             return res;
         }
@@ -299,12 +299,12 @@ int ExportVideo::displayFileDialog()
     // The Xiph.Org Foundation decided to create a new set of file extensions and media types to describe different
     // types of content such as .oga for audio only files, .ogv for video with or without sound (including Theora),
     // and .ogx for multiplexed Ogg."
-    d->formatComboBox->addItem("Ogg Vorbis (.ogv)", 0);
-    d->formatComboBox->addItem("JPEG (.jpg .jpeg)", 1);
+    d->formatComboBox->addItem("Ogg Vorbis (.ogv)", OGGVORBIS);
+    d->formatComboBox->addItem("JPEG (.jpg .jpeg)", JPGBATCH);
 #ifdef _WIN32
-    d->formatComboBox->addItem("MPEG2 (.avi)", 2);
+    d->formatComboBox->addItem("MPEG2 (.avi)", MPEG2);
 #else
-    d->formatComboBox->addItem("FFMPEG (.avi)", 2);
+    d->formatComboBox->addItem("FFMPEG (.avi)", FFMPEG);
 #endif
     d->formatComboBox->setCurrentIndex(d->format);
     gridbox->addWidget(new QLabel("Format", d->exportDialog), gridbox->rowCount()-1, 0);
@@ -351,7 +351,7 @@ int ExportVideo::displayFileDialog()
         {
             // Get back chosen parameters
             d->filename = filename;
-            d->format = d->formatComboBox->currentIndex();
+            d->format = d->formatComboBox->itemData(d->formatComboBox->currentIndex()).toInt();
             d->frameRate = d->frameRateSpinBox->value();
             d->subsampling = d->subsamplingComboBox->currentIndex()? false:true;
             d->quality = d->qualityComboBox->currentIndex();

--- a/src-plugins/mscExportVideo/mscExportVideo.cpp
+++ b/src-plugins/mscExportVideo/mscExportVideo.cpp
@@ -2,13 +2,18 @@
 
 #include <dtkCore/dtkAbstractProcessFactory.h>
 
-#include <vtkFFMPEGWriter.h>
 #include <vtkImageCanvasSource2D.h>
 #include <vtkImageData.h>
 #include <vtkJPEGWriter.h>
 #include <vtkOggTheoraWriter.h>
 #include <vtkQImageToImageSource.h>
 #include <vtkSmartPointer.h>
+
+#ifdef _WIN32
+#include <vtkMPEG2Writer.h>
+#else // Linux and Mac
+#include <vtkFFMPEGWriter.h>
+#endif
 
 // /////////////////////////////////////////////////////////////////
 // ExportVideoPrivate
@@ -217,15 +222,37 @@ int ExportVideo::exportAsVideo()
 
         writerVideo = writerVideoTmp;
     }
-    else if (d->format == FFMPEG)
+    else
     {
-        vtkSmartPointer<vtkFFMPEGWriter> writerVideoTmp = vtkSmartPointer<vtkFFMPEGWriter>::New();
-        writerVideoTmp->SetInputConnection(source->GetOutputPort());
-        writerVideoTmp->SetFileName(d->filename.toStdString().c_str());
-        writerVideoTmp->SetRate(d->frameRate);
+#ifdef _WIN32
+        if (d->format == MPEG2)
+        {
+            vtkSmartPointer<vtkMPEG2Writer> writerVideoTmp = vtkSmartPointer<vtkMPEG2Writer>::New();
+            writerVideoTmp->SetInputConnection(source->GetOutputPort());
+            writerVideoTmp->SetFileName(d->filename.toStdString().c_str());
 
-        writerVideo = writerVideoTmp;
+            writerVideo = writerVideoTmp;
+        }
+        else
+        {
+            return medAbstractProcess::FAILURE;
+        }
+#else
+        if (d->format == FFMPEG)
+        {
+            vtkSmartPointer<vtkFFMPEGWriter> writerVideoTmp = vtkSmartPointer<vtkFFMPEGWriter>::New();
+            writerVideoTmp->SetInputConnection(source->GetOutputPort());
+            writerVideoTmp->SetFileName(d->filename.toStdString().c_str());
+            writerVideoTmp->SetRate(d->frameRate);
+
+            writerVideo = writerVideoTmp;
+        }
+        else
+        {
+            return medAbstractProcess::FAILURE;
+        }
     }
+#endif
 
     writerVideo->Start();
 
@@ -274,7 +301,11 @@ int ExportVideo::displayFileDialog()
     // and .ogx for multiplexed Ogg."
     d->formatComboBox->addItem("Ogg Vorbis (.ogv)", 0);
     d->formatComboBox->addItem("JPEG (.jpg .jpeg)", 1);
+#ifdef _WIN32
+    d->formatComboBox->addItem("MPEG2 (.avi)", 2);
+#else
     d->formatComboBox->addItem("FFMPEG (.avi)", 2);
+#endif
     d->formatComboBox->setCurrentIndex(d->format);
     gridbox->addWidget(new QLabel("Format", d->exportDialog), gridbox->rowCount()-1, 0);
     gridbox->addWidget(d->formatComboBox, gridbox->rowCount()-1, 1);
@@ -338,42 +369,54 @@ void ExportVideo::handleWidgetDisplayAccordingToType(int index)
 {
     switch (index)
     {
-    case OGGVORBIS: default:
-    {
-        // Video
-        d->exportDialog->selectFile("video.ogv");
-        d->frameRateSpinBox->show();
-        d->frameRateLabel->show();
-        d->subsamplingComboBox->show();
-        d->subsamplingLabel->show();
-        d->qualityComboBox->show();
-        d->qualityLabel->show();
-        break;
-    }
-    case JPGBATCH:
-    {
-        // JPEG
-        d->exportDialog->selectFile("image0.jpg");
-        d->frameRateSpinBox->hide();
-        d->frameRateLabel->hide();
-        d->subsamplingComboBox->hide();
-        d->subsamplingLabel->hide();
-        d->qualityComboBox->hide();
-        d->qualityLabel->hide();
-        break;
-    }
-    case FFMPEG:
-    {
-        // Video
-        d->exportDialog->selectFile("video.avi");
-        d->frameRateSpinBox->show();
-        d->frameRateLabel->show();
-        d->subsamplingComboBox->hide();
-        d->subsamplingLabel->hide();
-        d->qualityComboBox->hide();
-        d->qualityLabel->hide();
-        break;
-    }
+        case OGGVORBIS: default:
+        {
+            // Video
+            d->exportDialog->selectFile("video.ogv");
+            d->frameRateSpinBox->show();
+            d->frameRateLabel->show();
+            d->subsamplingComboBox->show();
+            d->subsamplingLabel->show();
+            d->qualityComboBox->show();
+            d->qualityLabel->show();
+            break;
+        }
+        case JPGBATCH:
+        {
+            // JPEG
+            d->exportDialog->selectFile("image0.jpg");
+            d->frameRateSpinBox->hide();
+            d->frameRateLabel->hide();
+            d->subsamplingComboBox->hide();
+            d->subsamplingLabel->hide();
+            d->qualityComboBox->hide();
+            d->qualityLabel->hide();
+            break;
+        }
+        case FFMPEG:
+        {
+            // Video
+            d->exportDialog->selectFile("video.avi");
+            d->frameRateSpinBox->show();
+            d->frameRateLabel->show();
+            d->subsamplingComboBox->hide();
+            d->subsamplingLabel->hide();
+            d->qualityComboBox->hide();
+            d->qualityLabel->hide();
+            break;
+        }
+        case MPEG2:
+        {
+            // Video
+            d->exportDialog->selectFile("video.avi");
+            d->frameRateSpinBox->hide();
+            d->frameRateLabel->hide();
+            d->subsamplingComboBox->hide();
+            d->subsamplingLabel->hide();
+            d->qualityComboBox->hide();
+            d->qualityLabel->hide();
+            break;
+        }
     }
 }
 

--- a/src-plugins/mscExportVideo/mscExportVideo.h
+++ b/src-plugins/mscExportVideo/mscExportVideo.h
@@ -25,7 +25,8 @@ public:
     {
         OGGVORBIS,
         JPGBATCH,
-        FFMPEG
+        FFMPEG,
+        MPEG2
     };
 
 public slots:


### PR DESCRIPTION
Debug for 4.2.0 https://github.com/Inria-Asclepios/medInria-public/issues/534

Put back code for MPEG2, but only on Windows. On Linux and Max, compilation of FFMPEG.

Previous code was https://github.com/Inria-Asclepios/medInria-public/pull/529

This PR is linked to an other on the superproject: https://github.com/Inria-Asclepios/medinria-superproject/pull/54 

:m:
