### PR TITLE
Make database connections thread safe

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.cpp
@@ -58,6 +58,8 @@ QString medDatabaseImporter::getPatientID(QString patientName, QString birthDate
     query.bindValue ( ":name", patientName );
     query.bindValue ( ":birthdate", birthDate );
 
+    QMutexLocker mutexLocker(&medDataManager::instance()->controller()->getDatabaseMutex());
+
     if ( !query.exec() )
     {
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
@@ -119,6 +121,8 @@ int medDatabaseImporter::getOrCreatePatient ( const medAbstractData* medData, QS
     query.bindValue ( ":name", patientName );
     query.bindValue ( ":birthdate", birthDate );
 
+    QMutexLocker mutexLocker(&medDataManager::instance()->controller()->getDatabaseMutex());
+
     if ( !query.exec() )
     {
         qDebug() << DTK_COLOR_FG_RED << query.lastError() << DTK_NO_COLOR;
@@ -174,6 +178,8 @@ int medDatabaseImporter::getOrCreateStudy ( const medAbstractData* medData, QSql
     query.bindValue ( ":patient", patientDbId );
     query.bindValue ( ":studyName", studyName );
     query.bindValue ( ":studyUid", studyUid );
+
+    QMutexLocker mutexLocker(&medDataManager::instance()->controller()->getDatabaseMutex());
 
     if ( !query.exec() )
     {
@@ -243,6 +249,8 @@ int medDatabaseImporter::getOrCreateSeries ( const medAbstractData* medData, QSq
 
     if( seriesName=="EmptySeries" )
         return seriesDbId;
+
+    QMutexLocker(&medDataManager::instance()->controller()->getDatabaseMutex());
 
     if ( !query.exec() )
     {
@@ -376,6 +384,7 @@ void medDatabaseImporter::createDBEntryForMetadataAttachedFile(medAbstractData *
 {
     QSqlDatabase dbConnection = medDataManager::instance()->controller()->getThreadSpecificConnection();
     QSqlQuery query (dbConnection);
+    QMutexLocker mutexLocker(&medDataManager::instance()->controller()->getDatabaseMutex());
 
     query.exec("SELECT COUNT(*) as cpt FROM pragma_table_info('series') WHERE name='json_meta_path'");
     bool jsonColExist = false;

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
@@ -36,6 +36,7 @@ public:
     bool createConnection() = 0;
     virtual QSqlDatabase getMainConnection() const = 0;
     virtual QSqlDatabase getThreadSpecificConnection() const = 0;
+    virtual QMutex& getDatabaseMutex() const = 0;
 
     medDataIndex indexForPatient(int id);
     medDataIndex indexForStudy(int id);
@@ -70,7 +71,7 @@ public:
     QString metaData(const medDataIndex &index, const QString &key) const override;
     bool setMetaData(const medDataIndex &index, const QString &key, const QString &value) override;
 
-    virtual bool execQuery(QSqlQuery &query, const char *file = nullptr, int line = -1) const;
+    bool execQuery(QSqlQuery &query, const char *file = nullptr, int line = -1) const;
 
     bool isPersistent() const;
 

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
@@ -70,7 +70,7 @@ public:
     QString metaData(const medDataIndex &index, const QString &key) const override;
     bool setMetaData(const medDataIndex &index, const QString &key, const QString &value) override;
 
-    bool execQuery(QSqlQuery &query, const char *file = nullptr, int line = -1) const;
+    virtual bool execQuery(QSqlQuery &query, const char *file = nullptr, int line = -1) const;
 
     bool isPersistent() const;
 

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
@@ -33,10 +33,9 @@ class MEDCORELEGACY_EXPORT medDatabasePersistentController : public medAbstractD
 public:
     ~medDatabasePersistentController();
 
-    const QSqlDatabase &database() const;
-
     bool createConnection() = 0;
-    virtual bool closeConnection() = 0;
+    virtual QSqlDatabase getMainConnection() const = 0;
+    virtual QSqlDatabase getThreadSpecificConnection() const = 0;
 
     medDataIndex indexForPatient(int id);
     medDataIndex indexForStudy(int id);
@@ -57,8 +56,6 @@ public:
     bool moveDatabase(QString newLocation);
 
     QString stringForPath(const QString &name) const;
-
-    bool isConnected() const override;
 
     QList<medDataIndex> patients() const = 0;
     QList<medDataIndex> studies(const medDataIndex &index) const override;
@@ -82,7 +79,6 @@ public:
 
     QString attachedMetadataFileExists(const medDataIndex &index) override;
 protected:
-    void setConnected(bool flag);
     void reset();
 
 public slots:
@@ -109,7 +105,6 @@ protected slots:
 
 protected:
     medDatabasePersistentController();
-    QSqlDatabase m_database;
 
 private:
     medDatabasePersistentControllerPrivate *d;

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -77,13 +77,20 @@ medAbstractData* medDatabaseReader::run()
 
     query.prepare ( "SELECT name, birthdate, gender, patientId FROM patient WHERE id = :id" );
     query.bindValue ( ":id", patientDbId );
+
+    QMutexLocker mutexLocker(&medDataManager::instance()->controller()->getDatabaseMutex());
+
     if ( !query.exec() )
     {
+        query.finish();
+        mutexLocker.unlock();
         FAILURE(query.lastError());
     }
 
     if (! query.first() )
     {
+        query.finish();
+        mutexLocker.unlock();
         FAILURE("No record in patient table for id:" + patientDbId.toString());
     }
 
@@ -101,6 +108,8 @@ medAbstractData* medDatabaseReader::run()
 
     if (! query.first() )
     {
+        query.finish();
+        mutexLocker.unlock();
         FAILURE("No record in study table for id:" + studyDbId.toString());
     }
 
@@ -120,11 +129,15 @@ medAbstractData* medDatabaseReader::run()
 
     if ( !query.exec() )
     {
+        query.finish();
+        mutexLocker.unlock();
         FAILURE(query.lastError());
     }
 
     if ( ! query.first())
     {
+        query.finish();
+        mutexLocker.unlock();
         FAILURE("No record in series table for id:" + seriesDbId.toString());
     }
 
@@ -162,6 +175,9 @@ medAbstractData* medDatabaseReader::run()
     seriesTime = query.value ( 28 ).toString();
     seriesDate = query.value ( 29 ).toString();
     kvp = query.value ( 30 ).toString();
+
+    query.finish();
+    mutexLocker.unlock();
 
     QStringList filePaths = seriesPath.split(';', QString::SkipEmptyParts);
     for(int i = 0 ; i < filePaths.size(); i++)

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -63,7 +63,8 @@ medAbstractData* medDatabaseReader::run()
     QVariant   studyDbId = d->index.studyId();
     QVariant  seriesDbId = d->index.seriesId();
 
-    QSqlQuery query(medDataManager::instance()->controller()->database());
+    QSqlDatabase dbConnection = medDataManager::instance()->controller()->getThreadSpecificConnection();
+    QSqlQuery query(dbConnection);
 
     QString patientName, birthdate, gender, patientId;
     QString studyName, studyUid, studyId, studyTime, studyDate;

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.cpp
@@ -98,7 +98,7 @@ QSqlDatabase medLocalDbController::getThreadSpecificConnection() const
 {
     if (!databaseConnections.hasLocalData())
     {
-        QSqlDatabase database = QSqlDatabase::cloneDatabase(mainConnectionName, QUuid::createUuid().toString());
+        QSqlDatabase database = QSqlDatabase::cloneDatabase(QString(mainConnectionName), QUuid::createUuid().toString());
         database.open();
         const_cast<medLocalDbController*>(this)->databaseConnections.setLocalData(database);
     }

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.cpp
@@ -32,7 +32,8 @@ medLocalDbController *medLocalDbController::instance()
     return s_instance;
 }
 
-medLocalDbController::medLocalDbController() : medDatabasePersistentController()
+medLocalDbController::medLocalDbController() :
+    medDatabasePersistentController(), queryMutex(QMutex::Recursive)
 {
     databasePath = medStorage::dataLocation();
 
@@ -116,6 +117,12 @@ QSqlDatabase medLocalDbController::getThreadSpecificConnection() const
     }
 
     return databaseConnections.localData();
+}
+
+bool medLocalDbController::execQuery(QSqlQuery& query, const char* file, int line) const
+{
+    QMutexLocker mutexLocker(const_cast<QMutex*>(&queryMutex));
+    return medDatabasePersistentController::execQuery(query, file, line);
 }
 
 bool medLocalDbController::createPatientTable()

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
@@ -34,7 +34,7 @@ public:
     QSqlDatabase getMainConnection() const override;
     QSqlDatabase getThreadSpecificConnection() const override;
 
-    bool execQuery(QSqlQuery &query, const char *file = nullptr, int line = -1) const override;
+    QMutex& getDatabaseMutex() const override;
 
     QList<medDataIndex> patients() const override;
     void requestDatabaseForModel(QHash<int, QHash<QString, QVariant> > &patientData,
@@ -50,7 +50,7 @@ protected:
 private:
     QThreadStorage<QSqlDatabase> databaseConnections;
     QString databasePath;
-    QMutex queryMutex;
+    QMutex databaseMutex;
 
     QSqlDatabase createConnection(QString name) const;
 

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
@@ -47,8 +47,9 @@ protected:
 
 private:
     QThreadStorage<QSqlDatabase> databaseConnections;
+    QString databasePath;
 
-    QSqlDatabase createMainConnection();
+    QSqlDatabase createConnection(QString name) const;
 
     bool createPatientTable();
     bool createStudyTable();

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
@@ -34,6 +34,8 @@ public:
     QSqlDatabase getMainConnection() const override;
     QSqlDatabase getThreadSpecificConnection() const override;
 
+    bool execQuery(QSqlQuery &query, const char *file = nullptr, int line = -1) const override;
+
     QList<medDataIndex> patients() const override;
     void requestDatabaseForModel(QHash<int, QHash<QString, QVariant> > &patientData,
                                  QHash<int, QHash<QString, QVariant> > &studyData,
@@ -48,6 +50,7 @@ protected:
 private:
     QThreadStorage<QSqlDatabase> databaseConnections;
     QString databasePath;
+    QMutex queryMutex;
 
     QSqlDatabase createConnection(QString name) const;
 

--- a/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medLocalDbController.h
@@ -14,6 +14,7 @@
 
 #include <QSqlDatabase>
 #include <QSqlQuery>
+#include <QThreadStorage>
 
 #include <medDatabasePersistentController.h>
 #include <medCoreLegacyExport.h>
@@ -29,7 +30,9 @@ public:
     static medLocalDbController *instance();
 
     bool createConnection() override;
-    bool closeConnection() override;
+    bool isConnected() const override;
+    QSqlDatabase getMainConnection() const override;
+    QSqlDatabase getThreadSpecificConnection() const override;
 
     QList<medDataIndex> patients() const override;
     void requestDatabaseForModel(QHash<int, QHash<QString, QVariant> > &patientData,
@@ -43,10 +46,16 @@ protected:
     medLocalDbController();
 
 private:
+    QThreadStorage<QSqlDatabase> databaseConnections;
+
+    QSqlDatabase createMainConnection();
+
     bool createPatientTable();
     bool createStudyTable();
     bool createSeriesTable();
 
     bool updateFromNoVersionToVersion1();
     static medLocalDbController *s_instance;
+
+    static const char* mainConnectionName;
 };


### PR DESCRIPTION
`QSqlDatabase` connections should only be used by the thread that created them. MedInria is using the same connection everywhere, and this is causing crashes (for example when multiple data are removed at the same time).
This PR makes all database connections thread-specific by cloning the main connection for each thread that requests one (and when the thread terminates the connection will close automatically).