### PR TITLE
Adapt for qt5.15

### DIFF
--- a/superbuild/patches/VTK.patch
+++ b/superbuild/patches/VTK.patch
@@ -1,0 +1,24 @@
+diff --git a/Rendering/Qt/vtkQtLabelRenderStrategy.cxx b/Rendering/Qt/vtkQtLabelRenderStrategy.cxx
+index 8bfd3f6b6b..2d5adb1834 100644
+--- a/Rendering/Qt/vtkQtLabelRenderStrategy.cxx
++++ b/Rendering/Qt/vtkQtLabelRenderStrategy.cxx
+@@ -40,6 +40,7 @@
+ #include <QImage>
+ #include <QMap>
+ #include <QPainter>
++#include <QPainterPath>
+ #include <QPair>
+ #include <QPixmap>
+ #include <QTextDocument>
+diff --git a/Rendering/Qt/vtkQtStringToImage.cxx b/Rendering/Qt/vtkQtStringToImage.cxx
+index 549ffbe874..7f5a71adcb 100644
+--- a/Rendering/Qt/vtkQtStringToImage.cxx
++++ b/Rendering/Qt/vtkQtStringToImage.cxx
+@@ -34,6 +34,7 @@
+ #include <QPixmap>
+ #include <QTextDocument>
+ #include <QTextStream>
++#include <QPainterPath>
+ 
+ namespace
+ {

--- a/superbuild/patches/qwt-6.3-svn.patch
+++ b/superbuild/patches/qwt-6.3-svn.patch
@@ -1,0 +1,67 @@
+Index: qwt/qwtconfig.pri
+===================================================================
+--- qwt/qwtconfig.pri	(revision 3206)
++++ qwt/qwtconfig.pri	(working copy)
+@@ -72,7 +72,7 @@
+ # it will be a static library.
+ ######################################################################
+ 
+-QWT_CONFIG           += QwtDll
++QWT_CONFIG           -= QwtDll
+ 
+ ######################################################################
+ # QwtPlot enables all classes, that are needed to use the QwtPlot
+@@ -93,7 +93,7 @@
+ # export a plot to a SVG document
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtSvg
++QWT_CONFIG     -= QwtSvg
+ 
+ ######################################################################
+ # If you want to use a OpenGL plot canvas
+@@ -110,7 +110,7 @@
+ # to your qmake project file.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtMathML
++QWT_CONFIG     -= QwtMathML
+ 
+ ######################################################################
+ # If you want to build the Qwt designer plugin,
+@@ -118,7 +118,7 @@
+ # Otherwise you have to build it from the designer directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtDesigner
++QWT_CONFIG     -= QwtDesigner
+ 
+ ######################################################################
+ # Compile all Qwt classes into the designer plugin instead
+@@ -141,7 +141,7 @@
+ # Otherwise you have to build them from the examples directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtExamples
++QWT_CONFIG     -= QwtExamples
+ 
+ ######################################################################
+ # The playground is primarily intended for the Qwt development
+@@ -152,7 +152,7 @@
+ # Otherwise you have to build them from the playground directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtPlayground
++QWT_CONFIG     -= QwtPlayground
+ 
+ ######################################################################
+ # If you want to auto build the tests, enable the line below
+@@ -159,7 +159,7 @@
+ # Otherwise you have to build them from the tests directory.
+ ######################################################################
+ 
+-QWT_CONFIG     += QwtTests
++QWT_CONFIG     -= QwtTests
+ 
+ ######################################################################
+ # When Qt has been built as framework qmake wants

--- a/superbuild/patches/qwt-6.3-svn.patch
+++ b/superbuild/patches/qwt-6.3-svn.patch
@@ -65,3 +65,20 @@ Index: qwt/qwtconfig.pri
  
  ######################################################################
  # When Qt has been built as framework qmake wants
+Index: qwt/src/qwt_plot_abstract_canvas.cpp
+===================================================================
+--- qwt/src/qwt_plot_abstract_canvas.cpp	(revision 3206)
++++ qwt/src/qwt_plot_abstract_canvas.cpp	(working copy)
+@@ -589,9 +589,9 @@
+ 
+     canvasWidget->setAutoFillBackground( true );
+ 
+-    canvasWidget->setProperty( "lineWidth", 2 );
+-    canvasWidget->setProperty( "frameShadow", QFrame::Sunken );
+-    canvasWidget->setProperty( "frameShape", QFrame::Panel );
++    //canvasWidget->setProperty( "lineWidth", 2 );
++    //canvasWidget->setProperty( "frameShadow", QFrame::Sunken );
++    //canvasWidget->setProperty( "frameShape", QFrame::Panel );
+ }
+ 
+ QwtPlotAbstractCanvas::~QwtPlotAbstractCanvas()

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -41,6 +41,7 @@ if (NOT USE_SYSTEM_${ep})
 set(git_url ${GITHUB_PREFIX}Kitware/VTK.git)
 set(git_tag v8.1.2)
 
+
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
 ## #############################################################################
@@ -77,6 +78,13 @@ if(USE_OSPRay)
   -Dospray_DIR=${ospray_DIR}
   -DOSPRAY_INSTALL_DIR=${OSPRAY_INSTALL_DIR})
 endif()
+
+## #############################################################################
+## Check if patch has to be applied
+## #############################################################################
+ 
+ep_GeneratePatchCommand(VTK VTK_PATCH_COMMAND VTK.patch)
+
 ## #############################################################################
 ## Add external-project
 ## #############################################################################
@@ -92,6 +100,7 @@ ExternalProject_Add(${ep}
   
   GIT_REPOSITORY ${git_url}
   GIT_TAG ${git_tag}
+  PATCH_COMMAND ${VTK_PATCH_COMMAND}
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}

--- a/superbuild/projects_modules/qwt.cmake
+++ b/superbuild/projects_modules/qwt.cmake
@@ -24,8 +24,10 @@ if (NOT USE_SYSTEM_${ep})
 ## Define repository where get the sources
 ## #############################################################################
 
-set(git_url ${GITHUB_PREFIX}osakared/qwt.git)
-set(git_tag trunk)
+#set(git_url ${GITHUB_PREFIX}osakared/qwt.git)
+#set(git_tag trunk)
+
+set(svn_url https://svn.code.sf.net/p/qwt/code/trunk)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -46,7 +48,7 @@ set(cmake_args
   -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
 )
 
-ep_GeneratePatchCommand(${ep} QWT_PATCH_COMMAND qwt-6.3.patch)
+#ep_GeneratePatchCommand(${ep} QWT_PATCH_COMMAND qwt-6.3-svn.patch)
 
 ## #############################################################################
 ## Add external-project
@@ -71,15 +73,15 @@ ExternalProject_Add(${ep}
   BINARY_DIR ${build_path}
   TMP_DIR ${tmp_path}
   STAMP_DIR ${stamp_path}
-
-  GIT_REPOSITORY ${git_url}
-  GIT_TAG ${git_tag}
+  #GIT_REPOSITORY ${git_url}
+  SVN_REPOSITORY ${svn_url}
+  #GIT_TAG ${git_tag}
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   UPDATE_COMMAND ""
-  PATCH_COMMAND ${QWT_PATCH_COMMAND}
+  PATCH_COMMAND svn patch ${CMAKE_SOURCE_DIR}/superbuild/patches/qwt-6.3-svn.patch
   # Compile only the lib
   CONFIGURE_COMMAND ${QT_QMAKE_EXECUTABLE} ${SPEC} <SOURCE_DIR>/qwt/qwt.pro
   BUILD_COMMAND ${MAKE_PROGRAM} sub-src

--- a/superbuild/projects_modules/qwt.cmake
+++ b/superbuild/projects_modules/qwt.cmake
@@ -45,8 +45,6 @@ set(cmake_args
   -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
 )
 
-#ep_GeneratePatchCommand(${ep} QWT_PATCH_COMMAND qwt-6.3-svn.patch)
-
 ## #############################################################################
 ## Add external-project
 ## #############################################################################

--- a/superbuild/projects_modules/qwt.cmake
+++ b/superbuild/projects_modules/qwt.cmake
@@ -68,9 +68,7 @@ ExternalProject_Add(${ep}
   BINARY_DIR ${build_path}
   TMP_DIR ${tmp_path}
   STAMP_DIR ${stamp_path}
-  #GIT_REPOSITORY ${git_url}
   SVN_REPOSITORY ${svn_url}
-  #GIT_TAG ${git_tag}
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}

--- a/superbuild/projects_modules/qwt.cmake
+++ b/superbuild/projects_modules/qwt.cmake
@@ -24,9 +24,6 @@ if (NOT USE_SYSTEM_${ep})
 ## Define repository where get the sources
 ## #############################################################################
 
-#set(git_url ${GITHUB_PREFIX}osakared/qwt.git)
-#set(git_tag trunk)
-
 set(svn_url https://svn.code.sf.net/p/qwt/code/trunk)
 
 ## #############################################################################


### PR DESCRIPTION
Use the svn repo that is up to date and  can compile  with qt5.15. 
Update the patch and patch command. 

The patch include the problematic when the base class constructor is calling method on son but this one may not have finished to be constructed. 
A ticket has been create on the official repo. 
https://sourceforge.net/p/qwt/bugs/320/

The temp sol is to comment those lines and wait for qwt support answer. 

it is ok but qt5.15 is not valid with current version of medinria (vtk 8.1.2 does not compile with qt 5.15) 
