### PR TITLE
[manualRegistration] solve top views size problem

### DIFF
--- a/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
+++ b/src/plugins/legacy/manualRegistration/manualRegistrationToolBox.cpp
@@ -466,7 +466,7 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers* tab
 
         d->leftContainer = tabContainers->insertNewTab(0,"ManualRegistration");
         tabContainers->setCurrentIndex(0);
-        d->leftContainer->addData(d->currentView->layerData(0));//
+        d->leftContainer->addData(d->currentView->layerData(0));
         qobject_cast<medAbstractImageView*>(d->leftContainer->view())->windowLevelParameter(0)->setValues(windowing0);
 
         d->bottomContainer = d->leftContainer->splitHorizontally();
@@ -474,11 +474,12 @@ void manualRegistrationToolBox::constructContainers(medTabbedViewContainers* tab
         qobject_cast<medAbstractImageView*>(d->bottomContainer->view())->windowLevelParameter(0)->setValues(windowing0);
         d->bottomContainer->addData(d->currentView->layerData(1));
         qobject_cast<medAbstractImageView*>(d->bottomContainer->view())->windowLevelParameter(1)->setValues(windowing1);
-        tabContainers->containersInTab(0);
 
         d->rightContainer = d->leftContainer->splitVertically();
         d->rightContainer->addData(d->currentView->layerData(1));
         qobject_cast<medAbstractImageView*>(d->rightContainer->view())->windowLevelParameter(0)->setValues(windowing1);
+
+        tabContainers->adjustContainersSize();
 
         d->leftContainer->setUserSplittable(false);
         d->rightContainer->setUserSplittable(false);


### PR DESCRIPTION
The `constructContainers` method, used in pipelines for instance had a problem. Its 2 top views were not the same size.

:m: