### PR TITLE
[music-plugins] switch to master branch

### DIFF
--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -34,7 +34,7 @@ function(music_plugins_project)
     if (NOT USE_SYSTEM_${external_project})
 
         set(git_url ${GITHUB_PREFIX}Inria-Asclepios/music.git)
-        set(git_tag music3)
+        set(git_tag master)
 
         set(cmake_args
             ${ep_common_cache_args}


### PR DESCRIPTION
Use the music-plugins repo master branch instead of music3.

:m: