### PR TITLE
[ManualRegistration] avoid duplication in outputs

### DIFF
--- a/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
@@ -359,6 +359,7 @@ void manualRegistrationToolBox::computeRegistration()
             runProcess->setProcess (d->process);
             connect (runProcess, SIGNAL (success(QObject*)), this, SLOT(retrieveProcessOutputAndUpdateViews()));
             this->addConnectionsAndStartJob(runProcess);
+            enableOnProcessSuccessImportOutput(runProcess, false);
         }
     }
 }


### PR DESCRIPTION
Fix https://github.com/medInria/medInria-public/issues/925

This avoids the output duplication after a manual registration.

:m: