### PR TITLE
[Multi-part reading] Enable import of multi-part files

### DIFF
--- a/src/layers/legacy/medCoreLegacy/CMakeLists.txt
+++ b/src/layers/legacy/medCoreLegacy/CMakeLists.txt
@@ -41,6 +41,7 @@ list_source_files(${TARGET_NAME}
   views/interactors
   views/navigators
   parameters
+  readers
   resources
   )
 

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -246,7 +246,9 @@ void medAbstractDatabaseImporter::importFile ( void )
                     currentSeriesId = medMetaDataKeys::SeriesID.getFirstValue(medData);
                 }
                 else
+                {
                     medData->setMetaData ( medMetaDataKeys::SeriesID.key(), QStringList() << currentSeriesId );
+                }
 
                 // 2.3) Generate an unique id for each volume
                 // all images of the same volume should share the same id
@@ -586,9 +588,6 @@ void medAbstractDatabaseImporter::populateMissingMetadata ( medAbstractData* med
 
     if ( !medData->hasMetaData ( medMetaDataKeys::StudyID.key() ) )
         medData->setMetaData ( medMetaDataKeys::StudyID.key(), QStringList() << "0" );
-
-    if ( !medData->hasMetaData ( medMetaDataKeys::SeriesInstanceUID.key() ) )
-        medData->setMetaData ( medMetaDataKeys::SeriesInstanceUID.key(), QStringList() << "" );
 
     QString generatedSeriesId = QUuid::createUuid().toString().replace("{","").replace("}","");
 

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -364,7 +364,7 @@ void medAbstractDatabaseImporter::importFile ( void )
 
             dtkSmartPointer<medAbstractData> medData = data[i];
             QString aggregatedFileName = it.value()[i]; // note that this file might be aggregating more than one input files
-            if (medData)
+            if (!medData.isNull())
             {
                 // 3.3) a) re-populate missing metadata
                 // as files might be aggregated we use the aggregated file name as SeriesDescription (if not provided, of course)

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -271,7 +271,7 @@ void medAbstractDatabaseImporter::importFile ( void )
                 // i.e.: where we will write the imported image
                 QString imageFileName = determineFutureImageFileName ( medData, volumeUniqueIdToVolumeNumber[volumeId] );
 #ifdef Q_OS_WIN32
-                if ( (medStorage::dataLocation() + "/" + imageFileName).length() > 255 )
+                if ( (medStorage::dataLocation() + QDir::separator() + imageFileName).length() > 255 )
                 {
                     emit showError ( tr ( "Your database path is too long" ), 5000 );
                     emit dataImported(medDataIndex(), d->uuid);
@@ -411,7 +411,7 @@ void medAbstractDatabaseImporter::importFile ( void )
 
             // and finally we populate the database
             QFileInfo aggregatedFileNameFileInfo(aggregatedFileName);
-            QString pathToStoreThumbnails = aggregatedFileNameFileInfo.dir().path() + "/" + aggregatedFileNameFileInfo.completeBaseName() + "/";
+            QString pathToStoreThumbnails = aggregatedFileNameFileInfo.dir().path() + QDir::separator() + aggregatedFileNameFileInfo.completeBaseName() + QDir::separator();
             index = this->populateDatabaseAndGenerateThumbnails(medData, pathToStoreThumbnails);
 
             if(!d->uuid.isNull())
@@ -486,8 +486,8 @@ void medAbstractDatabaseImporter::importData()
 
     if ( !d->indexWithoutImporting )
     {
-        QString subDirName = "/" + patientId;
-        QString imageFileNameBase =  subDirName + "/" +  seriesId;
+        QString subDirName = QDir::separator() + patientId;
+        QString imageFileNameBase =  subDirName + QDir::separator() +  seriesId;
 
         QDir dir ( medStorage::dataLocation() + subDirName );
         if ( !dir.exists() )
@@ -520,7 +520,7 @@ void medAbstractDatabaseImporter::importData()
         }
 
          QFileInfo   seriesInfo ( imageFileName );
-         thumb_dir = seriesInfo.dir().path() + "/" + seriesInfo.completeBaseName() + "/";
+         thumb_dir = seriesInfo.dir().path() + QDir::separator() + seriesInfo.completeBaseName() + QDir::separator();
     }
 
     // Now, populate the database

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -327,8 +327,8 @@ void medAbstractDatabaseImporter::importFile ( void )
     // from now on the process cannot be cancelled
     emit disableCancel ( this );
 
-    // 3) First check is after the filtering we have something to import.
-    //    Maybe we had problems with all the files, or they were already in the database
+    // 3) First, check that there is something to import:
+    // maybe we had problems with all the files, or they were already in the database
     if (fileNamesToDataNames.isEmpty())
     {
         // TODO we know if it's either one or the other error, we can make this error better...
@@ -356,13 +356,13 @@ void medAbstractDatabaseImporter::importFile ( void )
 
         // 3.2) Try to read the whole image, not just the header
         bool readOnlyImageInformation = false;
-        auto data = tryReadImages (filesPaths, readOnlyImageInformation);
+        auto dataList = tryReadImages (filesPaths, readOnlyImageInformation);
 
-        for (int i = 0; i < data.size(); ++i)
+        for (int i = 0; i < dataList.size(); ++i)
         {
             currentImageIndex++;
 
-            dtkSmartPointer<medAbstractData> medData = data[i];
+            dtkSmartPointer<medAbstractData> medData = dataList[i];
             QString aggregatedFileName = it.value()[i]; // note that this file might be aggregating more than one input files
             if (!medData.isNull())
             {

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
@@ -62,10 +62,12 @@ signals:
     void dataImported ( const medDataIndex& index, const QUuid& uuid );
 
 public slots:
-    void onCancel ( QObject* );
+    void onCancel ( QObject* ) override;
+
+    void reportProgress(int dataIndex);
 
 protected:
-    virtual void internalRun ( void ) ;
+    void internalRun ( void ) override;
 
     QString file ( void );
     bool isCancelled ( void );

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
@@ -82,7 +82,8 @@ protected:
 
     QStringList getAllFilesToBeProcessed ( QString fileOrDirectory );
 
-    medAbstractData *tryReadImages ( const QStringList& filesPath,const bool readOnlyImageInformation );
+    QVector<dtkSmartPointer<medAbstractData>> tryReadImages(const QStringList& filesPath,  bool readOnlyImageInformation);
+    //medAbstractData *tryReadImages ( const QStringList& filesPath,const bool readOnlyImageInformation );
     bool tryWriteImage ( QString filePath, medAbstractData* medData );
 
     QString determineFutureImageFileName ( const medAbstractData* medData, int volumeNumber );

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
@@ -84,8 +84,7 @@ protected:
 
     QStringList getAllFilesToBeProcessed ( QString fileOrDirectory );
 
-    QVector<dtkSmartPointer<medAbstractData>> tryReadImages(const QStringList& filesPath,  bool readOnlyImageInformation);
-    //medAbstractData *tryReadImages ( const QStringList& filesPath,const bool readOnlyImageInformation );
+    QVector<medAbstractData*> tryReadImages(const QStringList& filesPath,  bool readOnlyImageInformation);
     bool tryWriteImage ( QString filePath, medAbstractData* medData );
 
     QString determineFutureImageFileName ( const medAbstractData* medData, int volumeNumber );

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
@@ -1,0 +1,28 @@
+#include "medAbstractDataReader.h"
+
+#include <medAbstractData.h>
+#include <dtkCoreSupport/dtkAbstractDataReader.h>
+
+medAbstractDataReader::medAbstractDataReader()
+    : dtkAbstractDataReader()
+{
+}
+
+medAbstractDataReader::medAbstractDataReader(const medAbstractDataReader& other)
+    : dtkAbstractDataReader(other)
+{
+}
+
+medAbstractDataReader::~medAbstractDataReader()
+{
+}
+
+int medAbstractDataReader::getNumberOfData() const
+{
+    return m_data.size();
+}
+
+QVector<dtkSmartPointer<medAbstractData>> medAbstractDataReader::getData() const
+{
+    return m_data;
+}

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
@@ -22,7 +22,7 @@ int medAbstractDataReader::getNumberOfData() const
     return m_data.size();
 }
 
-const QVector<dtkSmartPointer<medAbstractData>>& medAbstractDataReader::getData() const
+QVector<medAbstractData*> medAbstractDataReader::getData() const
 {
     return m_data;
 }

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
@@ -22,7 +22,7 @@ int medAbstractDataReader::getNumberOfData() const
     return m_data.size();
 }
 
-QVector<dtkSmartPointer<medAbstractData>> medAbstractDataReader::getData() const
+const QVector<dtkSmartPointer<medAbstractData>>& medAbstractDataReader::getData() const
 {
     return m_data;
 }

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.cpp
@@ -1,3 +1,18 @@
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013. All rights reserved.
+
+ See LICENSE.txt for details in the root of the sources or:
+ https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+
+ This software is distributed WITHOUT ANY WARRANTY; without even
+ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.
+
+=========================================================================*/
+
 #include "medAbstractDataReader.h"
 
 #include <medAbstractData.h>

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <medCoreLegacyExport.h>
+
+#include <dtkCoreSupport/dtkSmartPointer.h>
+#include <dtkCoreSupport/dtkAbstractDataReader.h>
+
+class medAbstractData;
+class medAbstractDataReaderPrivate;
+
+class MEDCORELEGACY_EXPORT medAbstractDataReader : public dtkAbstractDataReader
+{
+    Q_OBJECT
+
+public:
+    medAbstractDataReader(void);
+    medAbstractDataReader(const medAbstractDataReader& other);
+    virtual ~medAbstractDataReader(void);
+
+    int getNumberOfData() const;
+    QVector<dtkSmartPointer<medAbstractData>> getData() const;
+
+signals:
+    void finishedReadingData(int dataNumber);
+
+protected:
+    QVector<dtkSmartPointer<medAbstractData>> m_data;
+};

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
@@ -18,11 +18,11 @@ public:
     virtual ~medAbstractDataReader(void);
 
     int getNumberOfData() const;
-    const QVector<dtkSmartPointer<medAbstractData>>& getData() const;
+    QVector<medAbstractData*> getData() const;
 
 signals:
     void finishedReadingData(int dataNumber);
 
 protected:
-    QVector<dtkSmartPointer<medAbstractData>> m_data;
+    QVector<medAbstractData*> m_data;
 };

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
@@ -1,4 +1,18 @@
 #pragma once
+/*=========================================================================
+
+ medInria
+
+ Copyright (c) INRIA 2013. All rights reserved.
+
+ See LICENSE.txt for details in the root of the sources or:
+ https://github.com/medInria/medInria-public/blob/master/LICENSE.txt
+
+ This software is distributed WITHOUT ANY WARRANTY; without even
+ the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+ PURPOSE.
+
+=========================================================================*/
 
 #include <medCoreLegacyExport.h>
 

--- a/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
+++ b/src/layers/legacy/medCoreLegacy/readers/medAbstractDataReader.h
@@ -18,7 +18,7 @@ public:
     virtual ~medAbstractDataReader(void);
 
     int getNumberOfData() const;
-    QVector<dtkSmartPointer<medAbstractData>> getData() const;
+    const QVector<dtkSmartPointer<medAbstractData>>& getData() const;
 
 signals:
     void finishedReadingData(int dataNumber);


### PR DESCRIPTION
- Add medAbstractDataReader, a class that can return multiple medAbstractData instead of only one
- Adapt medAbstractDatabaseImporter to account for this new class
- Minimal cleanup of medAbstractDatabaseImporter

This P.R. is motivated by the need to read files that contain more than one "medAbstractData". This is the case with Carto and Rhythmia archives. 
Developers can now code readers that inherit from the medAbstractDataReader class instead of the dtkAbstractDataReader class.
The changes in the abstract importer where as few as possible, because I did not want to break everything.

I tested it multiple times (single data, multiple data of different types in same directory), and all seems to be working.