### PR TITLE
[dtk] Fix dtkAbstractData copy constructor.

### DIFF
--- a/superbuild/patches/dtk-1.7.1.patch
+++ b/superbuild/patches/dtk-1.7.1.patch
@@ -1,0 +1,13 @@
+diff --git a/src/dtkCoreSupport/dtkAbstractData.cpp b/src/dtkCoreSupport/dtkAbstractData.cpp
+index 55a9b2e..80200af 100644
+--- a/src/dtkCoreSupport/dtkAbstractData.cpp
++++ b/src/dtkCoreSupport/dtkAbstractData.cpp
+@@ -36,7 +36,7 @@ dtkAbstractData::dtkAbstractData(dtkAbstractData *parent) : dtkAbstractObject(*n
+     d->numberOfChannels = 0;
+ }
+ 
+-dtkAbstractData::dtkAbstractData(const dtkAbstractData& other) : dtkAbstractObject(*new dtkAbstractDataPrivate(*other.d_func()), this)
++dtkAbstractData::dtkAbstractData(const dtkAbstractData& other) : dtkAbstractObject(*new dtkAbstractDataPrivate(*other.d_func()), other)
+ {
+ 
+ }

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -86,6 +86,8 @@ set(cmake_args
 ## Add external-project
 ## #############################################################################
 
+ep_GeneratePatchCommand(${ep} DTK_PATCH_COMMAND dtk-1.7.1.patch)
+
 epComputPath(${ep})
 
 ExternalProject_Add(${ep}
@@ -101,6 +103,7 @@ ExternalProject_Add(${ep}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
+  PATCH_COMMAND ${DTK_PATCH_COMMAND}
   INSTALL_COMMAND ""
   BUILD_ALWAYS 1
   )


### PR DESCRIPTION
Some classes inheriting from dtkAbstractData in music3 use an overriden clone method. This method calls the copy constructor of the object, which in turn calls the copy constructor of dtkAbstractData.
Something in the new dtk version causes music to crash.
This P.R. reverts the copy constructor to the previous dtk version (the one that music 2 uses)
