### PR TITLE
[medViewContainer] allow to reset central view widgets

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.cpp
@@ -115,18 +115,6 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     QVariant themeChosen = medSettingsManager::instance()->value("startup","theme");
     int themeIndex = themeChosen.toInt();
 
-    d->defaultWidget = new QWidget;
-    d->defaultWidget->setObjectName("defaultWidget");
-    QLabel *defaultLabel = new QLabel(tr("Drag'n drop series/study here from the left panel or:"));
-    QPushButton *openButton  = new QPushButton(tr("Open a file from your system"));
-    QPushButton *sceneButton = new QPushButton(tr("Open a scene from your system"));
-    QVBoxLayout *defaultLayout = new QVBoxLayout(d->defaultWidget);
-    defaultLayout->addWidget(defaultLabel);
-    defaultLayout->addWidget(openButton);
-    defaultLayout->addWidget(sceneButton);
-    connect(openButton,  SIGNAL(clicked()), this, SLOT(openFromSystem()), Qt::UniqueConnection);
-    connect(sceneButton, SIGNAL(clicked()), this, SLOT(loadScene()),      Qt::UniqueConnection);
-
     d->menuButton = new QPushButton(this);
     d->menuButton->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Fixed);
     d->menuButton->setToolTip(tr("Tools"));
@@ -287,7 +275,7 @@ medViewContainer::medViewContainer(medViewContainerSplitter *parent): QFrame(par
     d->mainLayout->setContentsMargins(0, 0, 0, 0);
     d->mainLayout->setSpacing(0);
     d->mainLayout->addWidget(toolBar, 0, 0, Qt::AlignTop);
-    d->mainLayout->addWidget(d->defaultWidget, 0, 0, 0, 0, Qt::AlignCenter);
+    createdDefaultWidget();
 
     this->setAcceptDrops(true);
     this->setUserSplittable(true);
@@ -334,6 +322,45 @@ QUuid medViewContainer::uuid() const
 medAbstractView* medViewContainer::view() const
 {
     return d->view;
+}
+
+/**
+ * @brief Create the classic inner widget of a container
+ * 
+ */
+void medViewContainer::createdDefaultWidget()
+{
+    // create a default central widget
+    d->defaultWidget = new QWidget;
+    d->defaultWidget->setObjectName("defaultWidget");
+    QLabel *defaultLabel = new QLabel(tr("Drag'n drop series/study here from the left panel or:"));
+    QPushButton *openButton  = new QPushButton(tr("Open a file from your system"));
+    QPushButton *sceneButton = new QPushButton(tr("Open a scene from your system"));
+    QVBoxLayout *defaultLayout = new QVBoxLayout(d->defaultWidget);
+    defaultLayout->addWidget(defaultLabel);
+    defaultLayout->addWidget(openButton);
+    defaultLayout->addWidget(sceneButton);
+    connect(openButton,  SIGNAL(clicked()), this, SLOT(openFromSystem()), Qt::UniqueConnection);
+    connect(sceneButton, SIGNAL(clicked()), this, SLOT(loadScene()),      Qt::UniqueConnection);
+
+    // display the widget
+    d->mainLayout->addWidget(d->defaultWidget, 0, 0, 0, 0, Qt::AlignCenter);
+}
+
+/**
+ * @brief If the inner widget of a view has been removed to put a new 
+ * central widget, this method allows to reset, reinitialize the view 
+ * to the classic inner widget
+ * 
+ */
+void medViewContainer::initializeDefaultWidget()
+{
+    // clear
+    d->mainLayout->removeWidget(d->defaultWidget);
+    delete d->defaultWidget;
+
+    // recreate
+    createdDefaultWidget();
 }
 
 QWidget* medViewContainer::defaultWidget() const

--- a/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
+++ b/src/layers/legacy/medCoreLegacy/gui/viewContainers/medViewContainer.h
@@ -69,6 +69,8 @@ public:
     medViewContainer* splitHorizontally();
     medViewContainer* split(Qt::AlignmentFlag alignement = Qt::AlignRight);
 
+    void createdDefaultWidget();
+    void initializeDefaultWidget();
     void setDefaultWidget(QWidget *defaultWidget);
     QWidget* defaultWidget() const;
 


### PR DESCRIPTION
Fix https://github.com/Inria-Asclepios/music/issues/905

These changes allow to reset the central inner widget of a view when it was changed by a toolbox.

:m: