### PR TITLE
Add MUSIC plugins external project

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -68,6 +68,10 @@ else()
       )
 endif()
 
+list(APPEND external_projects
+    MUSIC_plugins
+    )
+
 if (USE_OSPRay)
   SET(ospray_DIR CACHE PATH "The directory containing a CMAKE configuration file for OSPRay")
   SET(OSPRAY_INSTALL_DIR CACHE PATH "Install location of OSPRay")

--- a/superbuild/projects_modules/MUSIC_plugins.cmake
+++ b/superbuild/projects_modules/MUSIC_plugins.cmake
@@ -1,0 +1,66 @@
+function(MUSIC_plugins_project)
+
+    set(external_project MUSIC_plugins)
+
+    list(APPEND ${external_project}_dependencies
+        medInria
+        dtk
+        ITK
+        VTK
+        )
+
+    EP_Initialisation(${external_project}
+        USE_SYSTEM OFF
+        BUILD_SHARED_LIBS ON
+        REQUIRED_FOR_PLUGINS ON
+        )
+
+    if (NOT USE_SYSTEM_${external_project})
+
+        set(git_url ${GITHUB_PREFIX}Inria-Asclepios/music.git)
+        set(git_tag music3)
+
+        set(${external_project}_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type for MUSIC plugins: None Debug Release RelWithDebInfo MinSizeRel")
+
+        set(cmake_args
+            ${ep_common_cache_args}
+            -DCMAKE_BUILD_TYPE=${${external_project}_BUILD_TYPE}
+            -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+            -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS_${external_project}}
+            -DQt5_DIR=${Qt5_DIR}
+            -Ddtk_DIR:FILEPATH=${dtk_DIR}
+            -DITK_DIR:FILEPATH=${ITK_DIR}
+            -DVTK_DIR:FILEPATH=${VTK_DIR}
+            -DmedInria_DIR:FILEPATH=${medInria_DIR}
+            -DBoost_INCLUDE_DIR=${Boost_INCLUDE_DIR}
+            )
+
+        epComputPath(${external_project})
+
+        ExternalProject_Add(${external_project}
+            PREFIX ${EP_PATH_SOURCE}
+            SOURCE_DIR ${EP_PATH_SOURCE}/${external_project}
+            BINARY_DIR ${build_path}
+            TMP_DIR ${tmp_path}
+            STAMP_DIR ${stamp_path}
+            GIT_REPOSITORY ${git_url}
+            GIT_TAG ${git_tag}
+            CMAKE_GENERATOR ${gen}
+            CMAKE_ARGS ${cmake_args}
+            DEPENDS ${${external_project}_dependencies}
+            INSTALL_COMMAND ""
+            UPDATE_COMMAND ""
+            BUILD_ALWAYS 1
+            )
+
+        set(EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS ${EXTERNAL_PROJECT_PLUGINS_LEGACY_DIRS} "${build_path}" PARENT_SCOPE)
+
+        ExternalProject_Get_Property(${external_project} binary_dir)
+        set(${external_project}_DIR ${binary_dir} PARENT_SCOPE)
+
+        ExternalProject_Get_Property(${external_project} source_dir)
+        set(${external_project}_SOURCE_DIR ${source_dir} PARENT_SCOPE)
+
+    endif()
+
+endfunction()


### PR DESCRIPTION
This PR adds the MUSIC plugins as an external project to medInria, to allow medInria's superbuild handle the download and configuration of the plugins. We won't have to clone the music repository separately anymore, and we won't have to manually specify the path to medInria's build, or fill in the private plugins path. This will all be done automatically, and the plugins will be placed in medInria's external projects folder (alongside dtk, ITK, VTK etc.). Ideally I would like to do this with all the repos (carmen, inria-private etc.), so that installing and configuring MUSIC will be much simpler.

Please note that:
- this will only work once the corresponding PR (to be posted) will be merged in the music repo.
- it is still possible to install the plugins as a private project, as before.