### PR TITLE
add a variable used by other project to find openssl

### DIFF
--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -58,7 +58,7 @@ function(music_plugins_project)
             -DTETGEN_DIR:FILEPATH=${tetgen_DIR}
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
-	    -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR} 
+            -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR} 
             )
 
         epComputPath(${external_project})

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -58,6 +58,7 @@ function(music_plugins_project)
             -DTETGEN_DIR:FILEPATH=${tetgen_DIR}
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
+	    -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR} 
             )
 
         epComputPath(${external_project})

--- a/superbuild/projects_modules/openssl.cmake
+++ b/superbuild/projects_modules/openssl.cmake
@@ -111,6 +111,8 @@ endif (WIN32)
 set(build_dir ${build_path})
 set(${ep}_DIR ${build_dir} PARENT_SCOPE)
 
+set(OPENSSL_ROOT_DIR "${EP_PATH_SOURCE}/${ep}" PARENT_SCOPE)
+
 endif() #NOT USE_SYSTEM_ep
 
 endfunction()


### PR DESCRIPTION
compute OPENSSL_ROOT_DIR var to help other cmake proj (other plugins) to find openssl