### PR TITLE
[DCMTK/QtDCM] Fix macOS linking problem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,12 @@ if (WIN32)
 ${Boost_INCLUDE_DIR})
 endif()
 
+find_package(DCMTK REQUIRED)
+# Do this once and for all
+if(APPLE)
+  FixDCMTKMacInstall("${DCMTK_LIBRARIES}" "${DCMTK_LIBRARIES}" "${DCMTK_DIR}")
+endif(APPLE)
+
 
 ## #############################################################################
 ## Qt Automoc

--- a/cmake/FixDCMTKMacInstall.cmake
+++ b/cmake/FixDCMTKMacInstall.cmake
@@ -11,18 +11,12 @@
 #
 ################################################################################
 
-macro(FixDCMTKMacInstall)
-
-  foreach(library ${DCMTK_LIBRARIES})
-    get_filename_component(lib ${library} NAME_WE)
-    if (EXISTS ${DCMTK_DIR}/lib/${lib}.dylib)
-      foreach(linkedlibrary ${DCMTK_LIBRARIES})
-        get_filename_component(linkedlib ${linkedlibrary} NAME_WE)
-        if (EXISTS ${DCMTK_DIR}/lib/${linkedlib}.dylib)
-          execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${linkedlib}.dylib ${DCMTK_DIR}/lib/${linkedlib}.dylib ${DCMTK_DIR}/lib/${lib}.dylib)
-        endif()
-      endforeach()
-    endif()
+macro(FixDCMTKMacInstall target_libraries dcmtk_libraries dcmtk_dir)
+  foreach(targetLib ${target_libraries})
+    foreach(linkedlibrary ${dcmtk_libraries})
+      get_filename_component(linkedlib ${linkedlibrary} NAME_WE)
+      execute_process(COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change ${linkedlib}.12.dylib ${dcmtk_dir}/lib/${linkedlib}.12.dylib ${targetLib})
+    endforeach()
   endforeach()
 
 endmacro(FixDCMTKMacInstall)

--- a/src-plugins/itkDataImage/CMakeLists.txt
+++ b/src-plugins/itkDataImage/CMakeLists.txt
@@ -38,12 +38,6 @@ if (ITK_USE_SYSTEM_GDCM)
   add_definitions(-DITK_USE_SYSTEM_GDCM)
 endif()
 
-find_package(DCMTK REQUIRED)
-if (APPLE)
-  include(FixDCMTKMacInstall)
-  FixDCMTKMacInstall()
-endif()
-
 find_package(VTK REQUIRED)
 include(${VTK_USE_FILE})
 
@@ -100,8 +94,9 @@ target_link_libraries(${PROJECT_NAME}
 
 # needed because of link  with medImageIO
 if(APPLE)
-  FixDCMTKMacLink(${PROJECT_NAME} ${DCMTK_LIBRARIES})  
+  FixDCMTKMacLink(${PROJECT_NAME} ${DCMTK_LIBRARIES})
 endif(APPLE)
+
 
 ## #############################################################################
 ## Install rules

--- a/src-plugins/qtdcmDataSource/CMakeLists.txt
+++ b/src-plugins/qtdcmDataSource/CMakeLists.txt
@@ -36,8 +36,6 @@ find_package(dtk REQUIRED)
 include(${dtk_USE_FILE})
 include(dtkPlugin)
 
-find_package(DCMTK REQUIRED)
-
 find_package(QtDCM REQUIRED)
 include(${QTDCM_USE_FILE})
 
@@ -90,6 +88,8 @@ target_link_libraries(${PROJECT_NAME}
   )
   
 if(APPLE)
+  set(QTDCM_LIBRARIES "${QTDCM_DIR}/lib/lib${QTDCM_LIBS}.dylib")
+  FixDCMTKMacInstall("${QTDCM_LIBRARIES}" "${DCMTK_LIBRARIES}" "${DCMTK_DIR}")
   add_custom_command(TARGET ${PROJECT_NAME}
     POST_BUILD
     COMMAND ${CMAKE_INSTALL_NAME_TOOL} -change @rpath/lib${QTDCM_LIBS}.dylib ${QTDCM_LIBRARY_DIRS}/lib${QTDCM_LIBS}.dylib ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/lib${PROJECT_NAME}.dylib
@@ -97,6 +97,7 @@ if(APPLE)
   )
   FixDCMTKMacLink(${PROJECT_NAME} ${DCMTK_LIBRARIES})
 endif(APPLE)
+
 
 
 ## #############################################################################

--- a/src/medImageIO/CMakeLists.txt
+++ b/src/medImageIO/CMakeLists.txt
@@ -24,9 +24,6 @@ include(${ITK_USE_FILE})
 find_package(VTK REQUIRED)
 include(${VTK_USE_FILE})
 
-find_package(DCMTK REQUIRED)
-
-
 ## #############################################################################
 ## List Sources
 ## #############################################################################
@@ -81,10 +78,6 @@ endif(APPLE)
 ## #############################################################################
 ## install
 ## #############################################################################
-
-if(APPLE)
-  FixDCMTKMacInstall()
-endif()
 
 set_lib_install_rules(${PROJECT_NAME} 
   ${${PROJECT_NAME}_HEADERS}


### PR DESCRIPTION
- Fix DCMTK link problem with itself.
- Fix QtDCM link problem with DCMTK.

Details:
- find_package(DCMTK ...) is now called once globally in medInria/CMakeLists.txt. Then, the FixDCMTKMacInstall.cmake is run to fix linking problems.
- FixDCMTKMacInstall.cmake is run a second time in plugin qtdcmDataSource, but this time it fixes QtDCM's linking with DCMTK.

N.B. This will break again when we update DCMTK version and libraries change name or suffix, e.g. libdcmdata.13.dylib instead of libdcmdata.12.dylib