### PR TITLE
[DB] information about dicom import & none empty names

### DIFF
--- a/src-plugins/itkDataImage/readers/itkDCMTKDataImageReader.cpp
+++ b/src-plugins/itkDataImage/readers/itkDCMTKDataImageReader.cpp
@@ -461,7 +461,6 @@ bool itkDCMTKDataImageReader::read (const QString& path)
 
 bool itkDCMTKDataImageReader::read(const QStringList& paths)
 {
-
     if (paths.size()==0)
         return false;
 

--- a/src/medCore/database/medAbstractDatabaseImporter.cpp
+++ b/src/medCore/database/medAbstractDatabaseImporter.cpp
@@ -345,11 +345,7 @@ void medAbstractDatabaseImporter::importFile ( void )
         patientID = itPat.value();
         QString seriesID = itSer.value();
 
-        //qDebug() << currentImageIndex << ": " << aggregatedFileName << "with " << filesPaths.size() << " files";
-
         dtkSmartPointer<medAbstractData> imagemedData;
-
-        QFileInfo imagefileInfo ( filesPaths[0] );
 
         // 3.2) Try to read the whole image, not just the header
         bool readOnlyImageInformation = false;
@@ -566,16 +562,19 @@ void medAbstractDatabaseImporter::populateMissingMetadata ( medAbstractData* med
         newSeriesDescription = seriesDescription;
     }
 
-    if ( !medData->hasMetaData ( medMetaDataKeys::PatientName.key() ) )
+    if ( !medData->hasMetaData ( medMetaDataKeys::PatientName.key() ) ||
+         medData->metadata(medMetaDataKeys::PatientName.key()).isEmpty() )
         medData->setMetaData ( medMetaDataKeys::PatientName.key(), QStringList() << "John Doe" );
 
     if (!medData->hasMetaData ( medMetaDataKeys::PatientID.key() ) )
       medData->setMetaData ( medMetaDataKeys::PatientID.key(), QStringList() << "0" );
 
-    if ( !medData->hasMetaData ( medMetaDataKeys::StudyDescription.key() ) )
+    if ( !medData->hasMetaData ( medMetaDataKeys::StudyDescription.key() ) ||
+        medData->metadata(medMetaDataKeys::StudyDescription.key()).isEmpty() )
         medData->setMetaData ( medMetaDataKeys::StudyDescription.key(), QStringList() << "EmptyStudy" );
 
-    if ( !medData->hasMetaData ( medMetaDataKeys::SeriesDescription.key() ) )
+    if ( !medData->hasMetaData ( medMetaDataKeys::SeriesDescription.key() ) ||
+         medData->metadata(medMetaDataKeys::SeriesDescription.key()).isEmpty() )
         medData->setMetaData ( medMetaDataKeys::SeriesDescription.key(), QStringList() << newSeriesDescription );
 
     if ( !medData->hasMetaData ( medMetaDataKeys::StudyID.key() ) )

--- a/src/medCore/gui/toolboxes/medActionsToolBox.cpp
+++ b/src/medCore/gui/toolboxes/medActionsToolBox.cpp
@@ -22,6 +22,7 @@ public:
 
     QWidget* buttonsWidget;
     QWidget* noButtonsSelectedWidget;
+    QWidget* informationWidget;
 
     QPushButton* removeBt;
     QPushButton* viewBt;
@@ -54,6 +55,17 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
 
     d->buttonsWidget = new QWidget(this);
     d->noButtonsSelectedWidget = new QWidget(this);
+
+    // Information Widget for File System tab
+    d->informationWidget = new QWidget(this);
+    QLabel* informationLabel = new QLabel(tr("To import DICOMs, select the directory containing these files.\nDo not select them separately."),
+                                          d->informationWidget);
+    informationLabel->setObjectName("actionToolBoxLabel");
+    informationLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Preferred);
+    informationLabel->setWordWrap(true);
+    QHBoxLayout* informationLayout = new QHBoxLayout(d->informationWidget);
+    informationLayout->addWidget(informationLabel, 0, Qt::AlignLeft);
+    this->addWidget(d->informationWidget);
 
     initializeItemToActionsMap();
 
@@ -98,6 +110,8 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
 
         // the order of the buttons in this list determines the order used to place them in the grid layout
         d->buttonsList << d->viewBt << d->loadBt << d->importBt << d->indexBt << d->bookmarkBt;
+
+        d->informationWidget->setVisible(true);
     }
     else //IF DATABASE
     {
@@ -146,6 +160,8 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
         
         d->buttonsList << d->viewBt << d->saveBt << d->exportBt << d->removeBt;
         d->buttonsList << d->newPatientBt << d->newStudyBt << d->editBt;
+
+        d->informationWidget->setVisible(false);
     }
 
     int COLUMNS = 3; // we will use 3 rows of 3 buttons each
@@ -168,6 +184,7 @@ medActionsToolBox::medActionsToolBox( QWidget *parent /*= 0*/, bool FILE_SYSTEM 
                 tr("Select any item to see possible actions."),
                 d->noButtonsSelectedWidget);
     noButtonsSelectedLabel->setObjectName("actionToolBoxLabel");
+
     // we use a layout to center the label
     QHBoxLayout* noButtonsSelectedLayout = new QHBoxLayout(d->noButtonsSelectedWidget);
     noButtonsSelectedLayout->addWidget(noButtonsSelectedLabel, 0, Qt::AlignCenter);


### PR DESCRIPTION
Fixes https://github.com/Inria-Asclepios/medInria-public/issues/485 (kind of, we explain how to import Dicoms)

Fixes https://github.com/Inria-Asclepios/medInria-public/issues/545 

 * Add an information widget on the File System tab in Browser, explaining how to import DICOM. Several users try selecting the files instead of the directory.

 * Imported DICOM do not have empty Patient Name, Study and Series description anymore, with some empty metadata.

:m: