### PR TITLE
missing build step in json: improve usage of the lib

### DIFF
--- a/superbuild/projects_modules/jsoncons.cmake
+++ b/superbuild/projects_modules/jsoncons.cmake
@@ -38,11 +38,9 @@ ExternalProject_Add(${ep}
   GIT_REPOSITORY ${git_url}
   GIT_TAG ${git_tag}
   DEPENDS ${${ep}_dependencies}
-  UPDATE_COMMAND ""
-  CONFIGURE_COMMAND ${CMAKE_COMMAND} -E echo "Jsoncons - no configure step required."
-  # Nothing to build
-  BUILD_COMMAND ""
-  INSTALL_COMMAND ""
+  CMAKE_GENERATOR ${gen}
+  CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+  CMAKE_ARGS ${cmake_args} 
   )
 ## #############################################################################
 ## Set variable to provide infos about the project


### PR DESCRIPTION
missing build step. 
some cmake files are not generated: jsonconsConfig.cmake, ... 