### PR TITLE
[n4biasCorrection] remove std::endl warnings

### DIFF
--- a/src/plugins/legacy/medN4BiasCorrection/medN4BiasCorrection.cpp
+++ b/src/plugins/legacy/medN4BiasCorrection/medN4BiasCorrection.cpp
@@ -205,7 +205,7 @@ int medN4BiasCorrection::update(medAbstractData *inputData)
     }
     else
     {
-        qDebug() << "N4 Bias Correction: mask not read, creating Otsu mask." << endl;
+        qDebug() << "N4 Bias Correction: mask not read, creating Otsu mask.";
         typedef itk::OtsuThresholdImageFilter<OutputImageType, MaskImageType>
             ThresholderType;
         ThresholderType::Pointer otsu = ThresholderType::New();
@@ -398,7 +398,7 @@ int medN4BiasCorrection::update(medAbstractData *inputData)
     }
     catch( ... )
     {
-        qDebug() << "Unknown exception caught." << endl;
+        qDebug() << "Unknown exception caught.";
         return medAbstractProcessLegacy::FAILURE;
     }
     


### PR DESCRIPTION
COMMIT https://github.com/Inria-Asclepios/medInria-public/commit/4bbbf71d0483da39c90bfdd5bdc9976782776a3d

Based on https://github.com/Inria-Asclepios/medInria-public/pull/847

This PR removes endl at end of qDebug to avoid compilation warning.

:m: