### PR TITLE
[medAbstractSelectableTlbx] typo in include

### DIFF
--- a/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.h
+++ b/src/layers/legacy/medCoreLegacy/gui/toolboxes/medAbstractSelectableToolBox.h
@@ -14,7 +14,7 @@
 
 #include <medCoreLegacyExport.h>
 #include <medToolBox.h>
-#include <dtkCoreSupport/dtkSmartPointer>
+#include <dtkCoreSupport/dtkSmartPointer.h>
 
 class medAbstractData;
 class medSelectorToolBox;


### PR DESCRIPTION
Small typo in an include in medAbstractSelectableToolBox.h

:m: