### PR TITLE
[Cropping] reset box if tlbx is switched to another & add reset button

### DIFF
--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -357,7 +357,6 @@ void medCropToolBox::resetBoxPlace()
         d->view3D->GetBoxWidget()->PlaceWidget(d->minInitialPositionBox[0], d->maxInitialPositionBox[0], 
                                             d->minInitialPositionBox[1], d->maxInitialPositionBox[1],
                                             d->minInitialPositionBox[2], d->maxInitialPositionBox[2]);
-        d->borderWidget->GetCurrentRenderer()->GetRenderWindow()->Render();
         d->updateBorderWidgetIfVisible();
     }
 }

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -141,9 +141,9 @@ medCropToolBox::medCropToolBox(QWidget* parent)
     cropToolBoxLayout->addWidget(d->saveButton);
     connect(d->saveButton, SIGNAL(clicked()), this, SLOT(saveCrop()));
 
-    d->resetButton = new QPushButton("Reset", this);
+    d->resetButton = new QPushButton("Reset Box", this);
     d->resetButton->setToolTip("Reset the cropping box");
-    d->resetButton->setObjectName("Reset");
+    d->resetButton->setObjectName("ResetBox");
     cropToolBoxLayout->addWidget(d->resetButton);
     connect(d->resetButton, &QPushButton::clicked, this, &medCropToolBox::resetBoxPlace);
 

--- a/src/plugins/legacy/reformat/medCropToolBox.h
+++ b/src/plugins/legacy/reformat/medCropToolBox.h
@@ -51,6 +51,8 @@ protected:
     virtual void clear();
     int generateOutput();
     void enableButtons(bool wantToEnable);
+    void initializeBoxPlace();
+    void resetBoxPlace();
 
 private:
     medCropToolBoxPrivate* const d;


### PR DESCRIPTION
This PR is about the Cropping bug in https://github.com/Inria-Asclepios/music/issues/1056

The problem was that there was no way to reset a Cropping box after the disappearance of the box, if the user moves it outside of the view for instance. 

This PR adds a reset of the box if you switch to an other toolbox, change data, apply data (the new data is applied in the view). In pipeline it's possible to Reset the toolbox directly with the pipeline button.

Concerning the orientation problem on mac, i had it once and couldn't redo it, so i couldn't really work on that qt or vtk problem, but resetting the toolbox solves the problem.

:m: