### PR TITLE
[FIX] StatsROI : VOLUMEML

### DIFF
--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -84,7 +84,7 @@ public:
     medDoubleParameter * thresholdLowerValue;
     medDoubleParameter * thresholdUpperValue;
     QPointer<medClutEditorToolBox> clutEditor;
-
+    QLabel * infoThreshold;
     QWidget * thresholdValueWidget;
     QWidget * thresholdUpperWidget;
     QWidget * thresholdLowerWidget;
@@ -288,19 +288,22 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     d->thresholdFilterWidget = new QWidget(this);
 
     d->thresholdFilterValue = new medDoubleParameter( tr("Threshold Value"), this);
-    d->thresholdFilterValue->setRange ( -10000, 10000 );
+    d->thresholdFilterValue->setRange ( -1000000000.0, 1000000000.0);
     d->thresholdFilterValue->setValue ( itkFiltersThresholdingProcess::defaultThreshold );
     d->thresholdFilterValue->setObjectName("thresholdValue");
 
     d->thresholdLowerValue = new medDoubleParameter( tr("Lower Value"), this);
-    d->thresholdLowerValue->setRange ( -10000, 10000 );
+    d->thresholdLowerValue->setRange ( -1000000000.0, 1000000000.0 );
     d->thresholdLowerValue->setValue ( itkFiltersThresholdingProcess::defaultLower );
     d->thresholdLowerValue->setObjectName("lowerValue");
+    d->thresholdLowerValue->setDecimals(10);
 
     d->thresholdUpperValue = new medDoubleParameter( tr("Upper Value"), this);
-    d->thresholdUpperValue->setRange ( -10000, 10000 );
+    d->thresholdUpperValue->setRange ( -1000000000.0, 1000000000.0 );
     d->thresholdUpperValue->setValue ( itkFiltersThresholdingProcess::defaultUpper );
     d->thresholdUpperValue->setObjectName("upperValue");
+    d->thresholdUpperValue->setDecimals(10);
+
     QSignalMapper* signalMapper = new QSignalMapper(this);
     signalMapper->setMapping(d->thresholdLowerValue, 0);
     signalMapper->setMapping(d->thresholdUpperValue, 1);
@@ -318,6 +321,8 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
 
     d->binaryThreshold = new QRadioButton(tr("Binarize Image"), this);
     d->binaryThreshold->setObjectName("binaryThresholdButton");
+    d->infoThreshold = new QLabel("Values equal to the threshold value are not set to OutsideValue.");
+    d->infoThreshold->setWordWrap(true);
     connect(d->binaryThreshold, SIGNAL(toggled(bool)), this, SLOT(checkBinaryThreshold(bool)));
 
     d->histogram = new QCheckBox(tr("Open Histogram"), this);
@@ -382,6 +387,7 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
 
     QVBoxLayout * thresholdFilterLayout1 = new QVBoxLayout;
     thresholdFilterLayout1->addWidget( d->binaryThreshold );
+    thresholdFilterLayout1->addWidget( d->infoThreshold );
     thresholdFilterLayout1->addWidget( thresholdFilterLabel );
     thresholdFilterLayout1->addWidget( d->buttonGroupWidget );
     thresholdFilterLayout1->addWidget( d->thresholdLowerWidget );
@@ -1109,11 +1115,13 @@ void itkFiltersToolBox::checkBinaryThreshold(bool checked)
         d->thresholdFilterValue->getLabel()->setText( tr ( "Inside Value " ) );
         d->thresholdFilterValue->setValue ( itkFiltersBinaryThresholdingProcess::defaultInsideValue );
         d->thresholdFilterValue->setDecimals(0);
+        d->infoThreshold->setText("Values equal to either threshold is considered to be between the thresholds.");
     }
     else
     {
         d->thresholdFilterValue->getLabel()->setText( tr ( "Threshold Value " ) );
         d->thresholdFilterValue->setValue ( itkFiltersThresholdingProcess::defaultThreshold );
+        d->infoThreshold->setText("Values equal to the threshold value are not set to OutsideValue." );
     }
 }
 

--- a/src-plugins/itkFilters/itkFiltersToolBox.cpp
+++ b/src-plugins/itkFilters/itkFiltersToolBox.cpp
@@ -288,18 +288,18 @@ itkFiltersToolBox::itkFiltersToolBox ( QWidget *parent ) : medAbstractSelectable
     d->thresholdFilterWidget = new QWidget(this);
 
     d->thresholdFilterValue = new medDoubleParameter( tr("Threshold Value"), this);
-    d->thresholdFilterValue->setRange ( -1000000000.0, 1000000000.0);
+    d->thresholdFilterValue->setRange ( std::numeric_limits<double>::lowest() , std::numeric_limits<double>::max() );
     d->thresholdFilterValue->setValue ( itkFiltersThresholdingProcess::defaultThreshold );
     d->thresholdFilterValue->setObjectName("thresholdValue");
 
     d->thresholdLowerValue = new medDoubleParameter( tr("Lower Value"), this);
-    d->thresholdLowerValue->setRange ( -1000000000.0, 1000000000.0 );
+    d->thresholdLowerValue->setRange ( std::numeric_limits<double>::lowest() , std::numeric_limits<double>::max() );
     d->thresholdLowerValue->setValue ( itkFiltersThresholdingProcess::defaultLower );
     d->thresholdLowerValue->setObjectName("lowerValue");
     d->thresholdLowerValue->setDecimals(10);
 
     d->thresholdUpperValue = new medDoubleParameter( tr("Upper Value"), this);
-    d->thresholdUpperValue->setRange ( -1000000000.0, 1000000000.0 );
+    d->thresholdUpperValue->setRange ( std::numeric_limits<double>::lowest() , std::numeric_limits<double>::max() );
     d->thresholdUpperValue->setValue ( itkFiltersThresholdingProcess::defaultUpper );
     d->thresholdUpperValue->setObjectName("upperValue");
     d->thresholdUpperValue->setDecimals(10);

--- a/src/medUtilities/statsROI.cpp
+++ b/src/medUtilities/statsROI.cpp
@@ -174,7 +174,7 @@ public:
                     px[0] = x;
                     px[1] = y;
                     px[2] = sl;
-                    if (m_itkMask->GetPixel(px)!=0)
+                    if (m_itkMask->GetPixel(px)!=composite->outsideValue)
                     {
                         nbPixInMask++;
                     }
@@ -219,6 +219,7 @@ statsROI::statsROI()
 {
     this->computedOutput.empty();
     chooseFct = MEANVARIANCE;
+    outsideValue = 0;
 }
 
 statsROI::~statsROI()
@@ -244,6 +245,11 @@ void statsROI::setInput (medAbstractData *data, int channel)
 void statsROI::setParameter(statsParameter fct)
 {
     chooseFct = fct;
+}
+
+void statsROI::setParameter(double outsideValue)
+{
+    this->outsideValue = outsideValue;
 }
 
 // Convert medAbstractData to ITK volume

--- a/src/medUtilities/statsROI.h
+++ b/src/medUtilities/statsROI.h
@@ -26,6 +26,7 @@ public:
     std::vector<double> computedOutput;
     enum statsParameter {MEANVARIANCE, VOLUMEML, MINMAX};
     statsParameter chooseFct;
+    double outsideValue;
 
     statsROI();
     virtual ~statsROI();
@@ -35,7 +36,8 @@ public:
        
     //! Parameters are set through here, channel allows to handle multiple parameters
     void setParameter(statsParameter fct);
-
+    //! Parameter used only with VOLUMEML statsParameter
+    void setParameter(double outsideValue);
     //! Method to actually start the filter
     int update();
     


### PR DESCRIPTION
In Histogarm Analysis Toolbox.
The Wall volume computed before and after thresholding were wrong because the background value of the given masks were not 0...
Add a parameter to statsROI Process for Volume computing option.
