### PR TITLE
Retrieve FilePath metadata, facilitate direct call to data import

### DIFF
--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.cpp
@@ -514,6 +514,7 @@ void medAbstractDatabaseImporter::importData()
 
     // Now, populate the database
     medDataIndex index = this->populateDatabaseAndGenerateThumbnails (  d->data, thumb_dir );
+    d->index = index;
 
     if (d->data->hasMetaData(medMetaDataKeys::Toolbox.key()) &&
     d->data->metadata(medMetaDataKeys::Toolbox.key())=="PolygonROI" &&

--- a/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
+++ b/src/layers/legacy/medCoreLegacy/database/medAbstractDatabaseImporter.h
@@ -48,6 +48,8 @@ public:
                                 const QUuid &uuid);
     ~medAbstractDatabaseImporter() override;
 
+    medDataIndex index(void) const;
+
 signals:
     /**
      * This signal is emitted after a successful import/index.
@@ -74,7 +76,6 @@ protected:
     bool indexWithoutImporting ( void );
     QMap<int, QString> volumeIdToImageFile ( void );
     QString callerUuid ( void );
-    medDataIndex index(void) const;
 
     void populateMissingMetadata ( medAbstractData* medData, const QString seriesDescription );
     void addAdditionalMetaData ( medAbstractData* imData, QString aggregatedFileName, QStringList aggregatedFilesPaths );

--- a/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabasePersistentController.cpp
@@ -80,6 +80,8 @@ void medDatabasePersistentControllerPrivate::buildMetaDataLookup()
     metaDataLookup.insert(medMetaDataKeys::StudyDate.key(),
                           TableEntryList() << TableEntry(T_study, "date"));
     // Series Data
+    metaDataLookup.insert(medMetaDataKeys::FilePaths.key(),
+                          TableEntryList() << TableEntry(T_series, "path"));
     metaDataLookup.insert(medMetaDataKeys::Size.key(),
                           TableEntryList() << TableEntry(T_series, "size"));
     metaDataLookup.insert(medMetaDataKeys::SeriesDescription.key(),

--- a/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
+++ b/src/layers/legacy/medCoreLegacy/database/medDatabaseReader.cpp
@@ -203,6 +203,7 @@ medAbstractData* medDatabaseReader::run()
     QFileInfo fullThumbnailPathInfo(fullThumbnailPath);
     medMetaDataKeys::SeriesThumbnail.add (medData, fullThumbnailPath);
 
+    medMetaDataKeys::FilePaths.set ( medData, seriesPath );
     medMetaDataKeys::PatientID.set ( medData, patientId );
     medMetaDataKeys::PatientName.set ( medData, patientName );
     medMetaDataKeys::BirthDate.set ( medData, birthdate );


### PR DESCRIPTION
Some changes are necessary in order to fix asynchronous import-related issues in the pipelines:
- Allow the direct retrieval of the data index of the newly imported data (instead of having to use signals/slots) so that the import functionality can be called manually and synchronously from the pipelines.
- Store the path of the file in the metadata, so that the file can be modified directly.