### PR TITLE
[vtkDataMeshReader] sync fct to be the same one as on medInria

### DIFF
--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriter.cpp
@@ -12,7 +12,6 @@
 =========================================================================*/
 
 #include "vtkDataMeshWriter.h"
-#include "vtkDataMeshHelper.h"
 
 #include <medAbstractData.h>
 #include <medAbstractDataFactory.h>
@@ -55,25 +54,23 @@ bool vtkDataMeshWriter::write(const QString& path)
         return false;
     }
     addMetaDataAsFieldData(mesh);
-    DataMeshHelper::prepareMetaDataForAsciiReadOrWrite(mesh, true);
 
-    bool success = true;
     try
     {
         setlocale(LC_NUMERIC, "C");
         QLocale::setDefault(QLocale("C"));
 
         mesh->Write(path.toLocal8Bit().constData());
+        clearMetaDataFieldData(mesh);
     }
     catch (...)
     {
         qDebug() << metaObject()->className() << ": error writing to " << path;
-        success = false;
+        clearMetaDataFieldData(mesh);
+        return false;
     }
-    clearMetaDataFieldData(mesh);
-    DataMeshHelper::prepareMetaDataForAsciiReadOrWrite(mesh, false);
 
-    return success;
+    return true;
 }
 
 QString vtkDataMeshWriter::description() const

--- a/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.h
+++ b/src/plugins/legacy/vtkDataMesh/writers/vtkDataMeshWriterBase.h
@@ -28,7 +28,7 @@ public:
     ~vtkDataMeshWriterBase() override = default;
 
 public slots:
-    bool canWrite (const QString& path) override;
+    bool canWrite (const QString& path);
 
     void addMetaDataAsFieldData(vtkMetaDataSet* dataSet);
     void clearMetaDataFieldData(vtkMetaDataSet* dataSet);


### PR DESCRIPTION
This PR fixes https://github.com/Inria-Asclepios/medInria-public/issues/748

The bug has been introduced in https://github.com/Inria-Asclepios/medInria-public/pull/710 which is a PR not sent to medInria solving meshes with NaN values.

We need to work on several things:
 * find data with NAN values to be able to test.
 * find a solution that can be sent to medInria, for instance it could be solved in VTK9, it could be tested in medInria 4.
 * if we need to keep this code, this needs not to crash when we save renamed temporary Scenes.
 * if the problem is not solved, it needs to be debugged from the scene crash, but also robust (cf the 2 weaknesses that Mehdi wrote on the first PR).

I put the PR on draft for now.

:m: 