### PR TITLE
[DCMTK] repo not accessible anymore, switch to github

### DIFF
--- a/superbuild/projects_modules/DCMTK.cmake
+++ b/superbuild/projects_modules/DCMTK.cmake
@@ -39,7 +39,7 @@ if (NOT USE_SYSTEM_${ep})
 ## Set up versioning control
 ## #############################################################################
 
-set(git_url git://git.dcmtk.org/dcmtk.git)
+set(git_url ${GITHUB_PREFIX}DCMTK/dcmtk.git)
 set(git_tag DCMTK-3.6.2)
 
 


### PR DESCRIPTION
The previous repo for DCMTK is down since yesterday at least. This PR switches it to the Github mirror.

:m: