### PR TITLE
[Histogram] switch QObject+QGraphicsItem to QGraphicsObject

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.cpp
+++ b/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.cpp
@@ -52,7 +52,7 @@ public:
 
 medClutEditorVertex::medClutEditorVertex(QPointF value, QPointF coord,
                                          QColor color, QGraphicsItem * parent)
-    : QObject(), QGraphicsItem(parent)
+    : QGraphicsObject(parent)
 {
     d = new medClutEditorVertexPrivate;
     d->value = value;
@@ -91,7 +91,7 @@ medClutEditorVertex::medClutEditorVertex(QPointF value, QPointF coord,
 
 medClutEditorVertex::medClutEditorVertex( const medClutEditorVertex & other,
                                           QGraphicsItem * parent)
-    : QObject(), QGraphicsItem( parent )
+    : QGraphicsObject(parent)
 {
     if ( parent == nullptr )
     {
@@ -431,7 +431,7 @@ public:
 
 medClutEditorTable::medClutEditorTable(const QString & title,
                                        QGraphicsItem *parent)
-    :QObject(), QGraphicsItem(parent)
+    : QGraphicsObject(parent)
 {
     d = new medClutEditorTablePrivate;
     d->title = title;
@@ -444,7 +444,7 @@ medClutEditorTable::medClutEditorTable(const QString & title,
 }
 
 medClutEditorTable::medClutEditorTable(const medClutEditorTable & table)
-    :QObject(),  QGraphicsItem( static_cast< QGraphicsItem *>( table.parentItem() ) )
+    : QGraphicsObject(static_cast< QGraphicsItem *>(table.parentItem()))
 {
     d = new medClutEditorTablePrivate;
     d->title = table.title();

--- a/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.h
+++ b/src/layers/legacy/medCoreLegacy/gui/lookUpTables/medClutEditor.h
@@ -26,11 +26,9 @@ class medAbstractImageView;
 
 class medClutEditorVertexPrivate;
 
-// TODO use QGraphicsObjectItem noobs.
-class MEDCORELEGACY_EXPORT medClutEditorVertex : public QObject, public QGraphicsItem
+class MEDCORELEGACY_EXPORT medClutEditorVertex : public QGraphicsObject
 {
     Q_OBJECT
-    Q_INTERFACES(QGraphicsItem)
 
 public:
     medClutEditorVertex(QPointF value, QPointF coord, QColor color = Qt::white, QGraphicsItem *parent = nullptr);
@@ -82,10 +80,9 @@ private :
 // /////////////////////////////////////////////////////////////////
 class medClutEditorTablePrivate;
 
-class MEDCORELEGACY_EXPORT medClutEditorTable : public QObject, public QGraphicsItem
+class MEDCORELEGACY_EXPORT medClutEditorTable : public QGraphicsObject
 {
     Q_OBJECT
-    Q_INTERFACES(QGraphicsItem)
 
 public:
     medClutEditorTable(const medClutEditorTable & table);


### PR DESCRIPTION
To avoid:
 * a warning on Ubuntu because of the lack of `Q_INTERFACES(QGraphicsItem)`
 * a compilation error on macOS because of its existence.
 
And to remove an old special comment ( 👀 ).
 
This PR changes the double inheritance in some histogram classes to a single one directly derived from QObjects.

:m: