### PR TITLE
[Paint] solve ROI remaining between 2 pipelines steps

### DIFF
--- a/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
+++ b/src-plugins/mscAlgorithmPaint/mscAlgorithmPaintToolBox.cpp
@@ -474,6 +474,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
 {
     setOfPaintBrushRois.clear();
+    this->clear();
 }
 
 medAbstractData* AlgorithmPaintToolBox::processOutput()


### PR DESCRIPTION
Fixes https://github.com/Inria-Asclepios/medInria-public/issues/541

it cleans the toolbox at its destruction -> no more ROI from a previous step in a new Paint step in pipelines.

:m: