### PR TITLE
Remove annotation data when destroying paint toolbox

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -507,6 +507,7 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
 {
     setOfPaintBrushRois.clear();
+    m_imageData->removeAttachedData(m_maskAnnotationData);
 }
 
 medAbstractData* AlgorithmPaintToolBox::processOutput()


### PR DESCRIPTION
In the pipelines, when resetting the paint step, the mask is not removed. This is not normal because resetting a pipeline step destroys and recreates everything (toolbox, view etc.). This was caused by annotation data being attached to the segmented data and not removed properly.