### PR TITLE
[itkDCMTKImageIO] when getting principal axis index assume 0 for missing origin

### DIFF
--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -687,6 +687,11 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
 double DCMTKImageIO::GetPositionFromPrincipalAxisIndex(int index, int principalAxisIndex)
 {
     std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
+    if ( s_position == "" )
+    {
+        itkWarningMacro ( << "Tag (0020,0032) (ImageOrigin) was not found, assuming 0.0/0.0/0.0" << std::endl);
+        return 0.0;
+    }
 
     // Convert string metadata to vector of double
     std::stringstream lineStream(s_position);

--- a/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
+++ b/src/layers/legacy/medImageIO/itkDCMTKImageIO.cpp
@@ -687,7 +687,7 @@ double DCMTKImageIO::GetPositionOnStackingAxisForImage (int index)
 double DCMTKImageIO::GetPositionFromPrincipalAxisIndex(int index, int principalAxisIndex)
 {
     std::string s_position = this->GetMetaDataValueString("(0020,0032)", index);
-    if ( s_position == "" )
+    if (s_position.empty())
     {
         itkWarningMacro ( << "Tag (0020,0032) (ImageOrigin) was not found, assuming 0.0/0.0/0.0" << std::endl);
         return 0.0;


### PR DESCRIPTION
From PR https://github.com/medInria/medInria-public/pull/1192 and https://github.com/medInria/medInria-public/pull/1203

Fix https://github.com/medInria/medInria-public/issues/1190 "If you try to open a DICOM in which the tag origin was not properly filled the software will crash."

:m: