### PR TITLE
[Paint] crash at app closing if no painting

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -507,7 +507,11 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
 AlgorithmPaintToolBox::~AlgorithmPaintToolBox()
 {
     setOfPaintBrushRois.clear();
-    m_imageData->removeAttachedData(m_maskAnnotationData);
+
+    if (m_imageData && m_maskAnnotationData)
+    {
+        m_imageData->removeAttachedData(m_maskAnnotationData);
+    }
 }
 
 medAbstractData* AlgorithmPaintToolBox::processOutput()


### PR DESCRIPTION
To get the crash:
 * open data view with Paint toolbox opened
 * do not draw something
 * close the software

:m: