### PR TITLE
[Icons] musicardio icon in windows taskbar 

### DIFF
--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -38,6 +38,7 @@ set(ICON_PATH "${PROJECT_SOURCE_DIR}/src/app/medInria/resources/MUSICardio_logo_
 
 # Used on pinned on taskbar
 set(CPACK_PACKAGE_ICON ${ICON_PATH})
+string(REGEX REPLACE "/" "\\\\\\\\" CPACK_PACKAGE_ICON "${CPACK_PACKAGE_ICON}")
 
 # The icon to install the application.
 set(CPACK_NSIS_MUI_ICON ${ICON_PATH})

--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -36,6 +36,9 @@ set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${MS
 
 set(ICON_PATH "${PROJECT_SOURCE_DIR}/src/app/medInria/resources/MUSICardio_logo_small.ico")
 
+# Used on pinned on taskbar
+set(CPACK_PACKAGE_ICON ${ICON_PATH})
+
 # The icon to install the application.
 set(CPACK_NSIS_MUI_ICON ${ICON_PATH})
 

--- a/src/app/medInria/resources/medInria.rc
+++ b/src/app/medInria/resources/medInria.rc
@@ -1,1 +1,1 @@
-MEDINRIA_ICON	ICON	"medInria.ico"
+MEDINRIA_ICON	ICON	"MUSICardio_logo_small.ico"


### PR DESCRIPTION
Based on this PR https://github.com/Inria-Asclepios/medInria-public/pull/695

The commits: https://github.com/Inria-Asclepios/medInria-public/commit/7f6bbdb6240376dad30aa06cd927cb67202b5f0e, https://github.com/Inria-Asclepios/medInria-public/commit/4276c0b52a858e0617c22742cc10b2c8002b99f4 and https://github.com/Inria-Asclepios/medInria-public/commit/bb56f6ca259c3f531813f9f189a2149c690c983f

This PR solves the icon error on Windows (medInria icon instead of MUSICardio ones, specially on task bar when pinned).

:m: