### PR TITLE
[PolygonROI] fix drawing pb if data is not yet in the database

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,6 @@
+MUSICardio 4.0.2:
+- Fix drawing problem in pipelines with custom step of PolygonROI.
+
 MUSICardio 4.0.1:
 - Fix Python module installation bug on macOS.
 - Fix Real Time compilation on Ubuntu/Fedora/macOS and Windows.

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.h
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.h
@@ -81,10 +81,10 @@ private slots:
     void clear() override;
 
 private:
-    QHash<medDataIndex, baseViewEvent *> viewEventHash;
+    QHash<const medAbstractData*, baseViewEvent *> viewEventHash;
+    medAbstractData* activeData;
     qint32 specialityPreference;
     medToolBox *pMedToolBox;
-    medDataIndex activeDataIndex;
     QPushButton *activateTBButton;
     QPushButton *saveBinaryMaskButton;
     QCheckBox *interpolate;


### PR DESCRIPTION
Fix https://github.com/Inria-Asclepios/music/issues/1074

If a data (created in a custom step of polygon roi) has not been saved in the database (temporary or not), the dataIndex is wrong. This PR fixes that problem using the data directly instead. This allows to not change the way `baseViewEvent` are handled.

:m: 