### PR TITLE
allow duplicate series names

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDbController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDbController.h
@@ -60,7 +60,7 @@ signals:
 public slots:
     virtual medAbstractData* retrieve(const medDataIndex& index, bool readFullData = true) const = 0;
 
-    virtual void importData(medAbstractData *data, const QUuid &importUuid) = 0;
+    virtual void importData(medAbstractData *data, const QUuid &importUuid, bool allowDuplicateSeriesName = false) = 0;
     virtual void importPath(const QString &file, const QUuid &importUuid, bool indexWithoutCopying) = 0;
     virtual bool importMetaDataFromPacs(const QHash<QString, QHash<QString, QVariant> > &pData,
                                         const QHash<QString, QHash<QString, QVariant> > &sData) = 0;

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.cpp
@@ -173,7 +173,7 @@ void medDataManager::loadData(const medDataIndex &index)
     return;
 }
 
-QUuid medDataManager::importData(medAbstractData *data, bool persistent)
+QUuid medDataManager::importData(medAbstractData *data, bool persistent, bool allowDuplicateSeriesName)
 {
     if (!data)
         return QUuid();
@@ -183,7 +183,15 @@ QUuid medDataManager::importData(medAbstractData *data, bool persistent)
     medAbstractDbController *controller =
         persistent ? d->dbController : d->nonPersDbController;
     qDebug() << "generated uuid " << uuid.toString();
-    controller->importData(data, uuid);
+
+    if (persistent)
+    {
+        d->dbController->importData(data, uuid, allowDuplicateSeriesName);
+    }
+    else
+    {
+        controller->importData(data, uuid);
+    }
     return uuid;
 }
 

--- a/src/layers/legacy/medCoreLegacy/database/medDataManager.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDataManager.h
@@ -40,7 +40,7 @@ public:
 
     QHash<QString, dtkAbstractDataWriter*> getPossibleWriters(medAbstractData* data);
 
-    QUuid importData(medAbstractData* data, bool persistent = false);
+    QUuid importData(medAbstractData* data, bool persistent = false, bool allowDuplicateSeriesName = false);
     QUuid importPath(const QString& dataPath, bool indexWithoutCopying, bool persistent = false);
     void fetchData(const QHash<QString, QHash<QString, QVariant> > &pData,
                    const QHash<QString, QHash<QString, QVariant> > &sData);

--- a/src/layers/legacy/medCoreLegacy/database/medDataPacsController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDataPacsController.h
@@ -85,7 +85,7 @@ public:
 public slots:
     medAbstractData *retrieve(const medDataIndex &index, bool readFullData = true) const override;
 
-    void importData(medAbstractData *data, const QUuid &importUuid) override{};
+    void importData(medAbstractData *data, const QUuid &importUuid, bool allowDuplicateSeriesName = false) override{};
     void importPath(const QString &file, const QUuid &importUuid, bool indexWithoutCopying) override{};
     bool importMetaDataFromPacs(const QHash<QString, QHash<QString, QVariant> > &pData,
                                 const QHash<QString, QHash<QString, QVariant> > &sData) override;

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.cpp
@@ -28,15 +28,15 @@
 //-----------------------------------------------------------------------------------------------------------
 
 medDatabaseImporter::medDatabaseImporter ( const QString& file, const QUuid& uuid, bool indexWithoutImporting) :
-    medAbstractDatabaseImporter(file, uuid, indexWithoutImporting)
+    medAbstractDatabaseImporter(file, uuid, indexWithoutImporting), duplicateSeriesNamesEnabled(false)
 {
 
 }
 
 //-----------------------------------------------------------------------------------------------------------
 
-medDatabaseImporter::medDatabaseImporter ( medAbstractData* medData, const QUuid& uuid ) :
-    medAbstractDatabaseImporter(medData, uuid)
+medDatabaseImporter::medDatabaseImporter (medAbstractData* medData, const QUuid& uuid , bool allowDuplicateSeriesName) :
+    medAbstractDatabaseImporter(medData, uuid), duplicateSeriesNamesEnabled(allowDuplicateSeriesName)
 {
     
 }
@@ -91,10 +91,13 @@ medDataIndex medDatabaseImporter::populateDatabaseAndGenerateThumbnails ( medAbs
 
     int studyDbId = getOrCreateStudy ( medData, dbConnection, patientDbId );
 
-    // Update name of the series if a permanent data has this name already
-    QString seriesName = medData->metadata(medMetaDataKeys::SeriesDescription.key());
-    QString newSeriesName = ensureUniqueSeriesName(seriesName, QString::number(studyDbId));
-    medData->setMetaData(medMetaDataKeys::SeriesDescription.key(), newSeriesName);
+    if (!duplicateSeriesNamesEnabled)
+    {
+        // Update name of the series if a permanent data has this name already
+        QString seriesName = medData->metadata(medMetaDataKeys::SeriesDescription.key());
+        QString newSeriesName = ensureUniqueSeriesName(seriesName, QString::number(studyDbId));
+        medData->setMetaData(medMetaDataKeys::SeriesDescription.key(), newSeriesName);
+    }
 
     int seriesDbId = getOrCreateSeries ( medData, dbConnection, studyDbId );
 

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseImporter.h
@@ -37,10 +37,12 @@ class MEDCORELEGACY_EXPORT medDatabaseImporter : public medAbstractDatabaseImpor
 
 public:
     medDatabaseImporter ( const QString& file, const QUuid& uuid, bool indexWithoutImporting = false);
-    medDatabaseImporter ( medAbstractData* medData, const QUuid& callerUuid );
+    medDatabaseImporter ( medAbstractData* medData, const QUuid& callerUuid, bool allowDuplicateSeriesName = false);
     ~medDatabaseImporter() override = default;
 
 private:
+    bool duplicateSeriesNamesEnabled;
+
     QString ensureUniqueSeriesName ( const QString seriesName, const QString studyId ) override;
 
     medDataIndex populateDatabaseAndGenerateThumbnails ( medAbstractData* medData, QString pathToStoreThumbnail ) override;

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.cpp
@@ -132,7 +132,7 @@ bool medDatabaseNonPersistentController::isConnected() const
 }
 
 void medDatabaseNonPersistentController::importData(medAbstractData *data,
-                                                    const QUuid & callerUuid)
+                                                    const QUuid & callerUuid, bool allowDuplicateSeriesName)
 {
     medDatabaseNonPersistentImporter * importer = new medDatabaseNonPersistentImporter(data,callerUuid);
     medMessageProgress * message = medMessageController::instance()->showProgress("Importing data item");

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseNonPersistentController.h
@@ -70,7 +70,7 @@ public:
 public slots:
     virtual medAbstractData *retrieve(const medDataIndex &index, bool readFullData = true) const;
 
-    void importData(medAbstractData *data, const QUuid &callerUuid);
+    void importData(medAbstractData *data, const QUuid &callerUuid, bool allowDuplicateSeriesName = false);
     void importPath(const QString &file, const QUuid &callerUuid, bool indexWithoutCopying);
     bool importMetaDataFromPacs(const QHash<QString, QHash<QString, QVariant> > &pData,
                                 const QHash<QString, QHash<QString, QVariant> > &sData) override { return false; };

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
@@ -185,9 +185,9 @@ void medDatabasePersistentController::importPath(const QString &file, const QUui
 * Import data into the db read from memory
 * @param medAbstractData * data dataObject
 */
-void medDatabasePersistentController::importData(medAbstractData *data, const QUuid &importUuid)
+void medDatabasePersistentController::importData(medAbstractData *data, const QUuid &importUuid, bool allowDuplicateSeriesName)
 {
-    medDatabaseImporter *importer = new medDatabaseImporter(data, importUuid);
+    medDatabaseImporter *importer = new medDatabaseImporter(data, importUuid, allowDuplicateSeriesName);
     medMessageProgress *message = medMessageController::instance()->showProgress("Saving database item");
 
     connect(importer, SIGNAL(progressed(int)), message, SLOT(setProgress(int)));

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.h
@@ -86,7 +86,7 @@ public slots:
     medAbstractData *retrieve(const medDataIndex &index, bool readFullData = true) const;
 
     void importPath(const QString &file, const QUuid &importUuid, bool indexWithoutCopying = false) override;
-    void importData(medAbstractData *data, const QUuid &importUuid) override;
+    void importData(medAbstractData *data, const QUuid &importUuid, bool allowDuplicateSeriesName = false) override;
     bool importMetaDataFromPacs(const QHash<QString, QHash<QString, QVariant> > &pData,
                                 const QHash<QString, QHash<QString, QVariant> > &sData) override { return false; };
 


### PR DESCRIPTION
Add an option to allow imported data to have the same name as another series in the study (no prefix added).