### PR TITLE
[minnor bug on medUtilities::switchTo3D]  unitialized variable 

### DIFF
--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -173,24 +173,25 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
                 break;
             }
         }
-
-        switch(mode3D)
-        {
-        case VR:
-            mode3DParam->setValue("VR");
-            break;
-        case MIP_MAXIMUM:
-            mode3DParam->setValue("MIP - Maximum");
-            break;
-        case MIP_MINIMUM:
-            mode3DParam->setValue("MIP - Minimum");
-            break;
-        case MSR:
-            mode3DParam->setValue("MSR");
-            break;
+        if(mode3DParam) {
+            switch(mode3D)
+            {
+            case VR:
+                mode3DParam->setValue("VR");
+                break;
+            case MIP_MAXIMUM:
+                mode3DParam->setValue("MIP - Maximum");
+                break;
+            case MIP_MINIMUM:
+                mode3DParam->setValue("MIP - Minimum");
+                break;
+            case MSR:
+                mode3DParam->setValue("MSR");
+                break;
+            }
         }
-
-        renderer3DParam->setValue("Ray Cast");
+        if(renderer3DParam)
+            renderer3DParam->setValue("Ray Cast");
     }
 }
 

--- a/src/medUtilities/medUtilities.cpp
+++ b/src/medUtilities/medUtilities.cpp
@@ -173,7 +173,8 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
                 break;
             }
         }
-        if(mode3DParam) {
+        if(mode3DParam) 
+	{
             switch(mode3D)
             {
             case VR:
@@ -190,8 +191,10 @@ void medUtilities::switchTo3D(medAbstractView *view, Mode3DType mode3D)
                 break;
             }
         }
-        if(renderer3DParam)
+        if(renderer3DParam) 
+	{
             renderer3DParam->setValue("Ray Cast");
+	}
     }
 }
 


### PR DESCRIPTION
crash when call to to switchTo3D      
    mode3DParam and  renderer3DParam could not have not been initialized. (that was my case) 
