### PR TITLE
[Video] put a better default frame rate

### DIFF
--- a/src/plugins/legacy/medExportVideo/medExportVideo.cpp
+++ b/src/plugins/legacy/medExportVideo/medExportVideo.cpp
@@ -85,7 +85,7 @@ ExportVideo::ExportVideo() : medAbstractProcessLegacy(), d(new ExportVideoPrivat
     // User parameters
     d->format = OGGVORBIS;
     d->filename = "";
-    d->frameRate = 1;
+    d->frameRate = 24;
     d->subsampling = false;
     d->quality = 2;
 }


### PR DESCRIPTION
Same PR as https://github.com/medInria/medInria-public/pull/1199

The frame rate default value was wrong during video exports, this PR changes it to a more normal one.

:m: