### PR TITLE
(Python on Windows) add site directory and fix plugin packaging

### DIFF
--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -135,6 +135,7 @@ file(INSTALL ${MEDINRIA_FILES}/
     FILES_MATCHING
     PATTERN \"*${CMAKE_EXECUTABLE_SUFFIX}\"
     PATTERN \"*${CMAKE_SHARED_LIBRARY_SUFFIX}\"
+    PATTERN \"*.pyd\"
     )
 
 foreach(file \${files})

--- a/src/app/medInria/main.cpp
+++ b/src/app/medInria/main.cpp
@@ -200,10 +200,22 @@ int main(int argc,char* argv[])
                 try
                 {
                     pyncpp::Module sysModule = pyncpp::Module::import("sys");
-                    sysModule.attribute("path").append(pyncpp::Object(pythonPluginPath.absolutePath()));
+                    pyncpp::Object sysPath = sysModule.attribute("path");
+                    sysPath.append(pyncpp::Object(pythonPluginPath.absolutePath()));
                     qInfo() << "Added Python plugin path: " << pythonPluginPath.path();
 
 #ifdef Q_OS_WIN
+                    QDir sitePackages = pythonHome;
+
+                    if (sitePackages.cd("lib/site-packages"))
+                    {
+                        sysPath.append(pyncpp::Object(sitePackages.absolutePath()));
+                    }
+                    else
+                    {
+                        pythonErrorMessage = "Cannot find site directory.";
+                    }
+
                     pyncpp::Module osModule = pyncpp::Module::import("os");
                     osModule.callMethod("add_dll_directory", applicationPath.absolutePath());
                     qInfo() << "Added Python DLL path: " << applicationPath.path();
@@ -280,8 +292,8 @@ int main(int argc,char* argv[])
 #ifdef USE_PYTHON
     if(!pythonErrorMessage.isEmpty())
     {
-        QMessageBox::warning(mainwindow, "Python error", pythonErrorMessage);
         qWarning() << "(Python error) " << pythonErrorMessage;
+        QMessageBox::warning(mainwindow, "Python error", pythonErrorMessage);
     }
 #endif
 


### PR DESCRIPTION
(based on https://github.com/Inria-Asclepios/medInria-public/pull/833)
Since Python extensions on Windows are pyd files (instead of dll), we need to include those file names when installing.
Also for some reason the Python site directory is not being added to `sys.path` on startup so we have to do it manually.