### PR TITLE
WIN32 - Add ZLIB_DIR and missing CMAKE_GENERATOR_PLATFORM

### DIFF
--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -10,13 +10,14 @@ function(music_plugins_project)
         medInria
         jsoncons
         asio
-        websocketpp
-        openssl
+		websocketpp
+		openssl
         mmg
         tetgen
         eigen
         qwt
         quazip
+		zlib
         )
 
     EP_Initialisation(${external_project}
@@ -58,11 +59,11 @@ function(music_plugins_project)
             -DTETGEN_DIR:FILEPATH=${tetgen_DIR}
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
-            -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR} 
+            -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR}
+			-DZLIB_DIR:FILEPATH=${zlib_DIR}
             )
 
         epComputPath(${external_project})
-
         ExternalProject_Add(${external_project}
             PREFIX ${EP_PATH_SOURCE}
             SOURCE_DIR ${EP_PATH_SOURCE}/${external_project}
@@ -72,6 +73,7 @@ function(music_plugins_project)
             GIT_REPOSITORY ${git_url}
             GIT_TAG ${git_tag}
             CMAKE_GENERATOR ${gen}
+			CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
             DEPENDS ${${external_project}_dependencies}
             INSTALL_COMMAND ""
@@ -88,5 +90,19 @@ function(music_plugins_project)
         set(${external_project}_SOURCE_DIR ${source_dir} PARENT_SCOPE)
 
     endif()
+
+
+if (WIN32)
+  file(TO_NATIVE_PATH ${zlib_DIR}                 ZLIB_BIN_BASE)
+  
+  set(CONFIG_MODE $<$<CONFIG:debug>:Debug>$<$<CONFIG:release>:Release>$<$<CONFIG:MinSizeRel>:MinSizeRel>$<$<CONFIG:RelWithDebInfo>:RelWithDebInfo>)
+  
+  set(MED_BIN_BASE ${MED_BIN_BASE}\\${CONFIG_MODE}\\bin)  
+  
+  add_custom_command(TARGET ${external_project}
+        POST_BUILD
+        COMMAND for %%I in ( ${ZLIB_BIN_BASE}\\bin\\${CONFIG_MODE}\\*.dll ) do (if EXIST ${MED_BIN_BASE}\\%%~nxI (del /S ${MED_BIN_BASE}\\%%~nxI & mklink /H ${MED_BIN_BASE}\\%%~nxI %%~fI) else mklink /H ${MED_BIN_BASE}\\%%~nxI %%~fI) 
+    )
+endif()
 
 endfunction()

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -10,14 +10,14 @@ function(music_plugins_project)
         medInria
         jsoncons
         asio
-		websocketpp
-		openssl
+	websocketpp
+	openssl
         mmg
         tetgen
         eigen
         qwt
         quazip
-		zlib
+	zlib
         )
 
     EP_Initialisation(${external_project}
@@ -60,7 +60,7 @@ function(music_plugins_project)
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
             -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR}
-			-DZLIB_DIR:FILEPATH=${zlib_DIR}
+	    -DZLIB_DIR:FILEPATH=${zlib_DIR}
             )
 
         epComputPath(${external_project})
@@ -73,7 +73,7 @@ function(music_plugins_project)
             GIT_REPOSITORY ${git_url}
             GIT_TAG ${git_tag}
             CMAKE_GENERATOR ${gen}
-			CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+	    CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
             DEPENDS ${${external_project}_dependencies}
             INSTALL_COMMAND ""

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -10,14 +10,14 @@ function(music_plugins_project)
         medInria
         jsoncons
         asio
-	websocketpp
-	openssl
+		websocketpp
+		openssl
         mmg
         tetgen
         eigen
         qwt
         quazip
-	zlib
+		zlib
         )
 
     EP_Initialisation(${external_project}
@@ -73,7 +73,7 @@ function(music_plugins_project)
             GIT_REPOSITORY ${git_url}
             GIT_TAG ${git_tag}
             CMAKE_GENERATOR ${gen}
-	    CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+	    	CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
             DEPENDS ${${external_project}_dependencies}
             INSTALL_COMMAND ""

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -10,14 +10,14 @@ function(music_plugins_project)
         medInria
         jsoncons
         asio
-		websocketpp
-		openssl
+        websocketpp
+        openssl
         mmg
         tetgen
         eigen
         qwt
         quazip
-		zlib
+        zlib
         )
 
     EP_Initialisation(${external_project}
@@ -60,7 +60,7 @@ function(music_plugins_project)
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
             -DOPENSSL_ROOT_DIR:FILEPATH=${OPENSSL_ROOT_DIR}
-	    -DZLIB_DIR:FILEPATH=${zlib_DIR}
+            -DZLIB_DIR:FILEPATH=${zlib_DIR}
             )
 
         epComputPath(${external_project})
@@ -73,7 +73,7 @@ function(music_plugins_project)
             GIT_REPOSITORY ${git_url}
             GIT_TAG ${git_tag}
             CMAKE_GENERATOR ${gen}
-	    	CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+            CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
             DEPENDS ${${external_project}_dependencies}
             INSTALL_COMMAND ""

--- a/superbuild/projects_modules/zlib.cmake
+++ b/superbuild/projects_modules/zlib.cmake
@@ -38,7 +38,7 @@ function(zlib_project)
             GIT_REPOSITORY ${git_url}
             GIT_TAG ${git_tag}
             CMAKE_GENERATOR ${gen}
-			CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
+            CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
             DEPENDS ${${external_project}_dependencies}
             UPDATE_COMMAND ""

--- a/superbuild/projects_modules/zlib.cmake
+++ b/superbuild/projects_modules/zlib.cmake
@@ -38,6 +38,7 @@ function(zlib_project)
             GIT_REPOSITORY ${git_url}
             GIT_TAG ${git_tag}
             CMAKE_GENERATOR ${gen}
+			CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
             DEPENDS ${${external_project}_dependencies}
             UPDATE_COMMAND ""


### PR DESCRIPTION
Some minor modifications in external project cmake (music-plugins.cmake)
to be able to:
- find zlib 
- build dependencies with the good arch (x64)