### PR TITLE
Check for OpenMP

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -40,6 +40,14 @@ if(USE_Python AND UNIX)
     find_package(OpenSSL COMPONENTS SSL)
 endif()
 
+if(USE_MUSIC_PLUGINS)
+    find_package(OpenMP REQUIRED)
+
+    if(NOT OpenMP_CXX_FOUND)
+        message(FATAL_ERROR "OpenMP not found. It may have to be manually installed, with OpenMP_ROOT set to the installation path.")
+    endif()
+endif()
+
 ## #############################################################################
 ## Add exteral projects
 ## #############################################################################

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -77,6 +77,12 @@ function(music_plugins_project)
               )
         endif()
 
+        if (OpenMP_ROOT)
+            list(APPEND cmake_args
+                -DOpenMP_ROOT:PATH=${OpenMP_ROOT}
+                )
+        endif()
+
         epComputPath(${external_project})
         ExternalProject_Add(${external_project}
             PREFIX ${EP_PATH_SOURCE}


### PR DESCRIPTION
The music-plugins project uses the FindOpenMP module which does not always succeed on some systems. When this the case the `OpenMP_ROOT` variable must be manually set. This PR adds a check at configuration time with the appropriate message.