### PR TITLE
Revert changes to medLogger related to filesystem.h

### DIFF
--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -140,12 +140,6 @@ target_link_libraries(${TARGET_NAME}
   medPacs
   )
 
-if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
-    target_link_libraries(${TARGET_NAME} stdc++fs)
-elseif (CMAKE_CXX_COMPILER_ID MATCHES "[cC][lL][aA][nN][gG]")
-    target_link_libraries(${TARGET_NAME} c++fs)
-endif()
-
 ## #############################################################################
 ## install
 ## #############################################################################

--- a/src/app/medInria/medLogger.cpp
+++ b/src/app/medInria/medLogger.cpp
@@ -1,12 +1,6 @@
 #include "medLogger.h"
+
 #include <fstream>
-#if __has_include(<filesystem>)
-  #include <filesystem>
-  namespace fs = std::filesystem;
-#else
-  #include <experimental/filesystem>
-  namespace fs = std::experimental::filesystem;
-#endif
 
 class medLoggerPrivate
 {
@@ -99,7 +93,8 @@ medLogger::medLogger() : d(new medLoggerPrivate)
     dtkLogger::instance().redirectCout();
 
     // Redirect Qt messages
-    QObject::connect(this, SIGNAL(newQtMessage(QtMsgType,QString)), this, SLOT(redirectQtMessage(QtMsgType,QString)));
+    QObject::connect(this, SIGNAL(newQtMessage(QtMsgType,QString)),
+                     this, SLOT(redirectQtMessage(QtMsgType,QString)));
     qInstallMessageHandler(qtMessageHandler);
 }
 
@@ -108,7 +103,8 @@ medLogger::~medLogger()
     dtkLogger::instance().detachFile(dtkLogPath(qApp));
     dtkLogger::instance().detachConsole();
 
-    QObject::disconnect(this, SIGNAL(newQtMessage(QtMsgType,QString)), this, SLOT(redirectQtMessage(QtMsgType,QString)));
+    QObject::disconnect(this, SIGNAL(newQtMessage(QtMsgType,QString)),
+                        this, SLOT(redirectQtMessage(QtMsgType,QString)));
     qInstallMessageHandler(nullptr);
 }
 
@@ -119,25 +115,25 @@ void medLogger::truncateLogFileIfHeavy()
     // Over 5Mo, the file is truncated from the beginning (old lines are discarded)
     if (filesize > d->maxLogSize)
     {
-        fs::path path = dtkLogPath(qApp).toStdString();
+        QString path = dtkLogPath(qApp);
 
         std::ifstream fin;
-        fin.open(path);
+        fin.open(path.toUtf8());
         fin.seekg(filesize - d->minLogSize); // file is going to be cut to minLogSize size
 
         std::string keptText;
         std::string line;
         while (getline(fin,line))
         {
-            keptText += line; //TODO redo with stringstream because it's very poor programing with string
+            keptText += line;
             keptText += "\n";
         }
 
         fin.close();
-        fs::remove(path);
+        std::remove(path.toUtf8());
 
         std::ofstream newLogFile;
-        newLogFile.open(path);
+        newLogFile.open(path.toUtf8());
         newLogFile << keptText;
         newLogFile.close();
     }


### PR DESCRIPTION
(see https://github.com/medInria/medInria-public/issues/423)

After synching with the upstream, MUSIC 3 doesn't compile. This reverts the faulty commits so that we can keep working on this branch while waiting for a fix.