### PR TITLE
[Expiration] cmake custom duration before expiration in months

### DIFF
--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -76,6 +76,8 @@ endif()
 string(TIMESTAMP BUILD_DATE "\"%d_%m_%Y\"")
 add_definitions(-DMEDINRIA_BUILD_DATE=${BUILD_DATE})
 
+add_definitions(-DEXPIRATION_TIME=${EXPIRATION_TIME})
+
 ## #############################################################################
 ## OS specificites
 ## #############################################################################

--- a/src/app/medInria/areas/homepage/medHomepageArea.cpp
+++ b/src/app/medInria/areas/homepage/medHomepageArea.cpp
@@ -152,7 +152,8 @@ medHomepageArea::medHomepageArea ( QWidget * parent ) : QWidget ( parent ), d ( 
     medLogo = medLogo.scaled(576, 121, Qt::KeepAspectRatio, Qt::SmoothTransformation);
     medInriaLabel->setPixmap(medLogo);
 
-    QDate expiryDate = QDate::fromString(QString(MEDINRIA_BUILD_DATE), "dd_MM_yyyy").addYears(1);
+    QDate expiryDate = QDate::fromString(QString(MEDINRIA_BUILD_DATE), "dd_MM_yyyy")
+                                        .addMonths(EXPIRATION_TIME);
     QTextEdit * textEdit = new QTextEdit(this);
     textEdit->setHtml ( QString::fromUtf8("<br/><br/><b>%1</b> (%2) is a software developed in collaboration with "
                                           "the IHU LIRYC in order to propose functionalities "

--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -64,7 +64,10 @@ medApplication::medApplication(int & argc, char**argv) :
     QApplication::setStyle(QStyleFactory::create("fusion"));
 
     // Expiration Date
-    QDate expiryDate = QDate::fromString(QString(MEDINRIA_BUILD_DATE), "dd_MM_yyyy").addYears(1);
+    QDate expiryDate = QDate::fromString(QString(MEDINRIA_BUILD_DATE), "dd_MM_yyyy")
+                                        .addMonths(EXPIRATION_TIME);
+    qInfo() << "Expiration Date: " << qPrintable(expiryDate.toString());
+
     if ( ! expiryDate.isValid() || QDate::currentDate() > expiryDate)
     {
         QString expiredInfo = "This copy of ";

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -53,7 +53,7 @@ if (NOT WIN32)
       list(APPEND external_projects ffmpeg)
   endif()
 endif()
-  
+
 list(APPEND external_projects
      VTK
      ITK

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -68,6 +68,8 @@ endif()
 
 set(${ep}_BUILD_TYPE Debug CACHE STRING "Build type configuration specific to medInria.")
 
+set(EXPIRATION_TIME "12" CACHE STRING "After X months the copy will expire" FORCE)
+
 set(cmake_args
    ${ep_common_cache_args}
   -DCMAKE_BUILD_TYPE=${${ep}_BUILD_TYPE}
@@ -92,6 +94,7 @@ set(cmake_args
   -DBUILD_ALL_PLUGINS=OFF
   -DBUILD_COMPOSITEDATASET_PLUGIN=OFF
   -DBUILD_EXAMPLE_PLUGINS=OFF
+  -DEXPIRATION_TIME=${EXPIRATION_TIME}
   )
 
 if (${USE_FFmpeg})


### PR DESCRIPTION
Change the duration time before expiration have been ask for the application. This PR allows to change in CMake the duration (in months, 12 is default), thus it can be used as a parameter on our continuous integration platform.

NB: if you want to test you'll need a compilation from scratch of the `build`

:m: