### PR TITLE
Removing redirection of cerr and cout messages

### DIFF
--- a/src/app/medInria/medLogger.cpp
+++ b/src/app/medInria/medLogger.cpp
@@ -100,10 +100,6 @@ medLogger::medLogger() : d(new medLoggerPrivate)
     dtkLogger::instance().attachFile(dtkLogPath(qApp));
     dtkLogger::instance().attachConsole();
 
-    // Redirect cerr and cout messages
-    dtkLogger::instance().redirectCerr();
-    dtkLogger::instance().redirectCout();
-
     // Redirect Qt messages
     QObject::connect(this, SIGNAL(newQtMessage(QtMsgType,QString)), this, SLOT(redirectQtMessage(QtMsgType,QString)));
     qInstallMessageHandler(qtMessageHandler);


### PR DESCRIPTION
This redirection forces cout messages onto qDebug() but float values are badly interpreted and special characters appear
