### PR TITLE
[Github Actions] Create triggerJenkinsBuild.yml configuration file

### DIFF
--- a/.github/workflows/triggerJenkinsBuild.yml
+++ b/.github/workflows/triggerJenkinsBuild.yml
@@ -1,0 +1,38 @@
+name: triggerJenkinsBuild
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  #push:
+  #  branches: [ master ]
+  # Run when a pull request is merged on master
+  pull_request:
+    branches: [master]
+    types: [closed]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    name: triggerJenkinsBuild
+    
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    #if: github‧event‧pull_request‧merged == true
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      - name: Access to Jenkins and run
+        uses: appleboy/jenkins-action@master
+        with:
+          url: "https://ci.inria.fr/music/"
+          user: "mathilde.merle@ihu-liryc.fr"
+          # 1° Jenkins account -> Configure -> Jeton d'API (token) -> MUSICARDIOTOKEN -> keep the token value.
+          # 2° Github -> Settings -> Secrets -> MUSICARDIOTOKEN -> add the previous token value.
+          # 3° Jenkins -> each job needed to be run -> Configure -> "Trigger remote build" -> MUSICARDIOTOKEN
+          token: ${{ secrets.MUSICARDIOTOKEN }}
+          job: "music-ubuntu18-free,music-ubuntu20-free,music-macos-free,music-win-free"
+          


### PR DESCRIPTION
Add Github Actions configuration file which run compilation on the Jenkins MUSICardio jobs at **each PR merged**.

The process can be manually run in Github -> Actions -> triggerJenkinsBuild.

It could be enhanced with some additional behaviors that we would like. You can create the same file on your repository, create your own tokens and run also the branch/PR/jobs that you would like also. However, it could lead to multiple compilation run on the same time on Jenkins, and we would not be able to know what is going on, so, maybe we need to think about the process.
:m: