### PR TITLE
fix loading of DLLs by Python on Windows

### DIFF
--- a/src/app/medInria/CMakeLists.txt
+++ b/src/app/medInria/CMakeLists.txt
@@ -177,6 +177,12 @@ if(USE_Python)
         BUILD_PYTHON_HOME="${pyncpp_PYTHON_DIR}"
         BUILD_PYTHON_PLUGIN_PATH="${CMAKE_BINARY_DIR}/bin/python_plugins"
         )
+
+    if(WIN32)
+        target_compile_definitions(${TARGET_NAME} PUBLIC
+            PLUGINS_LEGACY_PATH="plugins_legacy"
+            )
+    endif()
 endif()
 
 ## #############################################################################


### PR DESCRIPTION
On Windows when Python loads an extension module that depends on other shared libraries it no longer uses `sys.paths` to load those dependencies. The function `os.add_dll_directory` must be used.