### PR TITLE
[Annotation] fix A/R/P/L orientation annotations in views

### DIFF
--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageViewCornerAnnotation.cxx
@@ -448,7 +448,7 @@ int vtkImageViewCornerAnnotation::RenderOpaqueGeometry(vtkViewport *viewport)
             tprop_has_changed ||
             this->GetMTime() > this->BuildTime)
         {
-            // Rebuid text props.
+            // Rebuild text props.
             // Perform shallow copy here since each individual corner has a
             // different aligment/size but they share the other this->TextProperty
             // attributes.
@@ -588,9 +588,7 @@ int vtkImageViewCornerAnnotation::RenderOpaqueGeometry(vtkViewport *viewport)
             }
 
             // Now set the position of the TextActors
-
             this->SetTextActorsPosition(vSize);
-
             for (i = 0; i < 4; i++)
             {
                 this->TextActor[i]->SetProperty(this->GetProperty());

--- a/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkOrientationAnnotation.cxx
+++ b/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkOrientationAnnotation.cxx
@@ -32,7 +32,7 @@ vtkOrientationAnnotation::~vtkOrientationAnnotation()
 
 
 //----------------------------------------------------------------------------
-void vtkOrientationAnnotation::SetTextActorsPosition(int vsize[2])
+void vtkOrientationAnnotation::SetTextActorsPosition(const int vsize[2])
 {
   this->TextActor[2]->SetPosition(5, vsize[1]/2);
   this->TextActor[3]->SetPosition(vsize[0]/2, 5);

--- a/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkOrientationAnnotation.h
+++ b/src/layers/legacy/medVtkInria/vtkWidgetsAddOn/vtkOrientationAnnotation.h
@@ -32,7 +32,7 @@ protected:
 
   // Description:
   // Set text actor positions given a viewport size and justification
-  virtual void SetTextActorsPosition(int vsize[2]);
+  virtual void SetTextActorsPosition(const int vsize[2]);
   virtual void SetTextActorsJustification();
 
 private:


### PR DESCRIPTION
Same problem solved on medInria 5 https://github.com/medInria/medInria-public/pull/1253

> The orientation annotation in center of view borders are not well displayed.
> 
> Since newer version of VTK, vtkCornerAnnotation::SetTextActorsPosition method takes a const value, and if we don't change also in medInria, our virtual vtkOrientationAnnotation::SetTextActorsPosition method is not called.


:m: