### PR TITLE
[HistogramEditor] debug CLUT Editor save/load table

### DIFF
--- a/src/medCore/gui/lookUpTables/medClutEditor.cpp
+++ b/src/medCore/gui/lookUpTables/medClutEditor.cpp
@@ -336,10 +336,10 @@ void medClutEditorVertex::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
             table->constrainMoveSelection( this, withShift );
             table->triggerVertexMoving();
     }
+
     d->setValueSpinBox->setValue((double)this->value().x());
-    // this->updateValue();
-    // qDebug() << "[" << (long int) this << "] value: " << d->value;
-    // qDebug() << "[" << (long int) this << "] coord: " << this->pos();
+
+    this->updateValue();
 }
 
 void medClutEditorVertex::mouseDoubleClickEvent(QGraphicsSceneMouseEvent *event)

--- a/src/medCore/gui/lookUpTables/medClutEditor.cpp
+++ b/src/medCore/gui/lookUpTables/medClutEditor.cpp
@@ -573,7 +573,8 @@ void medClutEditorTable::constrainMoveSelection( medClutEditorVertex * driver,
     }
 
     int n = d->principalVertices.count();
-    for ( int i = 0 ; i < n; ++i ) {
+    for ( int i = 0 ; i < n; ++i )
+    {
         medClutEditorVertex * vertex = d->principalVertices.at( i );
 
         if ( vertex->isSelected() )
@@ -583,22 +584,28 @@ void medClutEditorTable::constrainMoveSelection( medClutEditorVertex * driver,
         qreal right = vertex->x() + 1.0;
 
         for ( int j = i - 1; j >= 0; --j )
-            if ( d->principalVertices.at( j )->isSelected() ) {
+        {
+            if ( d->principalVertices.at( j )->isSelected() )
+            {
                 left = d->principalVertices.at( j )->x() + static_cast<qreal>( i - j );
                 break;
             }
+        }
 
-            for ( int j = i + 1; j < n; ++j )
-                if ( d->principalVertices.at( j )->isSelected() ) {
-                    right = d->principalVertices.at( j )->x() + static_cast<qreal>( i - j );
-                    break;
-                }
+        for ( int j = i + 1; j < n; ++j )
+        {
+            if ( d->principalVertices.at( j )->isSelected() )
+            {
+                right = d->principalVertices.at( j )->x() + static_cast<qreal>( i - j );
+                break;
+            }
+        }
 
-                QRectF limits = box;
-                limits.setLeft( left );
-                limits.setRight( right );
+        QRectF limits = box;
+        limits.setLeft( left );
+        limits.setRight( right );
 
-                vertex->forceGeometricalConstraints( limits );
+        vertex->forceGeometricalConstraints( limits );
     }
 }
 

--- a/src/medCore/gui/lookUpTables/medLUTToXMLWriter.cpp
+++ b/src/medCore/gui/lookUpTables/medLUTToXMLWriter.cpp
@@ -46,32 +46,41 @@ bool medLUTToXMLWriter::writeFile(QIODevice *device)
     d->xml.writeStartDocument();
     d->xml.writeDTD("<!DOCTYPE medLUTs>");
     d->xml.writeStartElement("medLUTs");
-    d->xml.writeAttribute("version", "1.0");
+    d->xml.writeAttribute("version", "1.1");
+
     foreach (medClutEditorTable * table, d->tables)
+    {
         d->writeTable(*table);
+    }
     d->xml.writeEndDocument();
     return true;
 }
 
-void medLUTToXMLWriterPrivate::writeTable(const medClutEditorTable & table){
+void medLUTToXMLWriterPrivate::writeTable(const medClutEditorTable & table)
+{
     xml.writeStartElement("table");
     xml.writeAttribute("title", table.title());
-    qDebug()<< table.title();
-    qDebug()<< "size: " << table.vertices().count();
-    foreach (const medClutEditorVertex * vertex, table.vertices())
-        writeNode(*vertex);
-    xml.writeEndElement();
+    qDebug()<< "Table Title -> "<<table.title();
+    qDebug()<< "Number of vertices -> " << table.vertices().count();
+
+    // If the table has at least a node
+    if (table.vertices().count() > 0)
+    {
+        foreach (const medClutEditorVertex * vertex, table.vertices())
+        {
+            writeNode(*vertex);
+        }
+        xml.writeEndElement();
+    }
 }
 
 void medLUTToXMLWriterPrivate::writeNode(const medClutEditorVertex & vertex)
 {
     QString node;
-    //position
-    qDebug()<< "vertex: "<< (long int )&vertex;
-    qDebug() << "node:" << vertex.pos();
-    qDebug() << "color" <<vertex.color();
-    node.sprintf("%.4f;%.4f;%d;%d;%d;%d",vertex.pos().x(),
-                 vertex.pos().y(),
+
+    node.sprintf("%.4f;%.4f;%d;%d;%d;%d",
+                 vertex.value().x(),
+                 vertex.value().y(),
                  vertex.color().red(),
                  vertex.color().green(),
                  vertex.color().blue(),

--- a/src/medCore/gui/lookUpTables/medLoadLUTDialog.cpp
+++ b/src/medCore/gui/lookUpTables/medLoadLUTDialog.cpp
@@ -18,7 +18,7 @@ medLoadLUTDialog::medLoadLUTDialog(const QStringList & titles, QWidget *parent) 
 {
     setModal(Qt::WindowModal);
     setInputMode(QInputDialog::TextInput);
-    setLabelText(tr("Choose a transfert Function:"));
+    setLabelText(tr("Choose a table name:"));
     setComboBoxItems(titles);;
     setOkButtonText(tr("Choose"));
 }

--- a/src/medCore/gui/lookUpTables/medXMLToLUTReader.h
+++ b/src/medCore/gui/lookUpTables/medXMLToLUTReader.h
@@ -23,7 +23,7 @@ class medXMLToLUTReaderPrivate;
 
 class MEDCORE_EXPORT medXMLToLUTReader {
 public:
-    medXMLToLUTReader(QList<medClutEditorTable*> * tables);
+    medXMLToLUTReader(QList<medClutEditorTable*> * tables, medClutEditorScene *scene);
     ~medXMLToLUTReader();
     bool read(QIODevice *device);
     QString errorString() const;

--- a/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.cpp
+++ b/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.cpp
@@ -53,6 +53,7 @@ public:
     medAbstractData *dtk_data;
     medAbstractView *med_view;
     QList <medClutEditorTable *> * tables;
+    QString toolboxName;
 };
 
 medClutEditorToolBox::medClutEditorToolBox(QWidget *parent) : medToolBox(parent)
@@ -63,6 +64,7 @@ medClutEditorToolBox::medClutEditorToolBox(QWidget *parent) : medToolBox(parent)
     d->view->setScene(d->scene);
     d->histogram = NULL;
     d->med_view = NULL;
+    d->toolboxName = "Colormap Editor";
 
     d->newAction                = new QAction("New table",    this);
     d->loadTableAction          = new QAction("Load table",   this);
@@ -101,7 +103,7 @@ medClutEditorToolBox::medClutEditorToolBox(QWidget *parent) : medToolBox(parent)
     widget->setLayout(layout);
     this->addWidget(widget);
     
-    this->setTitle("Colormap Editor");
+    this->setTitle(d->toolboxName);
     widget->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Minimum);
     this->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Minimum);
     
@@ -565,7 +567,7 @@ void medClutEditorToolBox::forceLayer(int layer)
 void medClutEditorToolBox::showInfo()
 {
     QDialog *messageBox = new QDialog(this);
-    messageBox->setWindowTitle(tr("Histogram Editor"));
+    messageBox->setWindowTitle(d->toolboxName);
     QString description = "This histogram allows you to interactively apply a LUT to your image.<br>";
     description += "This LUT can be either discrete or linear.";
     QTextBrowser* descriptionWidget = new QTextBrowser;

--- a/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.cpp
+++ b/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.cpp
@@ -102,7 +102,7 @@ medClutEditorToolBox::medClutEditorToolBox(QWidget *parent) : medToolBox(parent)
     widget->setLayout(layout);
     this->addWidget(widget);
     
-    this->setTitle("Histogram Editor");
+    this->setTitle("Colormap Editor");
     widget->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Minimum);
     this->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Minimum);
     

--- a/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.cpp
+++ b/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.cpp
@@ -52,7 +52,7 @@ public:
 
     medAbstractData *dtk_data;
     medAbstractView *med_view;
-    QList <medClutEditorTable *> * tables;
+    QList <medClutEditorTable *> tables;
     QString toolboxName;
 };
 
@@ -62,8 +62,8 @@ medClutEditorToolBox::medClutEditorToolBox(QWidget *parent) : medToolBox(parent)
     d->scene = new medClutEditorScene;
     d->view  = new medClutEditorView( this );
     d->view->setScene(d->scene);
-    d->histogram = NULL;
-    d->med_view = NULL;
+    d->histogram = nullptr;
+    d->med_view = nullptr;
     d->toolboxName = "Colormap Editor";
 
     d->newAction                = new QAction("New table",    this);
@@ -114,13 +114,12 @@ medClutEditorToolBox::medClutEditorToolBox(QWidget *parent) : medToolBox(parent)
     updateSavedTables();
 
     d->discreteMode = false;
-    d->invertLUT = false;  //"conventional" LUT is /
+    d->invertLUT = false;
     d->layerForced = 0;
 }
 
 medClutEditorToolBox::~medClutEditorToolBox(void)
 {
-    delete d->tables;
     delete d->scene;
     delete d->view;
     delete d;
@@ -128,8 +127,8 @@ medClutEditorToolBox::~medClutEditorToolBox(void)
 
 void medClutEditorToolBox::reset()
 {
-    d->dtk_data = NULL;
-    d->med_view = NULL;
+    d->dtk_data = nullptr;
+    d->med_view = nullptr;
     d->discreteMode = false;
     d->layerForced = 0;
 }
@@ -146,7 +145,7 @@ bool medClutEditorToolBox::registered()
 
 void medClutEditorToolBox::setData(medAbstractData *data)
 {
-    if ( data == NULL ) {
+    if ( data == nullptr ) {
         this->deleteTable();
         d->dtk_data = data;
     }
@@ -157,7 +156,7 @@ void medClutEditorToolBox::setData(medAbstractData *data)
     if (medAbstractImageData *image =
         dynamic_cast<medAbstractImageData *>(data)) {
 
-        if ( d->histogram != NULL )
+        if ( d->histogram != nullptr )
             delete d->histogram;
 
         d->histogram = new medClutEditorHistogram();
@@ -202,7 +201,7 @@ void medClutEditorToolBox::setView(medAbstractView *view)
 
     d->med_view = view;
 
-    if (d->med_view != NULL)
+    if (d->med_view != nullptr)
     {
         QList<double> scalars;
         QList<QColor> colors;
@@ -246,7 +245,7 @@ void medClutEditorToolBox::deleteTable(void)
 
 void medClutEditorToolBox::applyTable(medAbstractView* view)
 {
-    if ( view != NULL )
+    if ( view != nullptr )
     {
         QList<double> scalars;
         QList<QColor> colors;
@@ -331,7 +330,7 @@ void medClutEditorToolBox::onLoadTableAction(void)
     updateSavedTables();
 
     QStringList titles;
-    foreach (medClutEditorTable * table,*d->tables )
+    foreach (medClutEditorTable* table, d->tables)
     {
         titles << table->title();
     }
@@ -341,7 +340,7 @@ void medClutEditorToolBox::onLoadTableAction(void)
     if( dialog.exec() == QDialog::Accepted )
     {
         // We got Ok
-        foreach (medClutEditorTable * table,*d->tables )
+        foreach (medClutEditorTable* table, d->tables)
         {
             if ( table->title() == dialog.textValue())
             {
@@ -373,7 +372,7 @@ void medClutEditorToolBox::onSaveTableAction(void)
             // Check if table name already saved
             int indexIfTableAlreadySaved = -1;
             int currentIndex = 0;
-            foreach (medClutEditorTable* savedtable, *d->tables )
+            foreach (medClutEditorTable* savedtable, d->tables)
             {
                 if (tableToSave->title() == savedtable->title())
                 {
@@ -384,7 +383,7 @@ void medClutEditorToolBox::onSaveTableAction(void)
                 currentIndex++;
             }
 
-            QList<medClutEditorTable*>  l = *d->tables;
+            QList<medClutEditorTable*>  l = d->tables;
             if (indexIfTableAlreadySaved != -1)
             {
                 l[indexIfTableAlreadySaved] = tableToSave; // Update
@@ -421,8 +420,15 @@ void medClutEditorToolBox::onSaveTableAction(void)
 
 void medClutEditorToolBox::updateSavedTables()
 {
-    d->tables = new QList<medClutEditorTable *>();
-    medXMLToLUTReader reader = medXMLToLUTReader(d->tables, this->getScene());
+    // Initialize tables
+    foreach (medClutEditorTable* table, d->tables)
+    {
+        delete table;
+    }
+    d->tables.clear();
+
+    // Get table file from file system
+    medXMLToLUTReader reader = medXMLToLUTReader(&d->tables, this->getScene());
     QString lutFileName = medStorage::dataLocation();
     lutFileName.append("/LUTs.xml");
     QFile file(lutFileName);
@@ -438,7 +444,7 @@ void medClutEditorToolBox::clear()
 {
     medTabbedViewContainers * containers = this->getWorkspace()->stackedViewContainers();
     QList<medViewContainer*> containersInTabSelected = containers->containersInTab(containers->currentIndex());
-    medAbstractView *view=NULL;
+    medAbstractView *view = nullptr;
     for(int i=0;i<containersInTabSelected.length();i++)
     {
         if (containersInTabSelected[i]->isSelected())
@@ -574,7 +580,7 @@ void medClutEditorToolBox::showInfo()
     descriptionWidget->setHtml(description);
 
     QString shortcuts =
-        "<b>Double click:</b> Add a new vertex.<br>";
+            "<b>Double click:</b> Add a new vertex.<br>";
     shortcuts +=" <b>Delete:</b> Remove the selected vertex.<br>";
     shortcuts +=" <b>a:</b> Select all vertices.<br>";
     shortcuts +=" <b>c:</b> Modify color of the selected vertex.<br>";

--- a/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.h
+++ b/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.h
@@ -51,6 +51,7 @@ public:
     void reset();
     void deleteTable();
     void invertLUT(bool);
+    void updateSavedTables();
 
 public slots:
     void setDiscreteMode(bool);

--- a/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.h
+++ b/src/medVtkInria/medClutEditorToolBox/medClutEditorToolBox.h
@@ -64,13 +64,13 @@ protected:
     void mousePressEvent(QMouseEvent *event);
 
 protected slots:
+    /**
+     * @brief onNewTableAction delete every point on this histogram
+     */
     void onNewTableAction();
     void onLoadTableAction();
     void onSaveTableAction();
-    // void onDeleteTableAction();
     void onApplyTablesAction();
-    // void onColorAction();
-    // void onDeleteAction();
     void onVertexMoved();
     void onToggleDirectUpdateAction();
 private:


### PR DESCRIPTION
Fixes https://github.com/Inria-Asclepios/medInria-public/issues/538

 * Open a histogram, add/move vertices, changes colors
 * Right click -> you can save and load vertices tables

These tables are saved/updated in a `LUTs.xml` file in the same directory as the database (can be accessed with the Log button at homepage which open this directory).

Example:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE medLUTs>
<medLUTs version="1.1">
<table title="Blue">
<node>614.6923;0.4962;0;0;255;127</node>
<node>1182.4615;0.0846;0;0;255;21</node>
</table>
</medLUTs>
```

The tool name switch from "CLUT Editor" (nobody understand) to "Histogram Editor".

:m:

