### PR TITLE
[Ubuntu18] thumbnail - driver name

### DIFF
--- a/src/medCore/data/medAbstractData.cpp
+++ b/src/medCore/data/medAbstractData.cpp
@@ -211,8 +211,7 @@ void medAbstractData::generateThumbnail()
     if ( ! gpu.vendor.toLower().contains("intel"))
         offscreenCapable = true;
 #elif defined(Q_OS_LINUX)
-    // only works on NVidia
-    if (gpu.vendor.toLower().contains("nvidia"))
+    if (gpu.vendor.toLower().contains("nvidia") || gpu.vendor.toLower().contains("intel"))
         offscreenCapable = true;
 #endif
 


### PR DESCRIPTION
Fixes https://github.com/Inria-Asclepios/medInria-public/issues/568

The driver's name is not nvidia, and there is no problem with mine.

It could be possible that in Ubuntu 14 (not sure), 16 and 18, the previous crash does not exist anymore. 

(By curiosity, @paulineMig can you comment this line on your code, compile, and import a data to check if the thumbnail is done? ^^)

:m: