### PR TITLE
[Paint] allow to force hide the Save button & polygonROI setObjectNames

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -1460,7 +1460,10 @@ void AlgorithmPaintToolBox::showButtons( bool value )
 {
     if (value)
     {
-        m_applyButton->show();
+        if (!m_applyButton->property("forceHide").toBool())
+        {
+            m_applyButton->show();
+        }
         m_clearMaskButton->show();
     }
     else

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -28,8 +28,6 @@
 #include <medMetaDataKeys.h>
 #include <medContours.h>
 
-const char *polygonRoiToolBox::generateBinaryImageButtonName = "generateBinaryImageButton";
-
 polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     medAbstractSelectableToolBox(parent), activeDataIndex()
 {
@@ -48,10 +46,12 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
 
     auto layout = new QVBoxLayout();
     displayWidget->setLayout(layout);
+    displayWidget->setObjectName("displayWidget");
 
     auto *explanation = new QLabel(tr("Drop a data in the view and activate:"));
     explanation->setWordWrap(true);
     explanation->setStyleSheet("font: italic");
+    explanation->setObjectName("explanationLabel");
     layout->addWidget(explanation );
 
     activateTBButton = new QPushButton(tr("Activate Toolbox"));
@@ -67,7 +67,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     connect(interpolate,SIGNAL(clicked(bool)) ,this,SLOT(interpolateCurve(bool)));
 
     auto repulsorLayout = new QHBoxLayout();
-    repulsorLabel = new QLabel("Correct contours");
+    repulsorLabel = new QLabel("Correct contours:");
     repulsorLayout->addWidget(repulsorLabel);
 
     repulsorTool = new QPushButton(tr("Repulsor"));
@@ -86,6 +86,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     pMedToolBox = medToolBoxFactory::instance()->createToolBox(identifier);
     pMedToolBox->header()->hide();
     pMedToolBox->hide();
+    pMedToolBox->setObjectName("pMedToolBoxButton");
     layout->addWidget(pMedToolBox);
     connect(activateTBButton, SIGNAL(toggled(bool)), pMedToolBox, SLOT(setEnabled(bool)), Qt::UniqueConnection);
 
@@ -95,10 +96,12 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     contoursActionLayout->addLayout(repulsorLayout);
 
     saveLabel = new QLabel("Save segmentations as:");
+    saveLabel->setObjectName("saveSegmentationsLabel");
+
     auto saveButtonsLayout = new QHBoxLayout();
     saveBinaryMaskButton = new QPushButton(tr("Mask(s)"));
     saveBinaryMaskButton->setToolTip("Import the current mask to the non persistent database");
-    saveBinaryMaskButton->setObjectName(generateBinaryImageButtonName);
+    saveBinaryMaskButton->setObjectName("generateBinaryImageButton");
     connect(saveBinaryMaskButton,SIGNAL(clicked()),this,SLOT(saveBinaryImage()));
     saveButtonsLayout->addWidget(saveBinaryMaskButton);
 


### PR DESCRIPTION
Commit : https://github.com/Inria-Asclepios/medInria-public/commit/932ad3e64643772570b7d87b3f6764353999ccf6
Based on https://github.com/Inria-Asclepios/medInria-public/pull/764

This PR allows to keep hidden the Save button in pipelines for instance (cf https://github.com/Inria-Asclepios/music/pull/982) even if there is a drawing in the view. The flag stays even after a reset of a step, or a clear of the view.

:m: