### PR TITLE
[VoiCutter] solve keys, min and max intensity, and add waiting toolbox

### DIFF
--- a/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
+++ b/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
@@ -77,22 +77,21 @@ public:
 
         vtkRenderWindowInteractor *iren = static_cast<medVtkViewBackend*>
                 (tb->d->currentView->backend())->renWin->GetInteractor();
-        char keycode = iren->GetKeyCode();
 
         // enter => keep only VOI defined
         // tab => restore VOI defined
         // backspace => delete VOI defined
-        switch(keycode)
+        if (iren->GetKeySym() == vtkStdString("Delete"))
         {
-            case '\b': // backspace
-                tb->launchTheCutting(Remove);
-                break;
-            case '\r': // return
-                tb->launchTheCutting(Keep);
-                break;
-            case '\t': // tab
-                tb->launchTheCutting(Restore);
-                break;
+            tb->launchTheCutting(Remove);
+        }
+        else if (iren->GetKeySym() == vtkStdString("Return"))
+        {
+            tb->launchTheCutting(Keep);
+        }
+        else if (iren->GetKeySym() == vtkStdString("Tab"))
+        {
+            tb->launchTheCutting(Restore);
         }
     }
 
@@ -404,11 +403,15 @@ void voiCutterToolBox::launchTheCutting(MODE m)
 {
     if (d->currentView && d->scissorOn)
     {
+        this->setToolBoxOnWaitStatusForNonRunnableProcess();
+
         vtkImageView3D *view3D =  static_cast<medVtkViewBackend*>(d->currentView->backend())->view3D;
         std::vector<vtkVector2i> polygonPoints = static_cast<vtkInriaInteractorStyleDrawPolygon*>(view3D->GetInteractor()->GetInteractorStyle())->GetPolygonPoints();
         definePolygonsImage(polygonPoints, m);
         d->interactorStyleDrawPolygon->ResetPolygon();
         view3D->GetInteractor()->SetInteractorStyle(d->interactorStyleDrawPolygon);
+
+        this->setToolBoxOnReadyToUse();
     }
 }
 

--- a/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
+++ b/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
@@ -21,6 +21,7 @@
 #include <medBoolGroupParameterL.h>
 #include <medCompositeParameterL.h>
 #include <medDataManager.h>
+#include <medDoubleParameterL.h>
 #include <medPluginManager.h>
 #include <medStringListParameterL.h>
 #include <medTabbedViewContainers.h>
@@ -55,8 +56,9 @@ public:
     medAbstractBoolParameterL *orientation3DParam;
     
     // Rendering parameters
-    QHash<QString, QVariant> windowingParams;
     QString lut;
+    double minIntensity;
+    double maxIntensity;
 };
 
 class vtkCutterObserver : public vtkCommand
@@ -77,20 +79,21 @@ public:
 
         vtkRenderWindowInteractor *iren = static_cast<medVtkViewBackend*>
                 (tb->d->currentView->backend())->renWin->GetInteractor();
-
-        // enter => keep only VOI defined
-        // tab => restore VOI defined
-        // backspace => delete VOI defined
-        if (iren->GetKeySym() == vtkStdString("Delete"))
+        auto key = iren->GetKeySym();
+        
+        if ((key == vtkStdString("Delete")) || (key == vtkStdString("BackSpace")))
         {
+            // Delete VOI defined
             tb->launchTheCutting(Remove);
         }
-        else if (iren->GetKeySym() == vtkStdString("Return"))
+        else if (key == vtkStdString("Return"))
         {
+            // Keep only VOI defined
             tb->launchTheCutting(Keep);
         }
-        else if (iren->GetKeySym() == vtkStdString("Tab"))
+        else if (key == vtkStdString("Tab"))
         {
+            // Restore VOI defined
             tb->launchTheCutting(Restore);
         }
     }
@@ -154,6 +157,9 @@ voiCutterToolBox::voiCutterToolBox(QWidget *parent) :
     d->orientation3DParam = 0;
 
     activateButtons(false);
+
+    d->minIntensity = std::numeric_limits<double>::min();
+    d->maxIntensity = std::numeric_limits<double>::max();
 }
 
 voiCutterToolBox::~voiCutterToolBox()
@@ -431,17 +437,16 @@ void voiCutterToolBox::saveRenderingParameters()
                 {
                     d->lut = qobject_cast<medStringListParameterL*>(parameters[j])->value();
                 }
+                else if (parameters[j]->name() == "Min Intensity")
+                {
+                    d->minIntensity = qobject_cast<medDoubleParameterL*>(parameters[j])->value();
+                }
+                else if (parameters[j]->name() == "Max Intensity")
+                {
+                    d->maxIntensity = qobject_cast<medDoubleParameterL*>(parameters[j])->value();
+                }
             }
         }
-    }
-
-    // Synchronize Window/Level
-    medCompositeParameterL *windowLevelParameter1 = d->currentView->windowLevelParameter(0);
-    QList<QVariant> windowLevel = windowLevelParameter1->values();
-    if (windowLevel.size() == 2)
-    {
-        d->windowingParams.insert("Level",  windowLevel[0]);
-        d->windowingParams.insert("Window", windowLevel[1]);
     }
 }
 
@@ -460,12 +465,17 @@ void voiCutterToolBox::applyRenderingParameters()
                 {
                     qobject_cast<medStringListParameterL*>(parameters[j])->setValue(d->lut);
                 }
+                else if (parameters[j]->name() == "Min Intensity")
+                {
+                    qobject_cast<medDoubleParameterL*>(parameters[j])->setValue(d->minIntensity);
+                }
+                else if (parameters[j]->name() == "Max Intensity")
+                {
+                    qobject_cast<medDoubleParameterL*>(parameters[j])->setValue(d->maxIntensity);
+                }
             }
         }
     }
-
-    medCompositeParameterL *windowLevelParameter = d->currentView->windowLevelParameter(0);
-    windowLevelParameter->setValues(d->windowingParams);
 }
 
 // intersect3D_SegmentPlane(): intersect a segment and a plane


### PR DESCRIPTION
Fix https://github.com/Inria-Asclepios/music/issues/1063

This PR:
 * Solve key problem on macOS.
 * Min and max intensities are kept after output is displayed on view (@fcollot in pipeline it could be useful too, setting Window/Level directly seems to bug, but setting Min and Max intensity instead is ok).
 * Add a waiting toolbox when computation is done.

By the way, there is a Tab command in Voi Cutter, but it's not clear how it's working.

:m: