### PR TITLE
[EP: zlib] Add zlib as external project

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -64,6 +64,7 @@ list(APPEND external_projects
      qwt
      mmg
      tetgen
+     zlib
      quazip
      )
 

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -57,6 +57,7 @@ function(music_plugins_project)
             -DTETGEN_INCLUDE_DIR:FILEPATH=${tetgen_INCLUDE_DIR}
             -DTETGEN_DIR:FILEPATH=${tetgen_DIR}
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
+            -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
             )
 
         epComputPath(${external_project})

--- a/superbuild/projects_modules/quazip.cmake
+++ b/superbuild/projects_modules/quazip.cmake
@@ -6,7 +6,8 @@ set(ep quazip)
 ## List the dependencies of the project
 ## #############################################################################
 
-list(APPEND ${ep}_dependencies "")
+list(APPEND ${ep}_dependencies
+     zlib)
   
 ## #############################################################################
 ## Prepare the project
@@ -43,7 +44,8 @@ set(cmake_args
   -DCMAKE_CXX_FLAGS:STRING=${${ep}_cxx_flags}
   -DCMAKE_SHARED_LINKER_FLAGS:STRING=${${ep}_shared_linker_flags}
   -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-  -DQT_QMAKE_EXECUTABLE:FILEPATH=${QT_QMAKE_EXECUTABLE}
+  # to find zlib 
+  -DCMAKE_PREFIX_PATH:FILEPATH=${zlib_DIR}
 )
 
 ## #############################################################################
@@ -53,24 +55,7 @@ if(APPLE)
   set(SPEC -spec macx-clang)
 endif()
 
-set(MAKE_PROGRAM ${CMAKE_MAKE_PROGRAM})
-if(WIN32)
-  set(MAKE_PROGRAM nmake)
-endif()
-
 find_package(Qt5 REQUIRED Core)
-get_target_property (QT_QMAKE_EXECUTABLE Qt5::qmake IMPORTED_LOCATION)
-
-find_package(ZLIB REQUIRED)
-
-## quazip fails to compile if zlib is found in an already
-## included default path.
-if (UNIX)
-  string(COMPARE EQUAL ${ZLIB_INCLUDE_DIRS} "/usr/include" _cmp)
-  if (_cmp)
-    set(ZLIB_INCLUDE_DIRS "")
-  endif (_cmp)
-endif (UNIX)
 
 epComputPath(${ep})
 
@@ -88,8 +73,7 @@ ExternalProject_Add(${ep}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND ${QT_QMAKE_EXECUTABLE} ${SPEC} PREFIX=${build_path} CONFIG+=staticlib LIBS+=${ZLIB_LIBRARIES} INCLUDEPATH+=${ZLI_INCLUDE_DIRS} <SOURCE_DIR>/quazip.pro
-  BUILD_COMMAND ${MAKE_PROGRAM} sub-quazip-install_subtargets
+  BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} quazip_static
   INSTALL_COMMAND ""
 )
 
@@ -97,8 +81,8 @@ ExternalProject_Add(${ep}
 ## Set variable to provide infos about the project
 ## #############################################################################
 
-ExternalProject_Get_Property(${ep} binary_dir)
 set(${ep}_DIR ${build_path} PARENT_SCOPE)
+set(${ep}_INCLUDE_DIR ${EP_PATH_SOURCE}/${ep} PARENT_SCOPE)
 
 endif() #NOT USE_SYSTEM_ep
 

--- a/superbuild/projects_modules/zlib.cmake
+++ b/superbuild/projects_modules/zlib.cmake
@@ -1,0 +1,49 @@
+function(zlib_project)
+
+    set(external_project zlib)
+
+    list(APPEND ${external_project}_dependencies
+        )
+
+    EP_Initialisation(${external_project}
+        USE_SYSTEM OFF
+        BUILD_SHARED_LIBS ON
+        REQUIRED_FOR_PLUGINS OFF
+        )
+
+    if (NOT USE_SYSTEM_${external_project})
+
+        set(git_url ${GITHUB_PREFIX}madler/zlib.git)
+        set(git_tag v1.2.11)
+
+        set(${external_project}_BUILD_TYPE RelWithDebInfo CACHE STRING "Build type for zlib: None Debug Release RelWithDebInfo MinSizeRel")
+
+        set(cmake_args
+            ${ep_common_cache_args}
+            -DCMAKE_BUILD_TYPE=${${external_project}_BUILD_TYPE}
+            -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+            -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS_${external_project}}
+            )
+
+        epComputPath(${external_project})
+
+        ExternalProject_Add(${external_project}
+            PREFIX ${EP_PATH_SOURCE}
+            SOURCE_DIR ${EP_PATH_SOURCE}/${external_project}
+            BINARY_DIR ${build_path}
+            TMP_DIR ${tmp_path}
+            STAMP_DIR ${stamp_path}
+
+            GIT_REPOSITORY ${git_url}
+            GIT_TAG ${git_tag}
+            CMAKE_GENERATOR ${gen}
+            CMAKE_ARGS ${cmake_args}
+            DEPENDS ${${external_project}_dependencies}
+            UPDATE_COMMAND ""
+            )
+
+        set(${external_project}_DIR ${build_path} PARENT_SCOPE)
+
+    endif()
+
+endfunction()


### PR DESCRIPTION
- Zlib now an external project
- Change quazip compilation: uses CMake now, no fancy configuration step
- music-plugins compilation adjustments

N.B. Requires clean build of music-plugins and quazip.