### PR TITLE
Remove use of vtk during mmg compilation

### DIFF
--- a/superbuild/projects_modules/mmg.cmake
+++ b/superbuild/projects_modules/mmg.cmake
@@ -51,6 +51,7 @@ set(cmake_args
     -DBUILD_MMG:BOOL=ON
     -DLIBMMG_SHARED:BOOL=${BUILD_SHARED_LIBS_${ep}}
     -DUSE_SCOTCH:BOOL=OFF
+    -DUSE_VTK:BOOL=OFF
   )
 
 ## #############################################################################


### PR DESCRIPTION
Fix compilation error when more than one vtk is compiled on the laptop we do not need vtk in mmg