### PR TITLE
[PolygonROI] hand cursor to handle landmarks

### DIFF
--- a/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
+++ b/src/plugins/legacy/polygonRoi/viewevent/baseViewEvent.cpp
@@ -188,7 +188,7 @@ bool baseViewEvent::mouseMoveEvent(medAbstractView *view, QMouseEvent *mouseEven
     {
         if (currentLabel->getMinimumDistanceFromNodesToMouse(savedMousePosition, false) < 20.)
         {
-            setCustomCursor(view, Qt::red);
+            view->viewWidget()->setCursor(Qt::OpenHandCursor);
         }
         else
         {


### PR DESCRIPTION
In PolygonROI, a custom cursor apparently copied from Paint toolbox was used to handle the landmarks. The circle is not needed here, a Qt hand cursor is really fine and avoid unnecessary computations.

:m: