### PR TITLE
python plugin packaging on macOS

### DIFF
--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -31,7 +31,23 @@ for i in $*; do
         injectDirs="$injectDirs -inject-dir=$i"
 done
 
+mkdir python_plugins
+injectDirs="$injectDirs -inject-dir=@PROJECT_BINARY_DIR@/TmpInstall/python_plugins"
+
+python_libs=''
+for python_lib in @medInria_DIR@/bin/plugins/python/*; do
+    lib=${python_lib##*/}
+    libname=${lib%.so}
+    cp $python_lib python_plugins/$libname.dylib
+    python_libs="$python_libs $libname"
+done
+
 @dtk_DIR@/bin/dtkDeploy MUSICardio.app $injectDirs &>/dev/null
+
+mkdir MUSICardio.app/Contents/Plugins/python
+for python_lib in $python_libs; do
+    mv MUSICardio.app/Contents/Plugins/$python_lib.dylib MUSICardio.app/Contents/Plugins/python/$python_lib.so
+done
 
 @CMAKE_COMMAND@ -DCMAKE_INSTALL_PREFIX:STRING=MUSICardio.app/Contents/Resources -DCMAKE_INSTALL_COMPONENT:STRING=Python -P @pyncpp_DIR@/cmake_install.cmake
 

--- a/superbuild/projects_modules/pyncpp.cmake
+++ b/superbuild/projects_modules/pyncpp.cmake
@@ -47,11 +47,6 @@ function(pyncpp_project)
                 -D Qt5_DIR:PATH=${Qt5_DIR}
                 -D OPENSSL_ROOT_DIR:PATH=${OPENSSL_ROOT_DIR}
                 )
-            if(APPLE)
-                list(APPEND cmake_args
-                    -D CMAKE_MACOSX_RPATH:BOOL=OFF
-                    )
-            endif()
         endif()
 
         ## #####################################################################


### PR DESCRIPTION
dtkDeploy handles `.dylib` files and not `.so` so we have to rename the python plugins between the two in order to be packaged properly.
In addition we compile pyncpp with rpaths which solves linking issues with the bindings (since dtkDeploy does not handle dependencies between plugins either)