### PR TITLE
[Closing] handle default view widgets at closing

### DIFF
--- a/app/medInria/medFilteringWorkspace.cpp
+++ b/app/medInria/medFilteringWorkspace.cpp
@@ -83,23 +83,29 @@ void medFilteringWorkspace::changeToolBoxInput()
 
 void medFilteringWorkspace::resetDefaultWidgetInputContainer()
 {
-    QLabel *inputLabel = new QLabel("INPUT");
-    inputLabel->setAlignment(Qt::AlignCenter);
-    d->inputContainer->setDefaultWidget(inputLabel);
-    d->inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
-    d->inputContainer->setUserSplittable(false);
-    d->inputContainer->setMultiLayered(false);
+    if(selectorToolBox()) //null when users close the software
+    {
+        QLabel *inputLabel = new QLabel("INPUT");
+        inputLabel->setAlignment(Qt::AlignCenter);
+        d->inputContainer->setDefaultWidget(inputLabel);
+        d->inputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
+        d->inputContainer->setUserSplittable(false);
+        d->inputContainer->setMultiLayered(false);
+    }
 }
 
 void medFilteringWorkspace::resetDefaultWidgetOutputContainer()
 {
-    QLabel *outputLabel = new QLabel("OUTPUT");
-    outputLabel->setAlignment(Qt::AlignCenter);
-    d->outputContainer->setDefaultWidget(outputLabel);
-    d->outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
-    d->outputContainer->setUserSplittable(false);
-    d->outputContainer->setMultiLayered(false);
-    d->outputContainer->setUserOpenable(false);
+    if(selectorToolBox()) //null when users close the software
+    {
+        QLabel *outputLabel = new QLabel("OUTPUT");
+        outputLabel->setAlignment(Qt::AlignCenter);
+        d->outputContainer->setDefaultWidget(outputLabel);
+        d->outputContainer->setClosingMode(medViewContainer::CLOSE_VIEW);
+        d->outputContainer->setUserSplittable(false);
+        d->outputContainer->setMultiLayered(false);
+        d->outputContainer->setUserOpenable(false);
+    }
 }
 
 /**

--- a/app/medInria/medRegistrationWorkspace.cpp
+++ b/app/medInria/medRegistrationWorkspace.cpp
@@ -77,32 +77,41 @@ void medRegistrationWorkspace::setupViewContainerStack()
 
 void medRegistrationWorkspace::resetDefaultWidgetFixedContainer()
 {
-    QLabel *fixedLabel = new QLabel(tr("FIXED"));
-    fixedLabel->setAlignment(Qt::AlignCenter);
-    d->containers[Fixed]->setDefaultWidget(fixedLabel);
-    d->containers[Fixed]->setMultiLayered(false);
-    d->containers[Fixed]->setUserSplittable(false);
-    d->containers[Fixed]->setClosingMode(medViewContainer::CLOSE_VIEW);
+    if(selectorToolBox()) //null when users close the software
+    {
+        QLabel *fixedLabel = new QLabel(tr("FIXED"));
+        fixedLabel->setAlignment(Qt::AlignCenter);
+        d->containers[Fixed]->setDefaultWidget(fixedLabel);
+        d->containers[Fixed]->setMultiLayered(false);
+        d->containers[Fixed]->setUserSplittable(false);
+        d->containers[Fixed]->setClosingMode(medViewContainer::CLOSE_VIEW);
+    }
 }
 
 void medRegistrationWorkspace::resetDefaultWidgetMovingContainer()
 {
-    QLabel *movingLabel = new QLabel(tr("MOVING"));
-    movingLabel->setAlignment(Qt::AlignCenter);
-    d->containers[Moving]->setDefaultWidget(movingLabel);
-    d->containers[Moving]->setUserSplittable(false);
-    d->containers[Moving]->setMultiLayered(false);
-    d->containers[Moving]->setClosingMode(medViewContainer::CLOSE_VIEW);
+    if(selectorToolBox()) //null when users close the software
+    {
+        QLabel *movingLabel = new QLabel(tr("MOVING"));
+        movingLabel->setAlignment(Qt::AlignCenter);
+        d->containers[Moving]->setDefaultWidget(movingLabel);
+        d->containers[Moving]->setUserSplittable(false);
+        d->containers[Moving]->setMultiLayered(false);
+        d->containers[Moving]->setClosingMode(medViewContainer::CLOSE_VIEW);
+    }
 }
 
 void medRegistrationWorkspace::resetDefaultWidgetFuseContainer()
 {
-    QLabel *fuseLabel = new QLabel(tr("FUSE"));
-    fuseLabel->setAlignment(Qt::AlignCenter);
-    d->containers[Fuse]->setDefaultWidget(fuseLabel);
-    d->containers[Fuse]->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);
-    d->containers[Fuse]->setUserSplittable(false);
-    d->containers[Fuse]->setAcceptDrops(false);
+    if(selectorToolBox()) //null when users close the software
+    {
+        QLabel *fuseLabel = new QLabel(tr("FUSE"));
+        fuseLabel->setAlignment(Qt::AlignCenter);
+        d->containers[Fuse]->setDefaultWidget(fuseLabel);
+        d->containers[Fuse]->setClosingMode(medViewContainer::CLOSE_BUTTON_HIDDEN);
+        d->containers[Fuse]->setUserSplittable(false);
+        d->containers[Fuse]->setAcceptDrops(false);
+    }
 }
 
 void medRegistrationWorkspace::setInitialGroups()


### PR DESCRIPTION
Fixes https://github.com/Inria-Asclepios/medInria-public/issues/551

At closing of the application, we do not want to put default values in half-closed views.

:m: