### PR TITLE
[Thumbnail] no need to warn if no thumbn since the thumbnail setting added

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -699,10 +699,7 @@ QString medAbstractDatabaseImporter::generateThumbnail ( medAbstractData* medDat
         qWarning("medAbstractDatabaseImporter: Cannot create directory: %s", qPrintable(pathToStoreThumbnail));
     }
 
-    if ( ! thumbnail.save ( fullThumbnailPath, "PNG" ))
-    {
-        qWarning("medAbstractDatabaseImporter: Saving thumbnail to %s failed.", qPrintable(fullThumbnailPath));
-    }
+    thumbnail.save(fullThumbnailPath, "PNG");
 
     medData->addMetaData ( medMetaDataKeys::ThumbnailPath.key(), thumbnailPath );
 


### PR DESCRIPTION
Since a thumbnail setting has been added to allow or not the creation of the thumbnail at data import, there is no need to display a warning about the existence of thumbnail during the saving of a temporary data.

:m: