### PR TITLE
[Cropping] box color was not well displayed

### DIFF
--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -110,7 +110,6 @@ medCropToolBox::medCropToolBox(QWidget* parent)
     : medAbstractSelectableToolBox(parent), applyButtonName("Apply"), saveButtonName("Save"), d(new medCropToolBoxPrivate())
 {
     d->borderWidget = vtkSmartPointer<vtkBorderWidget>::New();
-    d->borderWidget->CreateDefaultRepresentation();
     d->borderWidget->SelectableOff();
 
     vtkNew<vtkNamedColors> colors;

--- a/src/plugins/legacy/reformat/medCropToolBox.cpp
+++ b/src/plugins/legacy/reformat/medCropToolBox.cpp
@@ -37,6 +37,7 @@
 #include <vtkPlane.h>
 #include <vtkPolyData.h>
 #include <vtkProperty2D.h>
+#include <vtkNamedColors.h>
 #include <vtkRenderer.h>
 
 class medCropCallback;
@@ -111,7 +112,12 @@ medCropToolBox::medCropToolBox(QWidget* parent)
     d->borderWidget = vtkSmartPointer<vtkBorderWidget>::New();
     d->borderWidget->CreateDefaultRepresentation();
     d->borderWidget->SelectableOff();
-    static_cast<vtkBorderRepresentation*>(d->borderWidget->GetRepresentation())->GetBorderProperty()->SetColor(0,1,0);
+
+    vtkNew<vtkNamedColors> colors;
+    vtkNew<vtkBorderRepresentation> rep;
+    rep->BuildRepresentation();
+    rep->SetBorderColor(colors->GetColor3d("Chartreuse").GetData());
+    d->borderWidget->SetRepresentation(rep);
 
     QWidget *cropToolBoxBody = new QWidget(this);
     QVBoxLayout *cropToolBoxLayout = new QVBoxLayout(cropToolBoxBody);


### PR DESCRIPTION
On 4.1 branch we lost the color on Cropping, due to the VTK version used. This PR adds back the green color.

By the way, at least on Ubuntu, the cursors are well displayed at the corner of the box. We lost that features a long time ago.

:m: