### PR TITLE
[vtkDataMesh] Copy constructor and clone method

### DIFF
--- a/src-plugins/vtkDataMesh/datas/vtkDataMesh.cpp
+++ b/src-plugins/vtkDataMesh/datas/vtkDataMesh.cpp
@@ -35,18 +35,35 @@ class vtkDataMeshPrivate
 {
 public:
   vtkSmartPointer<vtkMetaDataSet> mesh;
-  QList<QImage>          thumbnails;
+  QList<QImage> thumbnails;
 };
 
-vtkDataMesh::vtkDataMesh(): medAbstractMeshData(), d (new vtkDataMeshPrivate)
+vtkDataMesh::vtkDataMesh()
+  : medAbstractMeshData(),
+    d (new vtkDataMeshPrivate())
 {
   this->moveToThread(QApplication::instance()->thread());
-  d->mesh = 0;
+  d->mesh = nullptr;
 }
+
+vtkDataMesh::vtkDataMesh(const vtkDataMesh& other)
+  : medAbstractMeshData(other),
+    d (new vtkDataMeshPrivate())
+{
+  this->moveToThread(QApplication::instance()->thread());
+
+  d->thumbnails = other.d->thumbnails;
+  d->mesh = other.d->mesh->Clone();
+}
+
 vtkDataMesh::~vtkDataMesh()
 {
   delete d;
-  d = 0;
+}
+
+vtkDataMesh* vtkDataMesh::clone()
+{
+  return new vtkDataMesh(*this);
 }
 
 bool vtkDataMesh::registered()

--- a/src-plugins/vtkDataMesh/datas/vtkDataMesh.h
+++ b/src-plugins/vtkDataMesh/datas/vtkDataMesh.h
@@ -27,7 +27,10 @@ class VTKDATAMESHPLUGIN_EXPORT vtkDataMesh : public medAbstractMeshData
                        "Mesh data based of vtkPolyData for surface meshes and vtkUnstructuredGrid for volume meshes.")
  public:
     vtkDataMesh();
+    vtkDataMesh(const vtkDataMesh& other);
     ~vtkDataMesh();
+
+    vtkDataMesh* clone() override;
 
     static bool registered();
 

--- a/src-plugins/vtkDataMesh/datas/vtkDataMesh4D.cpp
+++ b/src-plugins/vtkDataMesh/datas/vtkDataMesh4D.cpp
@@ -40,17 +40,30 @@ public:
 vtkDataMesh4D::vtkDataMesh4D(): medAbstractMeshData(), d (new vtkDataMesh4DPrivate)
 {
   this->moveToThread(QApplication::instance()->thread());
-  d->meshsequence = NULL;
+  d->meshsequence = nullptr;
 }
+
+vtkDataMesh4D::vtkDataMesh4D(const vtkDataMesh4D &other)
+  : medAbstractMeshData(other),
+    d (new vtkDataMesh4DPrivate())
+{
+  this->moveToThread(QApplication::instance()->thread());
+  d->meshsequence = other.d->meshsequence->Clone();
+}
+
 vtkDataMesh4D::~vtkDataMesh4D()
 {
   delete d;
-  d = NULL;
 }
 
 bool vtkDataMesh4D::registered()
 {
   return medAbstractDataFactory::instance()->registerDataType<vtkDataMesh4D>();
+}
+
+vtkDataMesh4D* vtkDataMesh4D::clone()
+{
+  return new vtkDataMesh4D(*this);
 }
 
 void vtkDataMesh4D::setData(void *data)

--- a/src-plugins/vtkDataMesh/datas/vtkDataMesh4D.h
+++ b/src-plugins/vtkDataMesh/datas/vtkDataMesh4D.h
@@ -27,7 +27,10 @@ class VTKDATAMESHPLUGIN_EXPORT vtkDataMesh4D : public medAbstractMeshData
                        "Mesh time sequence.")
  public:
     vtkDataMesh4D();
+    vtkDataMesh4D(const vtkDataMesh4D& other);
     ~vtkDataMesh4D();
+
+    vtkDataMesh4D* clone() override;
 
     static bool registered();
 

--- a/src/medCore/data/medAbstractData.cpp
+++ b/src/medCore/data/medAbstractData.cpp
@@ -61,6 +61,11 @@ medAbstractData::~medAbstractData( void )
     d = NULL;
 }
 
+medAbstractData* medAbstractData::clone(void)
+{
+    return new medAbstractData(*this);
+}
+
 /**
 * Attach a meddataindex to the data to carry it arround
 * @param const medDataIndex & index

--- a/src/medCore/data/medAbstractData.h
+++ b/src/medCore/data/medAbstractData.h
@@ -34,6 +34,8 @@ public:
     medAbstractData( const medAbstractData& other );
     virtual ~medAbstractData();
 
+    virtual medAbstractData* clone() override;
+
     void setDataIndex(const medDataIndex& index);
     medDataIndex dataIndex() const;
 

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -12,32 +12,32 @@
 =========================================================================*/
 
 #include <vtkMetaDataSet.h>
-#include "vtkObjectFactory.h"
 #include <fstream>
 #include <sstream>
 
-#include <vtkDataSet.h>
-#include <vtkFloatArray.h>
-#include <vtkPointData.h>
+#include <vtkActor.h>
+#include <vtkActorCollection.h>
+#include <vtkCell.h>
 #include <vtkCellData.h>
+#include <vtkDataSet.h>
+#include <vtkDataArrayCollection.h>
+#include <vtkDelimitedTextReader.h>
+#include <vtkErrorCode.h>
+#include <vtkFloatArray.h>
+#include <vtkImageData.h>
+#include <vtkLookupTable.h>
+#include <vtkMapper.h>
+#include <vtkMathConfigure.h>
+#include <vtkObjectFactory.h>
+#include <vtkPointData.h>
 #include <vtkPointSet.h>
 #include <vtkPoints.h>
-#include <vtkMapper.h>
-
-#include <vtkActorCollection.h>
-#include <vtkActor.h>
-#include <vtkScalarsToColors.h>
-#include <vtksys/SystemTools.hxx>
-#include <vtkErrorCode.h>
-#include <vtkLookupTable.h>
-#include <vtkDataArrayCollection.h>
-#include <vtkCell.h>
-#include <vtkLookupTable.h>
-#include <vtkTable.h>
-#include <vtkDelimitedTextReader.h>
-#include <vtkMathConfigure.h>
-
 #include <vtkPolyData.h>
+#include <vtkProperty.h>
+#include <vtkScalarsToColors.h>
+#include <vtkTable.h>
+#include <vtkUnstructuredGrid.h>
+#include <vtksys/SystemTools.hxx>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro( vtkMetaDataSet );
@@ -47,7 +47,7 @@ vtkCxxRevisionMacro( vtkMetaDataSet, "$Revision: 1298 $");
 vtkMetaDataSet::vtkMetaDataSet()
 {
   this->DataSet          = 0;
-  this->WirePolyData = NULL;
+  this->WirePolyData = nullptr;
 
   this->ActorList = vtkActorCollection::New();
   this->ArrayCollection = vtkDataArrayCollection::New();
@@ -60,9 +60,48 @@ vtkMetaDataSet::vtkMetaDataSet()
   this->PickedCellId     = -1;
   this->Name             = "";
   this->FilePath         = "";
-  this->LookupTable      = NULL;
+  this->LookupTable      = nullptr;
   this->Initialize();
-  
+}
+
+vtkMetaDataSet::vtkMetaDataSet(const vtkMetaDataSet& other)
+{
+  this->DataSet = nullptr;
+  if (other.DataSet)
+  {
+    if (other.DataSet->IsA("vtkPolyData"))
+    {
+        this->DataSet = vtkPolyData::New();
+    }
+    else if (other.DataSet->IsA("vtkUnstructuredGrid"))
+    {
+        this->DataSet = vtkUnstructuredGrid::New();
+    }
+    else if (other.DataSet->IsA("vtkImageData"))
+    {
+        this->DataSet = vtkImageData::New();
+    }
+
+    if (this->DataSet)
+    {
+        this->DataSet->DeepCopy(other.DataSet);
+    }
+  }
+
+  this->WirePolyData = nullptr;
+  this->ActorList = vtkActorCollection::New();
+  this->ArrayCollection = vtkDataArrayCollection::New();
+  this->CurrentScalarArray = nullptr;
+
+  this->Time             = other.Time;
+  this->Type             = other.Type;
+  this->PickedPointId    = other.PickedPointId;
+  this->PickedCellId     = other.PickedCellId;
+  this->Name             = other.Name;
+  this->FilePath         = other.FilePath;
+  this->LookupTable      = vtkLookupTable::New();
+  this->LookupTable->DeepCopy(other.LookupTable);
+  this->Property         = vtkProperty::New();
 }
 
 //----------------------------------------------------------------------------
@@ -88,6 +127,10 @@ vtkMetaDataSet::~vtkMetaDataSet()
   
 }
 
+vtkMetaDataSet* vtkMetaDataSet::Clone()
+{
+    return new vtkMetaDataSet(*this);
+}
 
 //----------------------------------------------------------------------------
 void vtkMetaDataSet::Initialize()
@@ -508,7 +551,7 @@ void vtkMetaDataSet::ReadDataInternal(const char* filename)
   
   file.close();
 
-  vtkDataSetAttributes* attributes = NULL;
+  vtkDataSetAttributes* attributes = nullptr;
   
   if (type == 1) // assign array to points
   {
@@ -884,7 +927,7 @@ vtkDataArray* vtkMetaDataSet::GetArray (const char* name)
   
 
   // then try in the pointdata and celldata array collections
-  vtkDataArray* ret = NULL;
+  vtkDataArray* ret = nullptr;
 
   vtkDataArrayCollection* arrays = vtkDataArrayCollection::New();
   this->GetColorArrayCollection (arrays);

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.cxx
@@ -69,18 +69,7 @@ vtkMetaDataSet::vtkMetaDataSet(const vtkMetaDataSet& other)
   this->DataSet = nullptr;
   if (other.DataSet)
   {
-    if (other.DataSet->IsA("vtkPolyData"))
-    {
-        this->DataSet = vtkPolyData::New();
-    }
-    else if (other.DataSet->IsA("vtkUnstructuredGrid"))
-    {
-        this->DataSet = vtkUnstructuredGrid::New();
-    }
-    else if (other.DataSet->IsA("vtkImageData"))
-    {
-        this->DataSet = vtkImageData::New();
-    }
+    this->DataSet = other.DataSet->NewInstance();
 
     if (this->DataSet)
     {
@@ -124,7 +113,7 @@ vtkMetaDataSet::~vtkMetaDataSet()
   this->ActorList->Delete();
   this->ArrayCollection->Delete();
   
-  
+
 }
 
 vtkMetaDataSet* vtkMetaDataSet::Clone()

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSet.h
@@ -62,6 +62,8 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSet: public vtkDataObject
   vtkTypeRevisionMacro(vtkMetaDataSet,vtkDataObject);
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
+  virtual vtkMetaDataSet* Clone();
+
   //BTX
   typedef itk::MetaDataDictionary DictionaryType;
   /**
@@ -379,6 +381,7 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSet: public vtkDataObject
   
  protected:
   vtkMetaDataSet();
+  vtkMetaDataSet(const vtkMetaDataSet& other);
   ~vtkMetaDataSet();
 
   /**
@@ -434,7 +437,6 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSet: public vtkDataObject
   
  private:
   
-  vtkMetaDataSet(const vtkMetaDataSet&);        // Not implemented.
   void operator=(const vtkMetaDataSet&);        // Not implemented.
 
   //BTX

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSetSequence.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSetSequence.cxx
@@ -50,6 +50,7 @@ vtkCxxRevisionMacro(vtkMetaDataSetSequence, "$Revision: 1370 $");
 
 //----------------------------------------------------------------------------
 vtkMetaDataSetSequence::vtkMetaDataSetSequence()
+  : vtkMetaDataSet()
 {
 
   this->SequenceDuration = 2.0;
@@ -58,6 +59,20 @@ vtkMetaDataSetSequence::vtkMetaDataSetSequence()
   this->SameGeometryFlag = true;
   this->ParseAttributes = true;
   
+}
+
+vtkMetaDataSetSequence::vtkMetaDataSetSequence(const vtkMetaDataSetSequence& other)
+  : vtkMetaDataSet(other)
+{
+    this->SequenceDuration = other.SequenceDuration;
+    this->CurrentId = other.CurrentId;
+    this->SameGeometryFlag = other.SameGeometryFlag;
+    this->ParseAttributes = other.ParseAttributes;
+
+    for (unsigned int i = 0; i < other.MetaDataSetList.size(); ++i)
+    {
+        this->MetaDataSetList.push_back(other.MetaDataSetList[i]->Clone());
+    }
 }
 
 //----------------------------------------------------------------------------
@@ -79,7 +94,10 @@ void vtkMetaDataSetSequence::Initialize()
 
 }
 
-
+vtkMetaDataSetSequence* vtkMetaDataSetSequence::Clone()
+{
+    return new vtkMetaDataSetSequence(*this);
+}
 
 
 //----------------------------------------------------------------------------
@@ -272,7 +290,7 @@ void vtkMetaDataSetSequence::Read(const char* dirname)
 //----------------------------------------------------------------------------
 void vtkMetaDataSetSequence::ReadAndAddFile (const char* filename, double time)
 {
-  vtkMetaDataSet* metadataset = NULL;
+  vtkMetaDataSet* metadataset = nullptr;
 
   if (this->GetType() == vtkMetaDataSet::VTK_META_UNKNOWN)
   {
@@ -473,7 +491,7 @@ void vtkMetaDataSetSequence::BuildSequenceFromGeometry(const char* filename, uns
     throw vtkErrorCode::CannotOpenFileError;
   }
 
-  vtkMetaDataSet* mainmetadataset = NULL;
+  vtkMetaDataSet* mainmetadataset = nullptr;
   
   switch(type)
   {
@@ -507,8 +525,8 @@ void vtkMetaDataSetSequence::BuildSequenceFromGeometry(const char* filename, uns
   for (unsigned int i=0; i<Niter; i++)
   {
     
-    vtkMetaDataSet* metadataset = NULL;
-    vtkPointSet* pointset = NULL;
+    vtkMetaDataSet* metadataset = nullptr;
+    vtkPointSet* pointset = nullptr;
     double time = (double)(i)*duration/(double)(Niter-1);
     
     switch(type)
@@ -553,7 +571,7 @@ void vtkMetaDataSetSequence::AddMetaDataSet (vtkMetaDataSet* metadataset)
 {
   if (!metadataset)
   {  
-    vtkErrorMacro(<<"NULL object !"<<endl);
+    vtkErrorMacro(<<"nullptr object !"<<endl);
     throw vtkErrorCode::UserError;
   }
   
@@ -566,7 +584,7 @@ void vtkMetaDataSetSequence::AddMetaDataSet (vtkMetaDataSet* metadataset)
     throw vtkErrorCode::UserError;
   }
 
-  vtkMetaImageData* metaimage1 = NULL;
+  vtkMetaImageData* metaimage1 = nullptr;
   metaimage1 = vtkMetaImageData::SafeDownCast (metadataset);
   if (metaimage1)
   {
@@ -690,7 +708,7 @@ void vtkMetaDataSetSequence::RemoveAllMetaDataSets()
 vtkMetaDataSet* vtkMetaDataSetSequence::GetMetaDataSet (unsigned int i)
 {
   if (i>=this->MetaDataSetList.size())
-    return NULL;
+    return nullptr;
   return this->MetaDataSetList[i];
 }
 
@@ -716,7 +734,7 @@ vtkMetaDataSet* vtkMetaDataSetSequence::FindMetaDataSet (const char* name)
     if (strcmp (this->MetaDataSetList[i]->GetName(), name) == 0)
       return this->MetaDataSetList[i];
   }
-  return NULL;
+  return nullptr;
 }
 
   
@@ -771,7 +789,7 @@ void vtkMetaDataSetSequence::BuildMetaDataSetFromMetaDataSet (vtkMetaDataSet* me
   this->CopyInformation(metadataset);
   this->SetProperty (metadataset->GetProperty());
   
-  vtkDataSet* dataset = NULL;
+  vtkDataSet* dataset = nullptr;
 
   switch (metadataset->GetDataSet()->GetDataObjectType())
   {
@@ -1302,8 +1320,8 @@ void vtkMetaDataSetSequence::ReadFrameData (const char* filename, unsigned int i
     for (unsigned int i = this->MetaDataSetList.size(); i<=iter; i++)
     {
       
-      vtkMetaDataSet* metadataset = NULL;
-      vtkDataSet* dataset = NULL;
+      vtkMetaDataSet* metadataset = nullptr;
+      vtkDataSet* dataset = nullptr;
       
       switch(this->GetType())
       {
@@ -1447,7 +1465,7 @@ vtkDoubleArray* vtkMetaDataSetSequence::GenerateFollowerTimeTable(const char* ar
     
     vtkWarningMacro(<<"array "<<arrayname<<" not found in all sequence instances"<<endl);
     ret->Delete();
-    return NULL;
+    return nullptr;
   }
   
 
@@ -1472,7 +1490,7 @@ vtkDoubleArray* vtkMetaDataSetSequence::GenerateMetaDataTimeTable(const char* me
     {
       vtkWarningMacro(<<"metadata "<<metadatakey<<" not found in all sequence frames"<<endl);
       ret->Delete();
-      return NULL;
+      return nullptr;
     }
     ret->InsertNextValue (val);
   }

--- a/src/medVtkInria/vtkDataManagement/vtkMetaDataSetSequence.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaDataSetSequence.h
@@ -55,6 +55,8 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSetSequence: public vtkMetaDataSet
   vtkTypeRevisionMacro(vtkMetaDataSetSequence,vtkMetaDataSet);
   virtual void PrintSelf(ostream& os, vtkIndent indent);
 
+  virtual vtkMetaDataSetSequence* Clone() override;
+
   /**
      Read and Write the Sequence into a directory
   */
@@ -528,6 +530,7 @@ class MEDVTKINRIA_EXPORT vtkMetaDataSetSequence: public vtkMetaDataSet
   
 protected:
   vtkMetaDataSetSequence();
+  vtkMetaDataSetSequence(const vtkMetaDataSetSequence& other);
   ~vtkMetaDataSetSequence();
 
   /**
@@ -549,7 +552,6 @@ protected:
   
  private:
   
-  vtkMetaDataSetSequence(const vtkMetaDataSetSequence&);      // Not implemented.
   void operator=(const vtkMetaDataSetSequence&);              // Not implemented.
 
   int    CurrentId;

--- a/src/medVtkInria/vtkDataManagement/vtkMetaImageData.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaImageData.cxx
@@ -14,15 +14,13 @@
 #include <vtkMetaImageData.h>
 #include "vtkObjectFactory.h"
 
-
 #include <vtkImageData.h>
 #include <vtkImageCast.h>
-
+#include <vtkVolumeProperty.h>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro( vtkMetaImageData );
 vtkCxxRevisionMacro(vtkMetaImageData, "$Revision: 1370 $");
-
 
 #include <itkMatrix.h>
 #include <itkImage.h>
@@ -33,8 +31,7 @@ vtkCxxRevisionMacro(vtkMetaImageData, "$Revision: 1370 $");
 #include <vtkPNGReader.h>
 #include <vtkJPEGReader.h>
 #include <vtkTIFFReader.h>
-#include <vtkMatrix4x4.h>
-  
+#include <vtkMatrix4x4.h>  
 
 //----------------------------------------------------------------------------
 vtkMetaImageData::vtkMetaImageData()
@@ -47,10 +44,29 @@ vtkMetaImageData::vtkMetaImageData()
   
 }
 
+vtkMetaImageData::vtkMetaImageData(const vtkMetaImageData& other)
+  : vtkMetaDataSet(other)
+{
+    this->OrientationMatrix = vtkMatrix4x4::New();
+    this->OrientationMatrix->DeepCopy(other.OrientationMatrix);
+
+    this->VolumeProperty = nullptr;
+    if (other.VolumeProperty)
+    {
+        this->VolumeProperty = vtkVolumeProperty::New();
+        this->VolumeProperty->DeepCopy(other.VolumeProperty);
+    }
+}
+
 //----------------------------------------------------------------------------
 vtkMetaImageData::~vtkMetaImageData()
 {
   this->OrientationMatrix->Delete();
+}
+
+vtkMetaImageData* vtkMetaImageData::Clone()
+{
+    return new vtkMetaImageData(*this);
 }
 
 //----------------------------------------------------------------------------
@@ -65,7 +81,7 @@ void vtkMetaImageData::SetDataSet(vtkDataSet* dataset)
 vtkImageData* vtkMetaImageData::GetImageData() const
 {
   if (!this->DataSet)
-    return NULL;
+    return nullptr;
   return vtkImageData::SafeDownCast (this->DataSet);
 }
 
@@ -158,7 +174,7 @@ itk::ImageBase<3>* vtkMetaImageData::GetItkImage()
 {
   if (!this->GetImageData())
   {
-    return NULL;
+    return nullptr;
   }
 
   if (m_ItkImage.IsNull())

--- a/src/medVtkInria/vtkDataManagement/vtkMetaImageData.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaImageData.h
@@ -80,8 +80,8 @@ class MEDVTKINRIA_EXPORT vtkMetaImageData: public vtkMetaDataSet
 
   vtkGetObjectMacro (OrientationMatrix, vtkMatrix4x4);
   virtual void SetOrientationMatrix (vtkMatrix4x4* matrix);
-  
-  
+
+  virtual vtkMetaImageData* Clone() override;
 
   //BTX
   typedef float ImageComponentType;
@@ -435,13 +435,13 @@ class MEDVTKINRIA_EXPORT vtkMetaImageData: public vtkMetaDataSet
   
  protected:
   vtkMetaImageData();
+  vtkMetaImageData(const vtkMetaImageData&);
   ~vtkMetaImageData();
 
   vtkVolumeProperty* VolumeProperty;
   
  private:
   
-  vtkMetaImageData(const vtkMetaImageData&);      // Not implemented.
   void operator=(const vtkMetaImageData&);        // Not implemented.
 
   vtkMatrix4x4* OrientationMatrix;

--- a/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.cxx
@@ -59,9 +59,19 @@ vtkMetaSurfaceMesh::vtkMetaSurfaceMesh()
   this->Type = vtkMetaDataSet::VTK_META_SURFACE_MESH;
 }
 
+vtkMetaSurfaceMesh::vtkMetaSurfaceMesh(const vtkMetaSurfaceMesh& other)
+    : vtkMetaDataSet(other)
+{
+}
+
 //----------------------------------------------------------------------------
 vtkMetaSurfaceMesh::~vtkMetaSurfaceMesh()
 {
+}
+
+vtkMetaSurfaceMesh* vtkMetaSurfaceMesh::Clone()
+{
+  return new vtkMetaSurfaceMesh(*this);
 }
 
 //----------------------------------------------------------------------------
@@ -84,7 +94,7 @@ void vtkMetaSurfaceMesh::Initialize()
 vtkPolyData* vtkMetaSurfaceMesh::GetPolyData() const
 {
   if (!this->DataSet)
-    return NULL;
+    return nullptr;
   return vtkPolyData::SafeDownCast (this->DataSet);
 }
 
@@ -693,7 +703,7 @@ void vtkMetaSurfaceMesh::CreateWirePolyData()
 void vtkMetaSurfaceMesh::ReadMeditCells(std::ifstream& file, vtkPolyData* mesh, int nbCellPoints, vtkDataArray* attrArray)
 {
   // get cell array
-  vtkCellArray* cells = NULL;
+  vtkCellArray* cells = nullptr;
   switch (nbCellPoints)
   {
     case 1:

--- a/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaSurfaceMesh.h
@@ -45,6 +45,8 @@ class MEDVTKINRIA_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
   static vtkMetaSurfaceMesh* New();
   vtkTypeRevisionMacro(vtkMetaSurfaceMesh,vtkMetaDataSet);
 
+  virtual vtkMetaSurfaceMesh* Clone() override;
+
   //BTX
   enum
   {
@@ -89,6 +91,7 @@ class MEDVTKINRIA_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
 
  protected:
   vtkMetaSurfaceMesh();
+  vtkMetaSurfaceMesh(const vtkMetaSurfaceMesh&);
   ~vtkMetaSurfaceMesh();
 
   virtual void ReadVtkFile(const char* filename);
@@ -111,7 +114,6 @@ class MEDVTKINRIA_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
  
  private:
   
-  vtkMetaSurfaceMesh(const vtkMetaSurfaceMesh&);       // Not implemented.
   void operator=(const vtkMetaSurfaceMesh&);        // Not implemented.
 
 };

--- a/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.cxx
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.cxx
@@ -48,10 +48,20 @@ vtkMetaVolumeMesh::vtkMetaVolumeMesh()
   this->Type = vtkMetaDataSet::VTK_META_VOLUME_MESH;
 }
 
+vtkMetaVolumeMesh::vtkMetaVolumeMesh(const vtkMetaVolumeMesh& other)
+  : vtkMetaDataSet(other)
+{
+}
+
 //----------------------------------------------------------------------------
 vtkMetaVolumeMesh::~vtkMetaVolumeMesh()
 {
 
+}
+
+vtkMetaVolumeMesh* vtkMetaVolumeMesh::Clone()
+{
+  return new vtkMetaVolumeMesh(*this);
 }
 
 //----------------------------------------------------------------------------
@@ -77,7 +87,7 @@ void vtkMetaVolumeMesh::Initialize()
 vtkUnstructuredGrid* vtkMetaVolumeMesh::GetUnstructuredGrid() const
 {
   if (!this->DataSet)
-    return NULL;
+    return nullptr;
   return vtkUnstructuredGrid::SafeDownCast (this->DataSet);
 }
 

--- a/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.h
+++ b/src/medVtkInria/vtkDataManagement/vtkMetaVolumeMesh.h
@@ -39,6 +39,8 @@ class MEDVTKINRIA_EXPORT vtkMetaVolumeMesh: public vtkMetaDataSet
   static vtkMetaVolumeMesh* New();
   vtkTypeRevisionMacro(vtkMetaVolumeMesh,vtkMetaDataSet);
 
+  virtual vtkMetaVolumeMesh* Clone() override;
+
   //BTX
   enum
   {
@@ -69,6 +71,7 @@ class MEDVTKINRIA_EXPORT vtkMetaVolumeMesh: public vtkMetaDataSet
   
  protected:
   vtkMetaVolumeMesh();
+  vtkMetaVolumeMesh(const vtkMetaVolumeMesh&);
   ~vtkMetaVolumeMesh();
 
   virtual void Initialize();
@@ -84,7 +87,6 @@ class MEDVTKINRIA_EXPORT vtkMetaVolumeMesh: public vtkMetaDataSet
 
  private:
   
-  vtkMetaVolumeMesh(const vtkMetaVolumeMesh&);      // Not implemented.
   void operator=(const vtkMetaVolumeMesh&);        // Not implemented.
 
 };


### PR DESCRIPTION
- Add a clone method and copy constructor for vtkDataMesh
- Add clone method and copy constructor for vtkMetaDataSet and children classes, i.e. vtkMetaSurfaceMesh, vtkMetaVolumeMesh, vtkMetaImageData and vtkMetaDataSetSequence.
N.B.: not implemented for vtkFiberDataSet as we are not using it for now.
- Trivializes the copy those types. As an example, some code in a process that copies the input:
**Old code**:
```cpp
        // create the underlying mesh
        vtkDataSet* outputMesh = nullptr;
        if (inputMetaDataSet->GetType() == vtkMetaDataSet::VTK_META_SURFACE_MESH)
        {
            outputMesh = vtkPolyData::New();
        }
        else
        {
            outputMesh = vtkUnstructuredGrid::New();
        }
        outputMesh->DeepCopy(d->mesh);

        // create the new abstract data
        vtkMetaSurfaceMesh* outputDataSet = vtkMetaSurfaceMesh::New();
        outputDataSet->SetDataSet(outputMesh);
        outputMesh->Delete();

        d->output = medAbstractDataFactory::instance()->createSmartPointer(d->input->identifier());
        d->output->setData(outputDataSet);
        outputDataSet->Delete();
```
**New code:**
```cpp
        d->output = d->input->clone();
```

Edited: nice colors