### PR TITLE
[vtkMetaDataSet] Fix memleak

### DIFF
--- a/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
+++ b/src-plugins/vtkDataMesh/readers/vtkDataMeshReader.cpp
@@ -61,14 +61,14 @@ bool vtkDataMeshReader::read(const QString& path) {
         if (!(medData->identifier() == "vtkDataMesh"))
             return false;
 
-        vtkMetaDataSet * dataSet = NULL;
+        vtkSmartPointer<vtkMetaDataSet> dataSet = NULL;
         if (vtkMetaVolumeMesh::CanReadFile(path.toLocal8Bit().constData()) != 0)
         {
-            dataSet = vtkMetaVolumeMesh::New();
+            dataSet = vtkSmartPointer<vtkMetaVolumeMesh>::New();
         }
         else if ( vtkMetaSurfaceMesh::CanReadFile(path.toLocal8Bit().constData()) != 0)
         {
-            dataSet = vtkMetaSurfaceMesh::New();
+            dataSet = vtkSmartPointer<vtkMetaSurfaceMesh>::New();
         }
         else
         {


### PR DESCRIPTION
- Fix memleak in vtkMetaDataSet when read from disk.
  Any mesh that was imported from the permanent DB into the view was not cleared from memory when closing the view...