### PR TITLE
[FIX] Set 2 libs to DCMTK_LIBRARIES

### DIFF
--- a/cmake/FindDCMTK.cmake
+++ b/cmake/FindDCMTK.cmake
@@ -244,7 +244,7 @@ endforeach()
 list(APPEND DCMTK_INCLUDE_DIRS ${DCMTK_DIR}/include)
 
 if(WIN32)
-  list(APPEND DCMTK_LIBRARIES netapi32 wsock32)
+  list(APPEND DCMTK_LIBRARIES iphlpapi ws2_32 netapi32 wsock32)
 endif()
 
 if(DCMTK_ofstd_INCLUDE_DIR)


### PR DESCRIPTION
Modify FindDCMTK.cmake file
Set ìphlpapi`and `ws2_32`to DCMTK_LIBRARIES Macro