### PR TITLE
[polygonRoi] hide activation label

### DIFF
--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -60,6 +60,7 @@ polygonRoiToolBox::polygonRoiToolBox(QWidget *parent ) :
     activateTBButton->setCheckable(true);
     activateTBButton->setObjectName("closedPolygonButton");
     connect(activateTBButton,SIGNAL(toggled(bool)),this,SLOT(clickClosePolygon(bool)));
+    connect(activateTBButton, &QAbstractButton::toggled, [=] (bool state) { explanation->setVisible(!state); });
 
     interpolate = new QCheckBox(tr("Interpolate between contours"));
     interpolate->setToolTip("Interpolate between master ROIs");


### PR DESCRIPTION
The label stayed after activating the toolbox.