### PR TITLE
[CreateMeshFromMask] clean memory management, avoid crash after process macOS14

### DIFF
--- a/src/layers/legacy/medCoreLegacy/process/medRunnableProcess.cpp
+++ b/src/layers/legacy/medCoreLegacy/process/medRunnableProcess.cpp
@@ -21,7 +21,7 @@
 class medRunnableProcessPrivate
 {
 public:
-    dtkAbstractProcess *process; // process is deleted by the toolbox calling medRunnableProcess
+    dtkSmartPointer<dtkAbstractProcess> process;
 };
 
 

--- a/src/layers/legacy/medCoreLegacy/process/medRunnableProcess.cpp
+++ b/src/layers/legacy/medCoreLegacy/process/medRunnableProcess.cpp
@@ -21,7 +21,7 @@
 class medRunnableProcessPrivate
 {
 public:
-    dtkSmartPointer<dtkAbstractProcess> process;
+    dtkAbstractProcess *process; // process is deleted by the toolbox calling medRunnableProcess
 };
 
 

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.cpp
@@ -86,26 +86,24 @@ template <class PixelType> int medCreateMeshFromMaskPrivate::update()
 
     //------------------------------------------------------
 
-    vtkImageData *vtkImage = filter->GetOutput();
+    vtkSmartPointer<vtkContourFilter> contourFilter = vtkSmartPointer<vtkContourFilter>::New();
+    contourFilter->SetInputData(filter->GetOutput());
+    contourFilter->SetValue(0, isoValue);
+    contourFilter->Update();
 
-    vtkContourFilter *contour = vtkContourFilter::New();
-    contour->SetInputData(vtkImage);
-    contour->SetValue(0, isoValue);
-    contour->Update();
-
-    vtkTriangleFilter *contourTrian = vtkTriangleFilter::New();
-    contourTrian->SetInputConnection(contour->GetOutputPort());
+    vtkSmartPointer<vtkTriangleFilter> contourTrian = vtkSmartPointer<vtkTriangleFilter>::New();
+    contourTrian->SetInputConnection(contourFilter->GetOutputPort());
     contourTrian->PassVertsOn();
     contourTrian->PassLinesOn();
     contourTrian->Update();
 
-    vtkPolyDataAlgorithm *lastAlgo = contourTrian;
+    vtkSmartPointer<vtkPolyDataAlgorithm> lastAlgo = contourTrian;
 
-    vtkDecimatePro *contourDecimated = nullptr;
+    vtkSmartPointer<vtkDecimatePro> contourDecimated = nullptr;
     if (decimate)
     {
         // Decimate the mesh if required
-        contourDecimated = vtkDecimatePro::New();
+        contourDecimated = vtkSmartPointer<vtkDecimatePro>::New();
         contourDecimated->SetInputConnection(lastAlgo->GetOutputPort());
         contourDecimated->SetTargetReduction(targetReduction);
         contourDecimated->SplittingOff();
@@ -114,11 +112,11 @@ template <class PixelType> int medCreateMeshFromMaskPrivate::update()
         lastAlgo = contourDecimated;
     }
 
-    vtkSmoothPolyDataFilter *contourSmoothed = nullptr;
+    vtkSmartPointer<vtkSmoothPolyDataFilter> contourSmoothed = nullptr;
     if(smooth)
     {
         // Smooth the mesh if required
-        contourSmoothed = vtkSmoothPolyDataFilter::New();
+        contourSmoothed = vtkSmartPointer<vtkSmoothPolyDataFilter>::New();
         contourSmoothed->SetInputConnection(lastAlgo->GetOutputPort());
         contourSmoothed->SetNumberOfIterations(iterations);
         contourSmoothed->SetRelaxationFactor(relaxationFactor);
@@ -126,7 +124,7 @@ template <class PixelType> int medCreateMeshFromMaskPrivate::update()
         lastAlgo = contourSmoothed;
     }
 
-    vtkPolyData *polydata = lastAlgo->GetOutput();
+    vtkSmartPointer<vtkPolyData> polydata = lastAlgo->GetOutput();
     nbTriangles = polydata->GetNumberOfPolys();
 
     if (nbTriangles > 0)
@@ -142,19 +140,8 @@ template <class PixelType> int medCreateMeshFromMaskPrivate::update()
 
         polydata->DeepCopy(transformFilter->GetOutput());
 
-        vtkMetaSurfaceMesh *smesh = vtkMetaSurfaceMesh::New();
+        vtkSmartPointer<vtkMetaSurfaceMesh> smesh = vtkSmartPointer<vtkMetaSurfaceMesh>::New();
         smesh->SetDataSet(polydata);
-
-        contour->Delete();
-        contourTrian->Delete();
-        if (contourDecimated)
-        {
-            contourDecimated->Delete();
-        }
-        if (contourSmoothed)
-        {
-            contourSmoothed->Delete();
-        }
 
         output = medAbstractDataFactory::instance()->createSmartPointer("vtkDataMesh");
         medUtilities::setDerivedMetaData(output, input, "mesh from mask");

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
@@ -23,8 +23,7 @@
 class medCreateMeshFromMaskToolBoxPrivate
 {
 public:
-
-    medCreateMeshFromMask *process;
+    QPointer<medCreateMeshFromMask> process;
     medAbstractLayeredView *view;
     medDoubleParameterL *thresholdSlider;
     QDoubleSpinBox *reductionSpinBox;
@@ -123,12 +122,17 @@ medCreateMeshFromMaskToolBox::medCreateMeshFromMaskToolBox(QWidget *parent)
     this->addWidget(widget);
 
     d->view = nullptr;
+    d->process = nullptr;
 
     connect(runButton, SIGNAL(clicked()), this, SLOT(run()));
 }
 
 medCreateMeshFromMaskToolBox::~medCreateMeshFromMaskToolBox()
 {
+    if (d->process)
+    {
+        delete d->process;
+    }
     delete d;
     d = nullptr;
 }
@@ -196,10 +200,16 @@ void medCreateMeshFromMaskToolBox::updateView()
 void medCreateMeshFromMaskToolBox::addMeshToView()
 {
     medAbstractData *data = this->processOutput();
-
-    int current = d->view->currentLayer();
-    d->view->addLayer(data);
-    d->view->setCurrentLayer(current);
+    if (data)
+    {
+        int current = d->view->currentLayer();
+        d->view->addLayer(data);
+        d->view->setCurrentLayer(current);
+    }
+    else
+    {
+        qDebug()<<"medCreateMeshFromMaskToolBox::addMeshToView error no output data.";
+    }
 }
 
 void medCreateMeshFromMaskToolBox::clear()
@@ -216,7 +226,10 @@ void medCreateMeshFromMaskToolBox::run()
         {
             this->setToolBoxOnWaitStatus();
 
-            d->process = new medCreateMeshFromMask();
+            if (!d->process)
+            {
+                d->process = new medCreateMeshFromMask();
+            }
             d->process->setInput(d->view->layerData(d->view->currentLayer()));
 
             d->process->setParameter(static_cast<double>(d->thresholdSlider->value()),      0); // iso value

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
@@ -122,7 +122,6 @@ medCreateMeshFromMaskToolBox::medCreateMeshFromMaskToolBox(QWidget *parent)
     this->addWidget(widget);
 
     d->view = nullptr;
-    d->process = nullptr;
 
     connect(runButton, SIGNAL(clicked()), this, SLOT(run()));
 }

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMaskToolBox.cpp
@@ -23,7 +23,7 @@
 class medCreateMeshFromMaskToolBoxPrivate
 {
 public:
-    QPointer<medCreateMeshFromMask> process;
+    dtkSmartPointer <medCreateMeshFromMask> process;
     medAbstractLayeredView *view;
     medDoubleParameterL *thresholdSlider;
     QDoubleSpinBox *reductionSpinBox;
@@ -129,10 +129,6 @@ medCreateMeshFromMaskToolBox::medCreateMeshFromMaskToolBox(QWidget *parent)
 
 medCreateMeshFromMaskToolBox::~medCreateMeshFromMaskToolBox()
 {
-    if (d->process)
-    {
-        delete d->process;
-    }
     delete d;
     d = nullptr;
 }


### PR DESCRIPTION
This PR aims to solves problems leading to the crash of CreateMeshFromMask on some macOS https://github.com/Inria-Asclepios/medInria-public/issues/886

At the end of the process call in `medCreateMeshFromMaskToolBox::run()` the process was automatically destroyed whereas it's still used in the toolbox in a method called in case of process success. Depending of the timing on some machines/modes/OS we could have a crash. The PR cleans also the way the process is stored, and variables inside the process handled.

This PR is needed, and we'll test the binaries on different machines.

:m:

