### PR TITLE
Keep old MUSIC database location when updating to MUSICardio

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medStorage.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medStorage.cpp
@@ -54,19 +54,30 @@ QString medStorage::dataLocation()
     {
         vDbLoc = medSettingsManager::instance()->value("database", "actual_database_location").toString();
 
-        // if the location is still not set we return the default paths
+        // if the location is still not set we search for an old setting or return the default paths
         if ( vDbLoc.isEmpty() )
         {
+            QSettings oldSettings("fr", "MUSIC");
+            QString oldDatabaseLocation = oldSettings.value("database/actual_database_location").toString();
+
+            if (!oldDatabaseLocation.isEmpty())
+            {
+                vDbLoc = oldDatabaseLocation;
+            }
+            else
+            {
 #ifdef Q_OS_MAC
-            vDbLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
-                    + "/" + QCoreApplication::organizationName()
-                    + "/" + QCoreApplication::applicationName();
+                vDbLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+                         + "/" + QCoreApplication::organizationName()
+                         + "/" + QCoreApplication::applicationName();
 #else
-            vDbLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
-                    + "/data/" + QCoreApplication::organizationName()
-                    + "/" + QCoreApplication::applicationName();
+                vDbLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation)
+                         + "/data/" + QCoreApplication::organizationName()
+                         + "/" + QCoreApplication::applicationName();
 #endif
+            }
         }
+
         setDataLocation(vDbLoc);
     }
     return vDbLoc;


### PR DESCRIPTION
The passage to MUSIC 3, and then MUSICardio, has caused the database location setting to be reset each time. This PR allows the setting that was used by the last release of MUSIC (2.4) to be retrieved if someone uses MUSICardio for the first time.
(please note it does not retrieve the setting for MUSIC 3, but this is not a problem since there are no users of MUSIC 3)

To test this you must reset your setting. On mac this is done with the following terminal command:
`defaults delete com.fr.MUSICardio database.actual_database_location`