### PR TITLE
[Paint] device ratio for cursor size

### DIFF
--- a/src/layers/legacy/medUtilities/medUtilities.cpp
+++ b/src/layers/legacy/medUtilities/medUtilities.cpp
@@ -317,3 +317,18 @@ int medUtilities::getDevicePixelRatio(QMouseEvent* mouseEvent)
 #endif
     return devicePixelRatio;
 }
+
+/**
+ * @brief Get the screen pixel ratio according to the current view
+ * 
+ * @param view a current view to get the screen ratio from
+ * @return int the screen pixel ratio
+ */
+int medUtilities::getDevicePixelRatio(medAbstractView *view)
+{
+    auto * widgetView = view->viewWidget();
+    auto positionView = widgetView->mapToGlobal({widgetView->width()/2,0});
+    int devicePixelRatio = QGuiApplication::screenAt(positionView)->devicePixelRatio();
+
+    return devicePixelRatio;
+}

--- a/src/layers/legacy/medUtilities/medUtilities.h
+++ b/src/layers/legacy/medUtilities/medUtilities.h
@@ -60,4 +60,6 @@ public:
 
     static int getDevicePixelRatio(QMouseEvent* mouseEvent);
 
+    static int getDevicePixelRatio(medAbstractView *view);
+
 };

--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -102,6 +102,9 @@ public:
 
             if (m_paintState != PaintState::Wand)
             {
+                // Update the cursor size for painting
+                m_cb->activateCustomedCursor();
+
                 // add current state to undo stack
                 bool isInside;
                 MaskType::IndexType index;
@@ -581,8 +584,9 @@ void AlgorithmPaintToolBox::activateCustomedCursor()
     // Get radius size of the brush in mm
     double radiusSize = (double)(m_brushSizeSlider->value());
 
-    // Adapt to scale of view (zoom, crop, etc)
-    double radiusSizeDouble = radiusSize * currentView->scale();
+    // Adapt to scale of view (zoom, crop, screen ratio, etc)
+    int devicePixelRatio = medUtilities::getDevicePixelRatio(currentView);
+    double radiusSizeDouble = radiusSize * currentView->scale() / devicePixelRatio;
 
     int radiusSizeInt = floor(radiusSizeDouble + 0.5);
 


### PR DESCRIPTION
This PR solves a bug on Retina screens. The cursor size is now updated according to the screen pixel ratio at the click on the Paint button, and at click on the view.

I'll do the same on medInria (with this one too https://github.com/Inria-Asclepios/medInria-public/pull/647)

:m: