### PR TITLE
[PolygonROI] Fix wrong polygon positions after double click

### DIFF
--- a/src/plugins/legacy/polygonRoi/data/vtkContourOverlayRepresentation.cxx
+++ b/src/plugins/legacy/polygonRoi/data/vtkContourOverlayRepresentation.cxx
@@ -210,7 +210,18 @@ int vtkContourOverlayRepresentation::AddNodeOnContour( int X, int Y )
     return result;
 }
 
-int vtkContourOverlayRepresentation::AddNodeOnContourAtIndex(int X, int Y, int idx)
+int vtkContourOverlayRepresentation::AddNodeAtDisplayPosition(int X, int Y)
+{
+    int result = Superclass::AddNodeAtDisplayPosition(X,Y);
+    if (result)
+    {
+        needToSaveState = true;
+    }
+    this->InvokeEvent(vtkCommand::PlacePointEvent);
+    return result;
+}
+
+int vtkContourOverlayRepresentation::AddNodeAtDisplayPosition(double displayPos[2])
 {
     double worldPos[3];
     double worldOrient[9] = {1.0,0.0,0.0,
@@ -220,9 +231,6 @@ int vtkContourOverlayRepresentation::AddNodeOnContourAtIndex(int X, int Y, int i
     // Compute the world position from the display position
     // based on the concrete representation's constraints
     // If this is not a valid display location return 0
-    double displayPos[2];
-    displayPos[0] = X;
-    displayPos[1] = Y;
     if ( !this->PointPlacer->ComputeWorldPosition( this->Renderer,
                                                    displayPos, worldPos,
                                                    worldOrient) )
@@ -230,49 +238,15 @@ int vtkContourOverlayRepresentation::AddNodeOnContourAtIndex(int X, int Y, int i
         return 0;
     }
 
-    double pos[3];
+    // this is a hack: the previous method call should be able to compute
+    // the correct world position. The problem is it uses the camera's
+    // focal point, which is not correctly updated in at least one case:
+    // when the views are linked and the 'current point' is changed
+    // by double-clicking.
+    vtkInteractorObserver::ComputeDisplayToWorld(this->Renderer, displayPos[0], displayPos[1], 0.0, worldPos);
 
-    if ( !this->PointPlacer->ComputeWorldPosition( this->Renderer,
-                                                   displayPos,
-                                                   pos,
-                                                   worldPos,
-                                                   worldOrient) )
-    {
-        return 0;
-    }
-
-    // Add a new point at this position
-    vtkContourRepresentationNode *node = new vtkContourRepresentationNode;
-    node->WorldPosition[0] = worldPos[0];
-    node->WorldPosition[1] = worldPos[1];
-    node->WorldPosition[2] = worldPos[2];
-    node->Selected = 0;
-
-    this->GetRendererComputedDisplayPositionFromWorldPosition(
-                worldPos, worldOrient, node->NormalizedDisplayPosition );
-    this->Renderer->DisplayToNormalizedDisplay(
-                node->NormalizedDisplayPosition[0],
-            node->NormalizedDisplayPosition[1] );
-
-    memcpy(node->WorldOrientation, worldOrient, 9*sizeof(double) );
-
-    this->Internal->Nodes.insert(this->Internal->Nodes.begin() + idx, node);
-
-    this->UpdateLines( idx );
-    this->NeedToRender = 1;
-    this->needToSaveState = true;
+    this->AddNodeAtPositionInternal( worldPos, worldOrient, displayPos );
     return 1;
-}
-
-int vtkContourOverlayRepresentation::AddNodeAtDisplayPosition( int X, int Y )
-{
-    int result = Superclass::AddNodeAtDisplayPosition(X,Y);
-    if (result)
-    {
-        needToSaveState = true;
-    }
-    this->InvokeEvent(vtkCommand::PlacePointEvent);
-    return result;
 }
 
 int vtkContourOverlayRepresentation::GetNthNodeWorldPosition(int n, double worldPos[])

--- a/src/plugins/legacy/polygonRoi/data/vtkContourOverlayRepresentation.h
+++ b/src/plugins/legacy/polygonRoi/data/vtkContourOverlayRepresentation.h
@@ -42,7 +42,7 @@ public:
     // Description:
     // The class maintains its true contour locations based on display co-ords
     // This method syncs the world co-ords data structure with the display co-ords.
-    virtual void UpdateContourWorldPositionsBasedOnDisplayPositions();
+    void UpdateContourWorldPositionsBasedOnDisplayPositions() override;
 
     vtkSetMacro(needToSaveState, bool)
     vtkGetMacro(needToSaveState, bool)
@@ -52,8 +52,11 @@ public:
     int SaveState();
     void Undo();
     void Redo();
-    virtual void Initialize(vtkPolyData* polyData){Superclass::Initialize(polyData);}
-    virtual void WidgetInteraction(double eventPos[2]);
+    void Initialize(vtkPolyData* polyData) override
+    {
+        Superclass::Initialize(polyData);
+    }
+    void WidgetInteraction(double eventPos[2]) override;
 
     /**
      * @brief ComputeInteractionState is called when the mouse hovers a slice with a vtkContourRepresentation.
@@ -63,19 +66,20 @@ public:
      * @param vtkNotUsed
      * @return Interaction state: cursor is nearby a contour point or not (outside)
      */
-    virtual int ComputeInteractionState(int X, int Y, int vtkNotUsed(modified));
-    virtual int DeleteLastNode();
-    virtual int DeleteActiveNode();
-    virtual int DeleteNthNode( int n );
-    virtual void ClearAllNodes();
-    virtual int AddNodeOnContour( int X, int Y );
-    virtual int AddNodeOnContourAtIndex(int X, int Y, int idx);
-    virtual int AddNodeAtDisplayPosition( int X, int Y );
-    virtual int GetNthNodeWorldPosition(int n, double worldPos[3]);
-    virtual int GetIntermediatePointWorldPosition(int n, int idx, double point[3]);
-    virtual int FindClosestPointOnContour( int X, int Y,
+    int ComputeInteractionState(int X, int Y, int vtkNotUsed(modified)) override;
+    int DeleteLastNode() override;
+    int DeleteActiveNode() override;
+    int DeleteNthNode( int n ) override;
+    void ClearAllNodes() override;
+    int AddNodeOnContour( int X, int Y ) override;
+    int AddNodeAtDisplayPosition( int X, int Y ) override;
+    int AddNodeAtDisplayPosition( double displayPos[2] ) override;
+
+    int GetNthNodeWorldPosition(int n, double worldPos[3]) override;
+    int GetIntermediatePointWorldPosition(int n, int idx, double point[3]) override;
+    int FindClosestPointOnContour( int X, int Y,
                                    double worldPos[3],
-                                   int *idx );
+                                   int *idx ) override;
 
 protected:
     vtkContourOverlayRepresentation();

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -135,6 +135,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
 polygonRoiToolBox::~polygonRoiToolBox()
 {
     delete viewEventFilter;
+    viewEventFilter = nullptr;
 }
 
 bool polygonRoiToolBox::registered()


### PR DESCRIPTION
- Hack to fix problem with polygon world positions after double clicking in a linked view
N.B. this does not fix the origin of the problem, which lies with the camera's focal point not being correctly updated.

- Fix seg fault when closing MUSIC in the polygonROI toolbox