### PR TITLE
[ProcessOutput] update mask label to binarize

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -519,6 +519,7 @@ medAbstractData* AlgorithmPaintToolBox::processOutput()
     // Check if painted data on the volume
     if (!m_undoStacks->empty() && !m_undoStacks->value(currentView)->isEmpty())
     {
+        updateMaskWithMasterLabel();
         return m_maskData; // return output data
     }
     else


### PR DESCRIPTION
In pipelines, Paint steps mask output were not well binarized due to a previous change.
This PR puts back the methods to binarize the output data.

:m: