### PR TITLE
[polygonRoi] fix processsOutput crash when no roi

### DIFF
--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -166,7 +166,7 @@ dtkPlugin* polygonRoiToolBox::plugin()
 
 medAbstractData *polygonRoiToolBox::processOutput()
 {
-    return processOutputs()[0];
+    return processOutputs().value(0);
 }
 
 QList<dtkSmartPointer<medAbstractData> > polygonRoiToolBox::processOutputs()


### PR DESCRIPTION
Returns `nullptr` if no ROI.