### PR TITLE
Read triangles, edges, ridges in medit mesh files

### DIFF
--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
@@ -281,14 +281,19 @@ void vtkMetaSurfaceMesh::Write (const char* filename)
 {
     try
     {
-        qDebug()<<"Writing: "<<filename;
         if (vtkMetaSurfaceMesh::IsVtpExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
         {
             this->WriteVtpFile (filename);
         }
+        else if (vtkMetaSurfaceMesh::IsVtkExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
+        {
+            qDebug()<<"Writing: "<<filename;
+            this->WriteVtkFile (filename);
+        }
         else
         {
-            this->WriteVtkFile (filename);
+            qDebug()<<"Can not write: " << filename << " vtu extension is for unstructured grid mesh";
+            throw vtkErrorCode::UserError;
         }
     }
     catch (vtkErrorCode::ErrorIds error)
@@ -302,7 +307,13 @@ bool vtkMetaSurfaceMesh::IsVtpExtension (const char* ext)
 {
     if (strcmp (ext, ".vtp") == 0)
         return true;
-    
+    return false;
+}
+
+bool vtkMetaSurfaceMesh::IsVtuExtension (const char* ext)
+{
+    if (strcmp (ext, ".vtu") == 0)
+        return true;
     return false;
 }
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.cxx
@@ -306,14 +306,18 @@ void vtkMetaSurfaceMesh::Write (const char* filename)
 bool vtkMetaSurfaceMesh::IsVtpExtension (const char* ext)
 {
     if (strcmp (ext, ".vtp") == 0)
+    {
         return true;
+    }
     return false;
 }
 
 bool vtkMetaSurfaceMesh::IsVtuExtension (const char* ext)
 {
     if (strcmp (ext, ".vtu") == 0)
+    {
         return true;
+    }
     return false;
 }
 
@@ -322,7 +326,9 @@ bool vtkMetaSurfaceMesh::IsVtkExtension (const char* ext)
 {
   if (strcmp (ext, ".fib") == 0 ||
       strcmp (ext, ".vtk") == 0)
-    return true;
+  {
+      return true;
+  }
   return false;
 }
 
@@ -330,7 +336,9 @@ bool vtkMetaSurfaceMesh::IsVtkExtension (const char* ext)
 bool vtkMetaSurfaceMesh::IsMeshExtension (const char* ext)
 {
   if (strcmp (ext, ".mesh") == 0)
-    return true;
+  {
+      return true;
+  }
   return false;
 }
 
@@ -338,7 +346,9 @@ bool vtkMetaSurfaceMesh::IsMeshExtension (const char* ext)
 bool vtkMetaSurfaceMesh::IsOBJExtension (const char* ext)
 {
   if (strcmp (ext, ".obj") == 0)
-    return true;
+  {
+      return true;
+  }
   return false;
 }
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.h
@@ -62,8 +62,8 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
      Overwridden methods for read and write surface meshes
       can only read and write vtkPolyData format files
   */
-  virtual void Read (const char* filename);  
-  virtual void Write (const char* filename);
+  virtual void Read (const char* filename) override;
+  virtual void Write (const char* filename) override;
 
   /**
      Get method to get the vtkDataSet as a vtkPolyData
@@ -75,6 +75,7 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
   */
   static bool         IsVtkExtension (const char* ext);
   static bool         IsVtpExtension (const char* ext);
+  static bool         IsVtuExtension (const char* ext);
   static bool         IsMeshExtension (const char* ext);
   static bool         IsOBJExtension (const char* ext);
   static unsigned int CanReadFile (const char* filename);
@@ -82,17 +83,17 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
   /**
      Get the type of the metadataset as string
   */
-  virtual const char* GetDataSetType() const
+  virtual const char* GetDataSetType() const override
   {
     return "SurfaceMesh";
   }
 
-  virtual void CreateWirePolyData();
+  virtual void CreateWirePolyData() override;
 
 protected:
   vtkMetaSurfaceMesh();
   vtkMetaSurfaceMesh(const vtkMetaSurfaceMesh&);
-  ~vtkMetaSurfaceMesh();
+  ~vtkMetaSurfaceMesh() override;
 
   virtual void ReadVtkFile(const char* filename);
   virtual void ReadVtpFile(const char* filename);
@@ -105,7 +106,7 @@ protected:
   /**
      Method called everytime the dataset changes for initialization
   */
-  virtual void Initialize();
+  virtual void Initialize() override;
   
 private:
   void operator=(const vtkMetaSurfaceMesh&);        // Not implemented.

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaSurfaceMesh.h
@@ -17,6 +17,7 @@
 #include <vtkMetaDataSet.h>
 
 class vtkPolyData;
+class vtkReaderErrorObserver;
 
 
 /**
@@ -88,7 +89,7 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaSurfaceMesh: public vtkMetaDataSet
     return "SurfaceMesh";
   }
 
-  virtual void CreateWirePolyData() override;
+  virtual void CreateWirePolyData();
 
 protected:
   vtkMetaSurfaceMesh();

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -17,6 +17,8 @@
 #include <vtkUnstructuredGrid.h>
 #include <vtkUnstructuredGridReader.h>
 #include <vtkUnstructuredGridWriter.h>
+#include <vtkXMLUnstructuredGridReader.h>
+#include <vtkXMLUnstructuredGridWriter.h>
 #include <vtksys/SystemTools.hxx>
 
 #include <vtkProperty.h>
@@ -104,6 +106,24 @@ void vtkMetaVolumeMesh::ReadVtkFile (const char* filename)
     reader->Delete();
 }
 
+void vtkMetaVolumeMesh::ReadVtuFile(const char* filename)
+{
+    vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
+    reader->SetFileName (filename);
+
+    try
+    {
+        reader->Update();
+        this->SetDataSet (reader->GetOutput());
+    }
+    catch (vtkErrorCode::ErrorIds error)
+    {
+        reader->Delete();
+        throw error;
+    }
+    reader->Delete();
+}
+
 //----------------------------------------------------------------------------
 void vtkMetaVolumeMesh::Read (const char* filename)
 {
@@ -116,6 +136,9 @@ void vtkMetaVolumeMesh::Read (const char* filename)
         {
             case vtkMetaVolumeMesh::FILE_IS_VTK :
                 this->ReadVtkFile (filename);
+                break;
+            case vtkMetaVolumeMesh::FILE_IS_VTU:
+                this->ReadVtuFile(filename);
                 break;
             case vtkMetaVolumeMesh::FILE_IS_MESH :
                 this->ReadMeshFile (filename);
@@ -169,12 +192,57 @@ void vtkMetaVolumeMesh::WriteVtkFile (const char* filename)
 }
 
 //----------------------------------------------------------------------------
+void vtkMetaVolumeMesh::WriteVtuFile (const char* filename)
+{
+    if (!this->DataSet)
+    {
+        vtkErrorMacro(<<"No DataSet to write"<<endl);
+        throw vtkErrorCode::UserError;
+    }
+
+    vtkUnstructuredGrid* c_mesh = vtkUnstructuredGrid::SafeDownCast (this->DataSet);
+    if (!c_mesh)
+    {
+        vtkErrorMacro(<<"DataSet is not a polydata object"<<endl);
+        throw vtkErrorCode::UserError;
+    }
+
+    vtkXMLUnstructuredGridWriter* writer = vtkXMLUnstructuredGridWriter::New();
+    writer->SetFileName (filename);
+
+    try
+    {
+        writer->SetInputData (c_mesh);
+        writer->Write();
+        writer->Delete();
+    }
+    catch (vtkErrorCode::ErrorIds error)
+    {
+        writer->Delete();
+        throw error;
+    }
+}
+
+//----------------------------------------------------------------------------
 void vtkMetaVolumeMesh::Write (const char* filename)
 {
     try
     {
-        qDebug() << "Writing: " << filename;
-        this->WriteVtkFile (filename);
+        if (vtkMetaVolumeMesh::IsVtuExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
+        {
+            qDebug()<<"Writing: "<<filename;
+            this->WriteVtuFile (filename);
+        }
+        else if (vtkMetaVolumeMesh::IsVtkExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
+        {
+            qDebug()<<"Writing: "<<filename;
+            this->WriteVtkFile (filename);
+        }
+        else
+        {
+            qDebug()<<"Can not write: " << filename << " vtp extension is for polydata mesh";
+            throw vtkErrorCode::UserError;
+        }
     }
     catch (vtkErrorCode::ErrorIds error)
     {
@@ -183,10 +251,24 @@ void vtkMetaVolumeMesh::Write (const char* filename)
 }
 
 //----------------------------------------------------------------------------
+bool vtkMetaVolumeMesh::IsVtpExtension (const char* ext)
+{
+    if (strcmp (ext, ".vtp") == 0)
+        return true;
+    return false;
+}
+
+bool vtkMetaVolumeMesh::IsVtuExtension (const char* ext)
+{
+    if (strcmp (ext, ".vtu") == 0)
+        return true;
+    return false;
+}
+
+//----------------------------------------------------------------------------
 bool vtkMetaVolumeMesh::IsVtkExtension (const char* ext)
 {
-    if (strcmp (ext, ".vtk") == 0 ||
-            strcmp (ext, ".vtu") == 0)
+    if (strcmp (ext, ".vtk") == 0)
         return true;
     return false;
 }
@@ -250,6 +332,23 @@ unsigned int vtkMetaVolumeMesh::CanReadFile (const char* filename)
             return 0;
         }
     }
+
+    if (vtkMetaVolumeMesh::IsVtuExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
+        {
+            vtkXMLUnstructuredGridReader* reader = vtkXMLUnstructuredGridReader::New();
+            reader->SetFileName (filename);
+            try
+            {
+                reader->Update();
+            }
+            catch  (vtkErrorCode::ErrorIds)
+            {
+                reader->Delete();
+                return 0;
+            }
+            reader->Delete();
+            return vtkMetaVolumeMesh::FILE_IS_VTU;
+        }
 
     if (!vtkMetaVolumeMesh::IsVtkExtension(vtksys::SystemTools::GetFilenameLastExtension(filename).c_str()))
     {

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -261,7 +261,9 @@ bool vtkMetaVolumeMesh::IsVtpExtension (const char* ext)
 bool vtkMetaVolumeMesh::IsVtuExtension (const char* ext)
 {
     if (strcmp (ext, ".vtu") == 0)
+    {
         return true;
+    }
     return false;
 }
 
@@ -269,21 +271,27 @@ bool vtkMetaVolumeMesh::IsVtuExtension (const char* ext)
 bool vtkMetaVolumeMesh::IsVtkExtension (const char* ext)
 {
     if (strcmp (ext, ".vtk") == 0)
+    {
         return true;
+    }
     return false;
 }
 //----------------------------------------------------------------------------
 bool vtkMetaVolumeMesh::IsMeshExtension (const char* ext)
 {
     if (strcmp (ext, ".mesh") == 0)
+    {
         return true;
+    }
     return false;
 }
 //----------------------------------------------------------------------------
 bool vtkMetaVolumeMesh::IsGMeshExtension (const char* ext)
 {
     if (strcmp (ext, ".msh") == 0)
+    {
         return true;
+    }
     return false;
 }
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.cxx
@@ -296,17 +296,16 @@ void vtkMetaVolumeMesh::ReadMeshFile (const char* filename)
         return result;
     };
 
-
     ifstream fileInput(filename );
     if(fileInput.fail())
     {
-        vtkErrorMacro("File not found\n");
+        vtkErrorMacro("File not found\n")
         throw vtkErrorCode::FileNotFoundError;
     }
 
     QHash<QString, QPair<int,int>> elementsNameHash;
     QStringList elementsNames;
-    elementsNames << "Vertices" << "Edges" << "Triangles" << "Tetrahedra";
+    elementsNames << "Vertices" << "Edges" << "Triangles" << "Tetrahedra" << "Ridges";
     for (int i = 0; i< elementsNames.size(); i++)
     {
         elementsNameHash[elementsNames[i]] = qMakePair(0, 0);
@@ -323,7 +322,6 @@ void vtkMetaVolumeMesh::ReadMeshFile (const char* filename)
             if (elementsNameHash[elementsNames[i]].first == curLine - 1
                     && elementsNameHash[elementsNames[i]].first != 0)
             {
-
                 std::istringstream  lineStream(line);
                 lineStream >> elementsNameHash[elementsNames[i]].second;
             }
@@ -336,7 +334,7 @@ void vtkMetaVolumeMesh::ReadMeshFile (const char* filename)
     }
 
     int nbOfCells = 0;
-    for (int i = 1; i< elementsNames.size(); i++)
+    for (int i = 1; i< elementsNames.size()-1; i++)
     {
         nbOfCells += elementsNameHash[elementsNames[i]].second;
     }
@@ -344,113 +342,139 @@ void vtkMetaVolumeMesh::ReadMeshFile (const char* filename)
     int nbOfPoints = elementsNameHash[elementsNames[0]].second;
 
     vtkPoints* points = vtkPoints::New();
-    points->SetNumberOfPoints (nbOfPoints);
+    points->SetNumberOfPoints(nbOfPoints);
 
     vtkUnsignedShortArray* pointarray = vtkUnsignedShortArray::New();
-    pointarray->SetName ("Point array");
+    pointarray->SetName("Point array");
     pointarray->Allocate(nbOfPoints);
 
     vtkUnsignedShortArray* cellarray  = vtkUnsignedShortArray::New();
-    cellarray->SetName ("Zones");
+    cellarray->SetName("Zones");
     cellarray->Allocate(nbOfCells);
+
+    vtkUnsignedShortArray* ridgesarray  = vtkUnsignedShortArray::New();
+    ridgesarray->SetName("Ridges");
+    ridgesarray->SetNumberOfComponents(1);
+    ridgesarray->SetNumberOfTuples(nbOfCells);
+    ridgesarray->FillValue(0);
 
     vtkUnstructuredGrid* outputmesh = vtkUnstructuredGrid::New();
     outputmesh->Allocate(nbOfCells);
 
-    int count = 0;
     //Get Vertices and their values
     if(positionStream(fileInput, elementsNameHash[elementsNames[0]].first+1, line))
     {
-        while (getline(fileInput, line) && count < elementsNameHash[elementsNames[0]].second)
+        curLine = 0;
+        while (getline(fileInput, line) && curLine < elementsNameHash[elementsNames[0]].second)
         {
             std::istringstream  lineStream(line);
             double pos[3];
             unsigned short ref;
             lineStream >> pos[0] >> pos[1] >> pos[2] >> ref;
-            points->SetPoint (count, pos[0], pos[1], pos[2]);
+            points->SetPoint(curLine, pos[0], pos[1], pos[2]);
             pointarray->InsertNextValue(ref);
-            count++;
+            curLine++;
         }
     }
     //Get Edges and their values
     if(positionStream(fileInput, elementsNameHash[elementsNames[1]].first+1, line))
     {
-        count = 0;
-        while (getline(fileInput, line) && count < elementsNameHash[elementsNames[1]].second)
+        curLine = 0;
+        while (getline(fileInput, line) && curLine < elementsNameHash[elementsNames[1]].second)
         {
             std::istringstream  lineStream(line);
             unsigned int pos[2];
             unsigned short ref;
             lineStream >> pos[0] >> pos[1] >> ref;
             vtkIdList* idlist = vtkIdList::New();
-            idlist->InsertNextId (pos[0]-1);
-            idlist->InsertNextId (pos[1]-1);
+            idlist->InsertNextId(pos[0]-1);
+            idlist->InsertNextId(pos[1]-1);
 
-            outputmesh->InsertNextCell (VTK_LINE, idlist);
+            outputmesh->InsertNextCell(VTK_LINE, idlist);
             idlist->Delete();
             cellarray->InsertNextValue(ref);
-            count++;
+            curLine++;
         }
     }
     //Get Triangles and their values
     if(positionStream(fileInput, elementsNameHash[elementsNames[2]].first+1, line))
     {
-        count = 0;
-        while (getline(fileInput, line) && count < elementsNameHash[elementsNames[2]].second)
+        curLine = 0;
+        while (getline(fileInput, line) && curLine < elementsNameHash[elementsNames[2]].second)
         {
             std::istringstream  lineStream(line);
             unsigned int pos[3];
             unsigned short ref;
             lineStream >> pos[0] >> pos[1] >> pos[2] >> ref;
             vtkIdList* idlist = vtkIdList::New();
-            idlist->InsertNextId (pos[0]-1);
-            idlist->InsertNextId (pos[1]-1);
-            idlist->InsertNextId (pos[2]-1);
+            idlist->InsertNextId(pos[0]-1);
+            idlist->InsertNextId(pos[1]-1);
+            idlist->InsertNextId(pos[2]-1);
 
-            outputmesh->InsertNextCell (VTK_TRIANGLE, idlist);
+            outputmesh->InsertNextCell(VTK_TRIANGLE, idlist);
             idlist->Delete();
             cellarray->InsertNextValue(ref);
-            count++;
+            curLine++;
         }
     }
     //Get Tetras and their values
     if(positionStream(fileInput, elementsNameHash[elementsNames[3]].first+1, line))
     {
-        count = 0;
-        while (getline(fileInput, line) && count < elementsNameHash[elementsNames[3]].second)
+        curLine = 0;
+        while (getline(fileInput, line) && curLine < elementsNameHash[elementsNames[3]].second)
         {
             std::istringstream  lineStream(line);
             unsigned int pos[4];
             unsigned short ref;
             lineStream >> pos[0] >> pos[1] >> pos[2] >> pos[3] >> ref;
             vtkIdList* idlist = vtkIdList::New();
-            idlist->InsertNextId (pos[0]-1);
-            idlist->InsertNextId (pos[1]-1);
-            idlist->InsertNextId (pos[2]-1);
-            idlist->InsertNextId (pos[3]-1);
+            idlist->InsertNextId(pos[0]-1);
+            idlist->InsertNextId(pos[1]-1);
+            idlist->InsertNextId(pos[2]-1);
+            idlist->InsertNextId(pos[3]-1);
 
-            outputmesh->InsertNextCell (VTK_TETRA, idlist);
+            outputmesh->InsertNextCell(VTK_TETRA, idlist);
             idlist->Delete();
             cellarray->InsertNextValue(ref);
-            count++;
+            curLine++;
+        }
+    }
+    //Get Ridges if present will be add as array on cell
+    if(positionStream(fileInput, elementsNameHash[elementsNames[4]].first+1, line) &&
+            elementsNameHash[elementsNames[1]].second > 0)
+    {
+        curLine = 0;
+        while (getline(fileInput, line) && curLine < elementsNameHash[elementsNames[4]].second)
+        {
+            std::istringstream  lineStream(line);
+            unsigned int pos;
+            lineStream >> pos;
+            //This work because the edges were the first cells added
+            ridgesarray->SetValue(pos-1, 1);
+            curLine++;
         }
     }
 
-    outputmesh->SetPoints (points);
+    outputmesh->SetPoints(points);
     if (outputmesh->GetPointData())
     {
-        outputmesh->GetPointData()->AddArray (pointarray);
+        outputmesh->GetPointData()->AddArray(pointarray);
     }
     if (outputmesh->GetCellData())
     {
-        outputmesh->GetCellData()->AddArray (cellarray);
+        outputmesh->GetCellData()->AddArray(cellarray);
+        if(elementsNameHash[elementsNames[4]].second > 0 && elementsNameHash[elementsNames[1]].second > 0)
+        {
+            outputmesh->GetCellData()->AddArray(ridgesarray);
+        }
     }
 
-    this->SetDataSet (outputmesh);
+    this->SetDataSet(outputmesh);
 
     points->Delete();
     pointarray->Delete();
     cellarray->Delete();
+    ridgesarray->Delete();
     outputmesh->Delete();
 }
 

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.h
@@ -44,26 +44,29 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaVolumeMesh: public vtkMetaDataSet
   //BTX
   enum
   {
-    FILE_IS_VTK = 1,
-    FILE_IS_MESH,
-    FILE_IS_OBJ,
-    FILE_IS_GMESH,
-    LAST_FILE_ID
+      FILE_IS_VTK = 1,
+      FILE_IS_VTU,
+      FILE_IS_MESH,
+      FILE_IS_OBJ,
+      FILE_IS_GMESH,
+      LAST_FILE_ID
   };
   //ETX
 
-  virtual void Read (const char* filename);
+  virtual void Read (const char* filename) override;
   
-  virtual void Write (const char* filename);
+  virtual void Write (const char* filename) override;
   
   vtkUnstructuredGrid* GetUnstructuredGrid() const;
   
   static bool         IsVtkExtension (const char* ext);
+  static bool         IsVtpExtension(const char *ext);
+  static bool         IsVtuExtension(const char *ext);
   static bool         IsMeshExtension (const char* ext);
   static bool         IsGMeshExtension (const char* ext);
   static unsigned int CanReadFile (const char* filename);
 
-  virtual const char* GetDataSetType() const
+  virtual const char* GetDataSetType() const override
   {
     return "VolumeMesh";
   }
@@ -71,13 +74,15 @@ class MEDVTKDATAMESHBASE_EXPORT vtkMetaVolumeMesh: public vtkMetaDataSet
 protected:
   vtkMetaVolumeMesh();
   vtkMetaVolumeMesh(const vtkMetaVolumeMesh&);
-  ~vtkMetaVolumeMesh();
+  ~vtkMetaVolumeMesh() override;
 
-  virtual void Initialize();
+  virtual void Initialize() override;
   virtual void ReadVtkFile(const char* filename);
+  virtual void ReadVtuFile(const char* filename);
   virtual void ReadMeshFile(const char* filename);
   virtual void ReadGMeshFile(const char* filename);
   virtual void WriteVtkFile (const char* filename);
+   virtual void WriteVtuFile (const char* filename);
 
 private:
   void operator=(const vtkMetaVolumeMesh&);        // Not implemented.

--- a/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.h
+++ b/src/layers/legacy/medVtkDataMeshBase/vtkMetaVolumeMesh.h
@@ -82,7 +82,7 @@ protected:
   virtual void ReadMeshFile(const char* filename);
   virtual void ReadGMeshFile(const char* filename);
   virtual void WriteVtkFile (const char* filename);
-   virtual void WriteVtuFile (const char* filename);
+  virtual void WriteVtuFile (const char* filename);
 
 private:
   void operator=(const vtkMetaVolumeMesh&);        // Not implemented.

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -88,7 +88,7 @@ QString vtkDataMeshWriter::identifier() const
 
 QStringList vtkDataMeshWriter::supportedFileExtensions() const
 {
-    return QStringList() << ".vtk" << ".vtp";
+    return QStringList() << ".vtk" << ".vtp" << ".vtu";
 }
 
 bool vtkDataMeshWriter::registered()


### PR DESCRIPTION
- In volume meshes,  edges, triangles, ridges are read  and not only tetrahedra as before.
- Similarly in surface meshes, edges, ridges are read and not only triangles.

- Add vtu reader and writer for mesh of type unstructured grid
- Prevent use of vtp writer for unstructured grid and vtu writer for polydata