### PR TITLE
Polygon roi pipeline adaptation

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.cpp
@@ -14,6 +14,7 @@
 #include <medAbstractSelectableToolBox.h>
 #include <medSelectorToolBox.h>
 #include <medTabbedViewContainers.h>
+#include <medAbstractData.h>
 
 class medAbstractSelectableToolBoxPrivate
 {
@@ -37,6 +38,13 @@ medAbstractSelectableToolBox::~medAbstractSelectableToolBox()
 dtkPlugin* medAbstractSelectableToolBox::plugin()
 {
     return nullptr;
+}
+
+QList<dtkSmartPointer<medAbstractData> > medAbstractSelectableToolBox::processOutputs()
+{
+    QList<dtkSmartPointer<medAbstractData>> outputs;
+    outputs.append(processOutput());
+    return outputs;
 }
 
 void medAbstractSelectableToolBox::setSelectorToolBox(medSelectorToolBox *toolbox)

--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -14,6 +14,7 @@
 
 #include <medCoreLegacyExport.h>
 #include <medToolBox.h>
+#include <dtkCoreSupport/dtkSmartPointer>
 
 class medAbstractData;
 class medSelectorToolBox;
@@ -31,7 +32,7 @@ public:
     virtual dtkPlugin* plugin();
 
     virtual medAbstractData *processOutput() = 0;
-
+    virtual QList<dtkSmartPointer<medAbstractData>> processOutputs();
     void setSelectorToolBox(medSelectorToolBox *toolbox);
 
 public slots:

--- a/src/plugins/legacy/polygonRoi/polygonLabel.cpp
+++ b/src/plugins/legacy/polygonRoi/polygonLabel.cpp
@@ -415,11 +415,11 @@ QVector<medWorldPosContours> polygonLabel::getContoursAsNodes()
     return contours;
 }
 
-void polygonLabel::createMask(int label, QString &desc)
+medAbstractData *polygonLabel::createMask(int label, QString &desc)
 {
     vtkImageView2D *view2d = getView2D();
     if (!view2d)
-        return;
+        return nullptr;
 
     QList<QPair<vtkPolygon *, int>> polygons;
     for (polygonRoi *roi : d->rois)
@@ -584,7 +584,7 @@ void polygonLabel::createMask(int label, QString &desc)
     output->setMetaData(medMetaDataKeys::Toolbox.key(), "PolygonROI");
     output->setMetaData(medMetaDataKeys::OriginalDataUID.key(), inputData->metadata(medMetaDataKeys::SeriesInstanceUID.key()));
     output->setMetaData(medMetaDataKeys::OriginalDataDesc.key(), inputData->metadata(medMetaDataKeys::SeriesDescription.key()));
-    medDataManager::instance()->importData(output, false);
+    return output;
 }
 
 void polygonLabel::SetMasterRoi()

--- a/src/plugins/legacy/polygonRoi/polygonLabel.h
+++ b/src/plugins/legacy/polygonRoi/polygonLabel.h
@@ -60,7 +60,7 @@ public:
     void deleteNode(double X, double Y);
     void deleteContour();
     void removeAllTick();
-    void createMask(int label, QString &desc);
+    medAbstractData *createMask(int label, QString &desc);
     void SetMasterRoi();
 
     vtkSmartPointer<vtkPolyData> getContoursAsPolyData(int label);

--- a/src/plugins/legacy/polygonRoi/toolboxes/defaultLabelToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/defaultLabelToolBox.cpp
@@ -32,12 +32,15 @@ defaultLabelToolBox::defaultLabelToolBox(QWidget *parent):
     labels = new QListWidget;
     labels->setSelectionMode(QAbstractItemView::SingleSelection);
     labels->setContentsMargins(0,0,0,0);
+    labels->setObjectName("labels");
 
     plusButton = new QPushButton(QIcon(":/pixmaps/plus.png"), "");
     plusButton->setMaximumSize(QSize(20,20));
+    plusButton->setObjectName("plusBttn");
 
     minusButton = new QPushButton(QIcon(":/pixmaps/minus.png"), "");
     minusButton->setMaximumSize(QSize(20,20));
+    minusButton->setObjectName("minBttn");
 
     auto listLabelLayout = new QVBoxLayout();
     layout->addLayout(listLabelLayout);

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -173,7 +173,8 @@ QList<dtkSmartPointer<medAbstractData> > polygonRoiToolBox::processOutputs()
     QList<dtkSmartPointer<medAbstractData> > outputMasks;
     for (baseViewEvent *event1 : viewEventHash.values())
     {
-        outputMasks.append(event1->saveMasks());
+        auto masks = event1->saveMasks();
+        outputMasks.append(masks);
     }
     return outputMasks;
 }

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -27,6 +27,7 @@
 #include <medSettingsManager.h>
 #include <medMetaDataKeys.h>
 #include <medContours.h>
+#include <medDataManager.h>
 
 const char *polygonRoiToolBox::generateBinaryImageButtonName = "generateBinaryImageButton";
 
@@ -95,6 +96,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     contoursActionLayout->addLayout(repulsorLayout);
 
     saveLabel = new QLabel("Save segmentations as:");
+    saveLabel->setObjectName("saveLabel");
     auto saveButtonsLayout = new QHBoxLayout();
     saveBinaryMaskButton = new QPushButton(tr("Mask(s)"));
     saveBinaryMaskButton->setToolTip("Import the current mask to the non persistent database");
@@ -164,6 +166,16 @@ dtkPlugin* polygonRoiToolBox::plugin()
 medAbstractData *polygonRoiToolBox::processOutput()
 {
     return nullptr;
+}
+
+QList<dtkSmartPointer<medAbstractData> > polygonRoiToolBox::processOutputs()
+{
+    QList<dtkSmartPointer<medAbstractData> > outputMasks;
+    for (baseViewEvent *event1 : viewEventHash.values())
+    {
+        outputMasks.append(event1->saveMasks());
+    }
+    return outputMasks;
 }
 
 void polygonRoiToolBox::updateView()
@@ -424,9 +436,10 @@ void polygonRoiToolBox::interpolateCurve(bool state)
 
 void polygonRoiToolBox::saveBinaryImage()
 {
-    for (baseViewEvent *event1 : viewEventHash.values())
+    QList<dtkSmartPointer<medAbstractData>> outputMasks = processOutputs();
+    for (auto output : outputMasks)
     {
-        event1->saveMask();
+       medDataManager::instance()->importData(output, false);
     }
 }
 

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.h
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.h
@@ -54,6 +54,7 @@ public:
     static bool registered();
     dtkPlugin* plugin() override;
     medAbstractData *processOutput() override;
+    QList<dtkSmartPointer<medAbstractData> > processOutputs() override;
     void drawCross(double *position);
     void eraseCross();
 

--- a/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
+++ b/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
@@ -460,7 +460,7 @@ bool baseViewEvent::rightButtonBehaviour(medAbstractView *view, QMouseEvent *mou
 
         auto saveMaskAction = new QAction("Mask", saveMenu);
         connect(saveMaskAction, &QAction::triggered, [=](){
-            saveMask(closestManager);
+            medDataManager::instance()->importData(saveMask(closestManager), false);
         });
         saveMenu->addAction(saveMaskAction);
 
@@ -713,15 +713,17 @@ void baseViewEvent::activateRepulsor(bool state)
     }
 }
 
-void baseViewEvent::saveMask()
+QList<dtkSmartPointer<medAbstractData>> baseViewEvent::saveMasks()
 {
+    QList<dtkSmartPointer<medAbstractData>> outputMasks;
     for (polygonLabel *label : labelList)
     {
         if (!label->getRois().empty())
         {
-            saveMask(label);
+            outputMasks.append(saveMask(label));
         }
     }
+    return outputMasks;
 }
 
 void baseViewEvent::saveAllContours()
@@ -955,11 +957,11 @@ bool baseViewEvent::isActiveContourInSlice()
     return retVal;
 }
 
-void baseViewEvent::saveMask(polygonLabel *manager)
+ dtkSmartPointer<medAbstractData> baseViewEvent::saveMask(polygonLabel *manager)
 {
     int label = labelList.indexOf(manager);
     QString desc = createMaskDescription(manager);
-    manager->createMask(label, desc);
+    return manager->createMask(label, desc);
 }
 
 QString baseViewEvent::createMaskDescription(polygonLabel *label)

--- a/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
+++ b/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
@@ -961,7 +961,9 @@ bool baseViewEvent::isActiveContourInSlice()
 {
     int label = labelList.indexOf(manager);
     QString desc = createMaskDescription(manager);
-    return manager->createMask(label, desc);
+    auto outputMask = manager->createMask(label, desc);
+    outputMask->setMetaData("LabelName", manager->getName());
+    return outputMask;
 }
 
 QString baseViewEvent::createMaskDescription(polygonLabel *label)

--- a/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.h
+++ b/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.h
@@ -57,7 +57,7 @@ public:
     void updatePosition(QString name, int position);
     void setEnableInterpolation(bool state);
     void activateRepulsor(bool state);
-    void saveMask();
+    QList<dtkSmartPointer<medAbstractData> > saveMasks();
     void saveAllContours();
 
     void removeViewFromList(medAbstractImageView *iView);
@@ -91,7 +91,7 @@ protected slots:
 private slots:
     void deleteNode(polygonLabel *manager, const double *mousePos);
     void deleteContour(polygonLabel *manager);
-    void saveMask(polygonLabel *manager);
+    dtkSmartPointer<medAbstractData> saveMask(polygonLabel *manager);
     void saveContour(polygonLabel *label);
     void copyContour(polygonLabel *manager);
 


### PR DESCRIPTION
- Add setObjectNames
- Add virtual method processOutputs (not pure) to medAbstractSelectableToolBox and polygonRoiToolbox
- Add custom metadatakey to be able to retrieve label name at the end of a pipeline step

Linked with:  [PR](https://github.com/Inria-Asclepios/music/pull/994)