### PR TITLE
[Settings Parameters] Background Color and others in medCombobox

### DIFF
--- a/src/layers/legacy/medCoreLegacy/parameters/medStringListParameterL.cpp
+++ b/src/layers/legacy/medCoreLegacy/parameters/medStringListParameterL.cpp
@@ -15,14 +15,12 @@
 
 #include <medStringListParameterL.h>
 
-#include <QComboBox>
 #include <dtkLog>
-
 
 class medStringListParameterLPrivate
 {
 public:
-    QComboBox* comboBox;
+    medComboBox* comboBox;
     QStringList items;
     QHash <QString, QIcon> iconForItem;
 
@@ -87,11 +85,11 @@ QStringList medStringListParameterL::items() const
 }
 
 
-QComboBox* medStringListParameterL::getComboBox()
+medComboBox* medStringListParameterL::getComboBox()
 {
     if(!d->comboBox)
     {
-        d->comboBox = new QComboBox;
+        d->comboBox = new medComboBox;
         for(QString item : d->items)
         {
             d->comboBox->addItem(d->iconForItem.value(item), item);

--- a/src/layers/legacy/medCoreLegacy/parameters/medStringListParameterL.h
+++ b/src/layers/legacy/medCoreLegacy/parameters/medStringListParameterL.h
@@ -17,9 +17,9 @@
 #include <QIcon>
 
 #include <medAbstractParameterL.h>
+#include <medComboBox.h>
 #include <medCoreLegacyExport.h>
 
-class QComboBox;
 class QWidget;
 class QStringList;
 
@@ -40,7 +40,7 @@ public:
     void clear();
 
     QStringList items() const;
-    QComboBox* getComboBox();
+    medComboBox* getComboBox();
 
     virtual QWidget* getWidget();
 


### PR DESCRIPTION
The use of Wheel mouse on some QCombobox can be annoying for users because scrolling inside the right column changes sometimes some comboboxes. medCombobox forbid the value change through wheel mouse.

:m:
