### PR TITLE
[realtime] pass realtime parameter each time

### DIFF
--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -64,12 +64,8 @@ function(music_plugins_project)
             -DQUAZIP_DIR:FILEPATH=${quazip_DIR}
             -DQUAZIP_INCLUDE_DIR:FILEPATH=${quazip_INCLUDE_DIR}
             -DZLIB_DIR:FILEPATH=${zlib_DIR}
+            -DUSE_RealTimeWorkspace=${USE_RealTimeWorkspace}
             )
-
-        if (${USE_RealTimeWorkspace})
-            list(APPEND cmake_args
-            -DUSE_RealTimeWorkspace=${USE_RealTimeWorkspace})
-        endif()
 
         epComputPath(${external_project})
         ExternalProject_Add(${external_project}


### PR DESCRIPTION
An other solution for this problem https://github.com/Inria-Asclepios/music/pull/890

The parameter is sent to music-plugins even if OFF or ON.

As before, if you wan't to switch the button from ON to OFF, you need to remove music-plugins external build before, to remove the previous compiled libs.

:m: