### PR TITLE
[Reslice] proper release of RAM

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.cpp
@@ -33,6 +33,12 @@ vtkImage2DDisplay::vtkImage2DDisplay()
     this->UseLookupTable    = false;
 }
 
+vtkImage2DDisplay::~vtkImage2DDisplay()
+{
+    ImageActor->Delete();
+    WindowLevel->Delete();
+}
+
 void vtkImage2DDisplay::SetInputData(vtkImageData *pi_poVtkImage)
 {
     if (pi_poVtkImage)

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImage2DDisplay.h
@@ -57,7 +57,7 @@ public:
 
 protected:
   vtkImage2DDisplay();
-  ~vtkImage2DDisplay() = default;
+  ~vtkImage2DDisplay();
 
 private:
   vtkSmartPointer<vtkImageMapToColors>        WindowLevel;

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView2D.cxx
@@ -147,6 +147,8 @@ vtkImageView2D::~vtkImageView2D()
   this->Command->Delete();
   this->OrientationAnnotation->Delete();
 
+  delete qtSignalHandler;
+  qtSignalHandler = nullptr;
 
   for (std::list<vtkDataSet2DWidget*>::iterator it3 = this->DataSetWidgets.begin();
       it3!=this->DataSetWidgets.end(); ++it3)
@@ -456,8 +458,14 @@ void vtkImageView2D::UpdateDisplayExtent()
   int *range = this->GetSliceRange();
   if (range)
   {
-    slice = std::max (slice, range[0]);
-    slice = std::min (slice, range[1]);
+      if (std::isdigit(range[0]))
+      {
+          slice = std::max (slice, range[0]);
+      }
+      if (std::isdigit(range[1]))
+      {
+          slice = std::min (slice, range[1]);
+      }
   }
 
   if (slice != this->Slice)

--- a/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
+++ b/src/plugins/legacy/itkDataImage/interactors/medVtkViewItkDataImageInteractor.cpp
@@ -205,7 +205,6 @@ bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int l
 {
     bool bRes = true;
 
-    auto *poOldConv = m_poConv;
     m_poConv = vtkItkConversionInterface::createInstance(data);
 
     if (m_poConv)
@@ -222,6 +221,7 @@ bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int l
             {
                 d->view2d->SetInput(poVtkAlgoOutputPort, poMatrix, layer);
                 d->view3d->SetInput(poVtkAlgoOutputPort, poMatrix, layer);
+                poMatrix->Delete();
             }
         }
     }
@@ -229,8 +229,6 @@ bool medVtkViewItkDataImageInteractor::SetViewInput(medAbstractData* data, int l
     {
         bRes = false;
     }
-
-    delete poOldConv;
 
     return bRes;
 }

--- a/src/plugins/legacy/medVtkView/medVtkView.cpp
+++ b/src/plugins/legacy/medVtkView/medVtkView.cpp
@@ -57,9 +57,6 @@
 class medVtkViewPrivate
 {
 public:
-    // internal state
-    vtkImageView *currentView; //2d or 3d depending on the navigator orientation.
-
     vtkInteractorStyle *interactorStyle2D;
 
     // views
@@ -83,8 +80,6 @@ public:
 medVtkView::medVtkView(QObject* parent): medAbstractImageView(parent),
     d(new medVtkViewPrivate)
 {
-    // setup initial internal state of the view
-    d->currentView = nullptr;
     d->interactorStyle2D = nullptr;
 
     // construct render window
@@ -194,6 +189,7 @@ medVtkView::~medVtkView()
         d->renWin->SetOffScreenRendering(0);
     d->renWin->Delete();
     delete d->viewWidget;
+    delete d->mainWindow;
 
     delete d;
 }

--- a/src/plugins/legacy/reformat/medResliceViewer.cpp
+++ b/src/plugins/legacy/reformat/medResliceViewer.cpp
@@ -17,12 +17,12 @@
 
 #include <medAbstractDataFactory.h>
 #include <medAbstractLayeredView.h>
+#include <medDoubleParameterL.h>
 #include <medSliderSpinboxPair.h>
 #include <medTransform.h>
 #include <medUtilities.h>
 #include <medUtilitiesITK.h>
 #include <medVtkViewBackend.h>
-#include <medDoubleParameterL.h>
 
 #include <vtkCamera.h>
 #include <vtkCellPicker.h>
@@ -36,13 +36,13 @@
 #include <vtkPlaneSource.h>
 #include <vtkProperty.h>
 #include <vtkRenderer.h>
+#include <vtkRenderWindowInteractor.h>
 #include <vtkResliceCursor.h>
 #include <vtkResliceCursorActor.h>
 #include <vtkResliceCursorPolyDataAlgorithm.h>
 #include <vtkResliceCursorThickLineRepresentation.h>
 #include <vtkResliceCursorWidget.h>
 #include <vtkTransform.h>
-#include <vtkRenderWindowInteractor.h>
 
 class medResliceCursorCallback : public vtkCommand
 {
@@ -122,7 +122,10 @@ public:
         reformatViewer->getImagePlaneWidget(0)->GetInteractor()->GetRenderWindow()->Render();
     }
 
-    medResliceCursorCallback() {}
+    ~medResliceCursorCallback()
+    {
+        reformatViewer = nullptr;
+    }
 
     medResliceViewer *reformatViewer;
 };
@@ -167,7 +170,7 @@ medResliceViewer::medResliceViewer(medAbstractView *view, QWidget *parent): medA
     }
 
     // Position of the new views in tab
-    QGridLayout *gridLayout = new QGridLayout(parent);
+    QGridLayout *gridLayout = new QGridLayout();
     gridLayout->addWidget(views[2], 0, 0);
     gridLayout->addWidget(views[3], 0, 1);
     gridLayout->addWidget(views[1], 1, 0);
@@ -286,6 +289,7 @@ medResliceViewer::~medResliceViewer()
         planeWidget[i] = nullptr;
     }
     vtkViewData = nullptr;
+    inputData = nullptr;
 }
 
 QString medResliceViewer::identifier() const

--- a/src/plugins/legacy/reformat/medResliceViewer.h
+++ b/src/plugins/legacy/reformat/medResliceViewer.h
@@ -12,18 +12,18 @@ PURPOSE.
 
 =========================================================================*/
 
+#include "resliceToolBox.h"
+
+#include <medAbstractView.h>
+#include <vtkImageView3D.h>
+
 #include <dtkCoreSupport/dtkSmartPointer.h>
 
 #include <itkImage.h>
 
-#include <medAbstractView.h>
-
 #include <QVTKOpenGLWidget.h>
 
-#include <resliceToolBox.h>
-
 #include <vtkImagePlaneWidget.h>
-#include <vtkImageView3D.h>
 #include <vtkResliceImageViewer.h>
 #include <vtkSmartPointer.h>
 

--- a/src/plugins/legacy/reformat/resliceToolBox.cpp
+++ b/src/plugins/legacy/reformat/resliceToolBox.cpp
@@ -11,6 +11,7 @@
 
 =========================================================================*/
 #include "resliceToolBox.h"
+#include "medResliceViewer.h"
 
 #include <medAbstractImageData.h>
 #include <medAbstractLayeredView.h>
@@ -18,7 +19,6 @@
 #include <medDoubleParameterL.h>
 #include <medMessageController.h>
 #include <medPluginManager.h>
-#include <medResliceViewer.h>
 #include <medTabbedViewContainers.h>
 #include <medToolBoxFactory.h>
 #include <medViewContainer.h>
@@ -31,31 +31,37 @@ public:
     QComboBox *bySpacingOrSize;
     QLabel *helpBegin;
     medDoubleParameterL *spacingOrSizeX, *spacingOrSizeY, *spacingOrSizeZ;
-    medAbstractLayeredView *currentView;
     medResliceViewer *resliceViewer;
     dtkSmartPointer<medAbstractData> reformatedImage;
     QWidget *reformatOptions;
     medVtkImageInfo* imageInfo;
+    medAbstractData *originalImage;
 };
 
 resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox (parent), d(new resliceToolBoxPrivate)
 {
-    // Fill the toolBox
-    QWidget *resliceToolBoxBody = new QWidget(this);
-    d->b_startReslice = new QPushButton("Start Reslice", resliceToolBoxBody);
+    QWidget *resliceToolBoxBody = new QWidget();
+    this->addWidget(resliceToolBoxBody);
+
+    QVBoxLayout *resliceToolBoxLayout =  new QVBoxLayout(resliceToolBoxBody);
+
+    d->b_startReslice = new QPushButton("Start Reslice");
     d->b_startReslice->setCheckable(false);
     d->b_startReslice->setObjectName("startReformatButton");
-    d->b_stopReslice = new QPushButton("Stop Reslice", resliceToolBoxBody);
+    resliceToolBoxLayout->addWidget(d->b_startReslice);
+
+    d->b_stopReslice = new QPushButton("Stop Reslice");
     d->b_stopReslice->setCheckable(false);
     d->b_stopReslice->setObjectName("stopReformatButton");
-    d->b_saveImage = new QPushButton("Save Image", resliceToolBoxBody);
+
+    d->b_saveImage = new QPushButton("Save Image");
     d->b_saveImage->setCheckable(false);
     d->b_saveImage->setObjectName("saveImageButton");
 
     // User can choose pixel or millimeter resample
     QHBoxLayout * resampleLayout = new QHBoxLayout();
-    QLabel *bySpacingOrSizeLabel = new QLabel("Select your resample parameter ", resliceToolBoxBody);
-    d->bySpacingOrSize = new QComboBox(resliceToolBoxBody);
+    QLabel *bySpacingOrSizeLabel = new QLabel("Select your resample parameter ");
+    d->bySpacingOrSize = new QComboBox();
     d->bySpacingOrSize->setObjectName("bySpacingOrSize");
     d->bySpacingOrSize->addItem("Spacing");
     d->bySpacingOrSize->addItem("Size");
@@ -64,8 +70,7 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
     connect(d->bySpacingOrSize, SIGNAL(currentIndexChanged(const QString&)), this, SLOT(switchSpacingAndDimension(const QString&)));
 
     // Spinboxes of resample values
-    QWidget *spinBoxes = new QWidget(resliceToolBoxBody);
-    QVBoxLayout *spacingSpinBoxLayout = new QVBoxLayout(resliceToolBoxBody);
+    QVBoxLayout *spacingSpinBoxLayout = new QVBoxLayout();
 
     QHBoxLayout *spacingSpinBoxLayoutX = new QHBoxLayout();
     spacingSpinBoxLayoutX->setAlignment(Qt::AlignCenter);
@@ -102,52 +107,43 @@ resliceToolBox::resliceToolBox (QWidget *parent) : medAbstractSelectableToolBox 
     spacingSpinBoxLayoutZ->addWidget(d->spacingOrSizeZ->getLabel());
     spacingSpinBoxLayoutZ->addWidget(d->spacingOrSizeZ->getSpinBox());
     spacingSpinBoxLayout->addLayout(spacingSpinBoxLayoutZ);
-
-    spinBoxes->setLayout(spacingSpinBoxLayout);
-
-    QVBoxLayout *resliceToolBoxLayout =  new QVBoxLayout(resliceToolBoxBody);
-    d->helpBegin = new QLabel("Drop a data in the view and click on 'Start Reslice'.", resliceToolBoxBody);
+    
+    d->helpBegin = new QLabel("Drop a data in the view and click on 'Start Reslice'.");
     d->helpBegin->setObjectName("helpBegin");
     d->helpBegin->setStyleSheet("font: italic");
     resliceToolBoxLayout->addWidget(d->helpBegin);
 
-    QLabel *help1 = new QLabel("To change the windowing left click on a 2D view.", resliceToolBoxBody);
-    QLabel *help2 = new QLabel("To reset axes in a view press 'o'.",               resliceToolBoxBody);
-    QLabel *help3 = new QLabel("To reset windowing in a view press 'r'.\n",        resliceToolBoxBody);
+    QLabel *help1 = new QLabel("To change the windowing left click on a 2D view.\n"
+                               "To reset axes in a view press 'o'.\n"
+                               "To reset windowing in a view press 'r'.\n"
+                                );
     help1->setStyleSheet("font: italic");
-    help2->setStyleSheet("font: italic");
-    help3->setStyleSheet("font: italic");
 
-    resliceToolBoxLayout->addWidget(d->b_startReslice);
-
-    d->reformatOptions = new QWidget(resliceToolBoxBody);
+    d->reformatOptions = new QWidget();
     QVBoxLayout *reformatOptionsLayout = new QVBoxLayout(d->reformatOptions);
     d->reformatOptions->setLayout(reformatOptionsLayout);
     d->reformatOptions->hide();
 
     resliceToolBoxLayout->addWidget(d->reformatOptions);
     reformatOptionsLayout->addWidget(help1);
-    reformatOptionsLayout->addWidget(help2);
-    reformatOptionsLayout->addWidget(help3);
     reformatOptionsLayout->addLayout(resampleLayout);
-    reformatOptionsLayout->addWidget(spinBoxes);
+    reformatOptionsLayout->addLayout(spacingSpinBoxLayout);
     reformatOptionsLayout->addWidget(d->b_saveImage);
     reformatOptionsLayout->addWidget(d->b_stopReslice);
     resliceToolBoxBody->setLayout(resliceToolBoxLayout);
-    this->addWidget(resliceToolBoxBody);
 
     // Connections
     connect(d->b_startReslice,SIGNAL(clicked()),this,SLOT(startReformat()));
     connect(d->b_stopReslice,SIGNAL(clicked()),this,SLOT(stopReformat()));
 
     d->resliceViewer = nullptr;
-    d->currentView   = nullptr;
 }
 resliceToolBox::~resliceToolBox()
 {
     delete d->resliceViewer;
     d->resliceViewer = nullptr;
-    d->currentView = nullptr;
+
+    d->originalImage = nullptr;
 
     delete d;
     d = nullptr;
@@ -167,52 +163,55 @@ dtkPlugin* resliceToolBox::plugin()
 
 void resliceToolBox::startReformat()
 {
-    if (d->currentView && getWorkspace())
+    if (getWorkspace())
     {
-        medAbstractData* data = d->currentView->layerData(d->currentView->currentLayer());
-        bool is3D = false;
+        auto tabbedContainers = getWorkspace()->tabbedViewContainers();
+        auto container = tabbedContainers->getFirstSelectedContainer();
+        auto view = qobject_cast<medAbstractLayeredView*>(tabbedContainers->getFirstSelectedContainerView());
 
-        // Toolbox does not work with meshes or vector images
-        if (data->identifier().contains("itkDataImage") &&
-                !data->identifier().contains("Vector"))
+        if (view)
         {
-            if (dynamic_cast<medAbstractImageData *>(data)->Dimension() == 3)
+            medAbstractData* data = view->layerData(view->currentLayer());
+            bool is3D = false;
+
+            // Toolbox does not work with meshes or vector images
+            if (data->identifier().contains("itkDataImage") &&
+                    !data->identifier().contains("Vector"))
             {
-                is3D = true;
-            }
+                if (dynamic_cast<medAbstractImageData *>(data)->Dimension() == 3)
+                {
+                    is3D = true;
+                }
 
-            if (d->currentView->layersCount() && is3D)
-            {
-                d->helpBegin->hide();
-                d->reformatOptions->show();
-                d->b_startReslice->hide();
+                if (view->layersCount() && is3D)
+                {
+                    d->helpBegin->hide();
+                    d->reformatOptions->show();
+                    d->b_startReslice->hide();
 
-                d->resliceViewer = new medResliceViewer(d->currentView,
-                                                        getWorkspace()->tabbedViewContainers());
-                d->resliceViewer->setToolBox(this);
-                getWorkspace()->tabbedViewContainers()->setAcceptDrops(false);
-                medViewContainer * container = getWorkspace()->tabbedViewContainers()->insertNewTab(0, "Reslice");
-                getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
-                container->setDefaultWidget(d->resliceViewer->viewWidget());
+                    d->resliceViewer = new medResliceViewer(view, container);
+                    d->resliceViewer->setToolBox(this);
 
-                connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),
-                    this,SLOT(saveReformatedImage()), Qt::UniqueConnection);
-                connect(container, SIGNAL(viewRemoved()),
-                    this, SLOT(stopReformat()), Qt::UniqueConnection);
-                connect(d->spacingOrSizeX, SIGNAL(valueChanged(double)), 
-                    d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
-                connect(d->spacingOrSizeY, SIGNAL(valueChanged(double)), 
-                    d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
-                connect(d->spacingOrSizeZ, SIGNAL(valueChanged(double)), 
-                    d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
-                connect(d->b_saveImage, SIGNAL(clicked()), 
-                    d->resliceViewer, SLOT(saveImage()), Qt::UniqueConnection);
+                    container->removeView();
+                    container->setDefaultWidget(d->resliceViewer->viewWidget());
 
-                d->reformatedImage = nullptr;
+                    connect(d->resliceViewer,SIGNAL(imageReformatedGenerated()),
+                        this,SLOT(saveReformatedImage()), Qt::UniqueConnection);
+                    connect(d->spacingOrSizeX, SIGNAL(valueChanged(double)), 
+                        d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
+                    connect(d->spacingOrSizeY, SIGNAL(valueChanged(double)), 
+                        d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
+                    connect(d->spacingOrSizeZ, SIGNAL(valueChanged(double)), 
+                        d->resliceViewer, SLOT(askedSpacingOrSizeChange(double)), Qt::UniqueConnection);
+                    connect(d->b_saveImage, SIGNAL(clicked()), 
+                        d->resliceViewer, SLOT(saveImage()), Qt::UniqueConnection);
 
-                // close the initial tab which is not needed anymore
-                getWorkspace()->tabbedViewContainers()->removeTab(1);
-                updateView();
+                    d->reformatedImage = nullptr;
+                }
+                else
+                {
+                    medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
+                }
             }
             else
             {
@@ -224,34 +223,30 @@ void resliceToolBox::startReformat()
             medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
         }
     }
-    else
-    {
-        medMessageController::instance()->showError(tr("Drop a 3D volume in the view"), 3000);
-    }
 }
 
 void resliceToolBox::stopReformat()
 {
-    if (getWorkspace())
+    if (getWorkspace() && d->resliceViewer)
     {
         d->bySpacingOrSize->setCurrentIndex(0); // init resample parameter
         d->helpBegin->show();
         d->reformatOptions->hide();
         d->b_startReslice->show();
 
-        getWorkspace()->tabbedViewContainers()->removeTab(0);
-        getWorkspace()->tabbedViewContainers()->insertNewTab(0, getWorkspace()->name());
-        getWorkspace()->tabbedViewContainers()->setCurrentIndex(0);
+        auto tabbedContainers = getWorkspace()->tabbedViewContainers();
+        auto container = tabbedContainers->getFirstSelectedContainer();
+        container->initializeDefaultWidget();
 
-        if (d->currentView)
+        if (d->originalImage)
         {
-            getWorkspace()->tabbedViewContainers()->getFirstSelectedContainer()->addData(d->currentView->layerData(0));
+            container->addData(d->originalImage);
         }
 
         disconnect(d->resliceViewer);
         delete d->resliceViewer;
-
         d->resliceViewer = nullptr;
+
         QList<medToolBox*> toolBoxes = getWorkspace()->toolBoxes();
         for (int i = 0; i < toolBoxes.length(); i++)
         {
@@ -267,18 +262,18 @@ void resliceToolBox::clear()
 
 void resliceToolBox::updateView()
 {
+    // Even if updateView is called because of an empty view, we want to keep the original data,
+    // so the toolbox can be reset to the original one.
     medAbstractView* view = this->getWorkspace()->tabbedViewContainers()->getFirstSelectedContainerView();
-
-    d->currentView = nullptr;
     if (view)
     {
         medAbstractLayeredView *layeredView = qobject_cast<medAbstractLayeredView*>(view);
         if (dynamic_cast<medAbstractImageData*>(layeredView->layerData(layeredView->currentLayer())))
         {
-            d->currentView = layeredView;
+            d->originalImage = layeredView->layerData(layeredView->currentLayer());
 
             // Get the original image information and display it
-            vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(d->currentView->backend())->view2D;
+            vtkImageView2D *view2d = static_cast<medVtkViewBackend*>(layeredView->backend())->view2D;
             d->imageInfo = view2d->GetMedVtkImageInfo();
             displayInfoOnCurrentView();
         }

--- a/src/plugins/legacy/reformat/resliceToolBox.h
+++ b/src/plugins/legacy/reformat/resliceToolBox.h
@@ -23,10 +23,10 @@ class resliceToolBoxPrivate;
  * "startReformatButton" : QPushButton\n
  * "stopReformatButton" : QPushButton\n
  * "saveImageButton" : QPushButton\n
- * "bySpacingOrDimension" : medComboBox\n
- * "SpacingX" : QDoubleSpinBox\n
- * "SpacingY" : QDoubleSpinBox\n
- * "SpacingZ" : QDoubleSpinBox\n
+ * "bySpacingOrDimension" : QComboBox\n
+ * "SpacingOrSizeX" : medDoubleParameterL\n
+ * "SpacingOrSizeY" : medDoubleParameterL\n
+ * "SpacingOrSizeZ" : medDoubleParameterL\n
  * "helpBegin" : QLabel
  */
 class REFORMATPLUGIN_EXPORT resliceToolBox : public medAbstractSelectableToolBox


### PR DESCRIPTION
This toolbox allows to solve memory problems in Reslice toolbox: mem leaks and memory used where it was not needed.

The toolbox does not close anymore the first container to create a new one with medResliceViewer. Instead, it removes the view, change the "default widget" to medResliceViewer, then at stop it initializes the default widget and add back the original data in the container, creating a new view itself. 
Also now, changing from this toolbox to an other does not create a new container/view/etc, especially if the toolbox was not activated. Before that, even opening this toolbox with a data and switching to an other toolbox was using a lot a memory for nothing. 

:m: