### PR TITLE
[Unix] 4.1 compilation for tetgen and mmg

### DIFF
--- a/superbuild/external_projects_tools/EP_Initialisation.cmake
+++ b/superbuild/external_projects_tools/EP_Initialisation.cmake
@@ -25,7 +25,7 @@ if (NOT ep_Initialisation_USE_SYSTEM)
 endif()
 
 if (NOT ep_Initialisation_BUILD_SHARED_LIBS)
-    set(ep_Initialisation_BUILD_SHARED_LIBS ON)
+    set(ep_Initialisation_BUILD_SHARED_LIBS OFF)
 endif()
 
 if (NOT ep_Initialisation_REQUIRED_FOR_PLUGINS)
@@ -58,7 +58,7 @@ if (USE_SYSTEM_${ep})
             #  provide path of project needeed for Asclepios and visages plugins
             file(APPEND ${${PROJECT_NAME}_CONFIG_FILE}
                 "find_package(${ep_Initialisation_PACKAGE_NAME} REQUIRED
-                    PATHS \"${${ep_Initialisation_PACKAGE_NAME}_DIR}\"
+                    PATHS \"${${ep_Initialisation_PACKAGE_NAME}_ROOT}\"
                     )\n"
                 )
         endif()
@@ -97,7 +97,6 @@ else()
       endif()
   endif()
 
-
 ## #############################################################################
 ## Add Variable : do we want a static or a dynamic build ?
 ## #############################################################################
@@ -108,7 +107,10 @@ else()
     )
   mark_as_advanced(BUILD_SHARED_LIBS_${ep})
   
-  
+  if (NOT ep_Initialisation_BUILD_SHARED_LIBS)
+    set(BUILD_SHARED_LIBS_${ep} OFF CACHE BOOL "Build shared libs for ${ep}" FORCE)
+  endif()
+
 ## #############################################################################
 ## Set compilation flags
 ## #############################################################################
@@ -117,15 +119,13 @@ else()
   set(${ep}_cxx_flags ${ep_common_cxx_flags})
   set(${ep}_shared_linker_flags ${ep_common_shared_linker_flags})
   
-  # Add PIC flag if Static build on UNIX with amd64 arch
+  # Add PIC flag if Static build on UNIX
   if (UNIX)
-    if (NOT BUILD_SHARED_LIBS_${ep} AND 
-        "${CMAKE_SYSTEM_PROCESSOR}" MATCHES 64)
-        
+    if (NOT BUILD_SHARED_LIBS_${ep})
       set(${ep}_c_flags "${${ep}_c_flags} -fPIC")
       set(${ep}_cxx_flags "${${ep}_cxx_flags} -fPIC")
     endif()
-  endif()  
+  endif()
 
   if (APPLE)
     if (BUILD_SHARED_LIBS_${ep})

--- a/superbuild/projects_modules/tetgen.cmake
+++ b/superbuild/projects_modules/tetgen.cmake
@@ -17,7 +17,7 @@ list(APPEND ${ep}_dependencies
 EP_Initialisation(${ep}
   USE_SYSTEM OFF 
   BUILD_SHARED_LIBS OFF
-  REQUIRED_FOR_PLUGINS OFF
+  REQUIRED_FOR_PLUGINS ON
   NO_CMAKE_PACKAGE
   )
 


### PR DESCRIPTION
Fix https://github.com/Inria-Asclepios/medInria-public/issues/856

Conf https://github.com/Inria-Asclepios/medInria-public/pull/845

Solve "relocation R_X86_64_PC32 against symbol XXX can not be used when making a shared object; recompilé avec -fPIC" in tetgen and mmg libraries.

`ep_Initialisation_BUILD_SHARED_LIBS` was not well created and always at `ON` even if mmg and tetgen are set to compile with `BUILD_SHARED_LIBS` at `OFF`. And also `-fPIC` was not set for x86_64, only for amd64.

In addition, in `EP_Initialisation.cmake` there could be also a problem with `REQUIRED_FOR_PLUGINS` with `_DIR`.

:m: