### PR TITLE
[Paint] avoid non-needed code which can crash in processOutput method

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@
 cmake_minimum_required(VERSION 3.19)
 
 if(NOT DEFINED ${medInria_VERSION})
-    set(medInria_VERSION 4.0.6)
+    set(medInria_VERSION 4.0.7)
 endif()
 
 project(medInria VERSION ${medInria_VERSION})

--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -519,8 +519,6 @@ medAbstractData* AlgorithmPaintToolBox::processOutput()
     // Check if painted data on the volume
     if (!m_undoStacks->empty() && !m_undoStacks->value(currentView)->isEmpty())
     {
-        updateMaskWithMasterLabel();
-        copyMetaData(m_maskData, m_imageData);
         return m_maskData; // return output data
     }
     else
@@ -928,6 +926,7 @@ void AlgorithmPaintToolBox::setData( medAbstractData *medData )
         else
         {
             m_maskData = medAbstractDataFactory::instance()->createSmartPointer( "itkDataImageUChar3" );
+            medUtilities::setDerivedMetaData(m_maskData, m_imageData, "");
 
             if ( !m_maskData )
             {


### PR DESCRIPTION
I'm investigating few crashs which happen randomly at some step endings.
The processOutput method of Paint runs non needed lines which could lead to crash. It's also quicker to not do unneeded lines.

:m: