### PR TITLE
[zlib] Fix music-plugins compilation

### DIFF
--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -58,6 +58,7 @@ function(music_plugins_project)
             -DTETGEN_DIR:FILEPATH=${tetgen_DIR}
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
+            -DZLIB_DIR:FILEPATH=${zlib_DIR}
             )
 
         epComputPath(${external_project})


### PR DESCRIPTION
- zlib filepath was not exposed to the project