### PR TITLE
[vtkImageView3D] Improvements

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -20,7 +20,6 @@
 #include <vtksys/SystemTools.hxx>
 
 #include <vtkProperty.h>
-#include <vtkDataSetSurfaceFilter.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkPolyDataNormals.h>
 

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -947,6 +947,7 @@ vtkSmartPointer<vtkActor> vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkPr
 
     idFilter->SetCellIds(1);
     idFilter->SetPointIds(1);
+    idFilter->SetFieldData(1);
     idFilter->SetIdsArrayName("vtkOriginalIds");
     idFilter->SetInputData(arg);
     normalextractor->SetFeatureAngle(90);

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.h
@@ -142,7 +142,7 @@ public:
 
     void SetInput      (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0) override;
     virtual bool data2DTreatment();
-    static vtkActor* DataSetToActor(vtkPointSet* arg, vtkProperty* prop = nullptr);
+    static vtkSmartPointer<vtkActor> DataSetToActor(vtkPointSet* arg, vtkProperty* prop = nullptr);
     virtual void SetInputLayer (vtkAlgorithmOutput* pi_poVtkAlgoOutput, vtkMatrix4x4 *matrix = nullptr, int layer = 0);
     void SetFirstLayer(vtkAlgorithmOutput *pi_poInputAlgoImg, vtkMatrix4x4 *matrix= nullptr, int layer = 0);
 

--- a/src/plugins/legacy/medVtkFibersData/manager/vtkFibersManager.cxx
+++ b/src/plugins/legacy/medVtkFibersData/manager/vtkFibersManager.cxx
@@ -52,9 +52,6 @@
 #include "vtkFibersManagerCallback.h"
 #include "vtkFiberPickerCallback.h"
 
-#include <vtkDataSetSurfaceFilter.h>
-#include <vtkPolyDataNormals.h>
-
 vtkStandardNewMacro(vtkFibersManager);
 
 

--- a/src/plugins/legacy/vtkDataMesh/datas/vtkDataMesh4D.cpp
+++ b/src/plugins/legacy/vtkDataMesh/datas/vtkDataMesh4D.cpp
@@ -21,7 +21,6 @@
 #include <vtkMetaDataSetSequence.h>
 
 #include <vtkPNGWriter.h>
-#include <vtkDataSetSurfaceFilter.h>
 #include <vtkPolyDataMapper.h>
 #include <vtkActor.h>
 #include <vtkProperty.h>

--- a/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
+++ b/src/plugins/legacy/vtkDataMesh/interactors/vtkDataMeshInteractor.cpp
@@ -17,7 +17,6 @@
 
 #include <vtkCamera.h>
 #include <vtkActor.h>
-#include <vtkDataSetSurfaceFilter.h>
 #include <vtkImageView.h>
 #include <vtkImageView2D.h>
 #include <vtkImageView3D.h>


### PR DESCRIPTION
- Use vtkGeometryFilter instead of vtkDataSetSurfaceFilter when adding a mesh into the view.
- Add vtkIdFilter for retrieval of original ids. This is critical for MUSICardio in mesh interactor.
- Remove code duplication
- Remove unneeded includes
