### PR TITLE
[CI] 24 months for binary duration, and update macos 4.1 github action script

### DIFF
--- a/.github/workflows/musicardio-macos.yml
+++ b/.github/workflows/musicardio-macos.yml
@@ -12,7 +12,7 @@ on:
       EXPIRATION_TIME:
         description: 'Expiration time in month'
         required: true
-        default: '12'
+        default: '24'
         type: string
   schedule:
     - cron: '0 0 * * 1'  # Each monday at 0h00, MIN HOUR DAY_IN_MONTH MONTH WEEK_DAY
@@ -52,7 +52,7 @@ jobs:
         # brew info cmake
 
     - name: Set default EXPIRATION_TIME if not provided (with non manual workflow)
-      run: echo "EXPIRATION_TIME=${{ inputs.EXPIRATION_TIME || '12' }}" >> $GITHUB_ENV
+      run: echo "EXPIRATION_TIME=${{ inputs.EXPIRATION_TIME || '24' }}" >> $GITHUB_ENV
 
     - name: Configure CMake
       run: |
@@ -84,41 +84,8 @@ jobs:
       run: |
         cd ${{github.workspace}}/build
         dmg=$(ls *.dmg)
-        echo "The current package to adapt: $dmg"
-
-        if [ -n "$dmg" ]; then
-          # Attach to read-write format and retrieve mount path
-          path=$(hdiutil attach -owners on $dmg -shadow | grep -i 'Volumes' | cut -f 3)
-          echo "The current path: $path"
-
-          # Navigate to correct directory
-          cd "$path/MUSICardio.app/Contents/"
-
-          pathPluginsLegacy="${{github.workspace}}/build/medInria-build/bin/plugins_legacy"
-
-          # Change library paths for plugins
-          for f in PlugIns/*.dylib; do
-            install_name_tool -change $pathPluginsLegacy/libAAMeshInteractorPlugin.dylib  @executable_path/../PlugIns/libAAMeshInteractorPlugin.dylib $f
-            install_name_tool -change $pathPluginsLegacy/libAAAMeshUtilityPlugin.dylib    @executable_path/../PlugIns/libAAAMeshUtilityPlugin.dylib $f
-            install_name_tool -change $pathPluginsLegacy/libAAAmedPipelinePlugin.dylib    @executable_path/../PlugIns/libAAAmedPipelinePlugin.dylib $f
-            install_name_tool -change $pathPluginsLegacy/libmscPipelinesPlugin.dylib      @executable_path/../PlugIns/libmscPipelinesPlugin.dylib $f
-            install_name_tool -change $pathPluginsLegacy/libAAAEPMapPlugin.dylib          @executable_path/../PlugIns/libAAAEPMapPlugin.dylib $f
-            install_name_tool -change $pathPluginsLegacy/libAAMFSSimulationPlugin.dylib   @executable_path/../PlugIns/libAAMFSSimulationPlugin.dylib $f
-            install_name_tool -change $pathPluginsLegacy/libFEMForwardProblemPlugin.dylib @executable_path/../PlugIns/libFEMForwardProblemPlugin.dylib $f
-          done
-
-          # Go back to original path
-          cd "${{github.workspace}}/build"
-
-          # Update dmg design
-          echo "### Now we are going to update the dmg design"
-          volumeName=$(basename "$path")
-          dmgbuild -s ../packaging/apple/settings.json "$volumeName" MUSICardio.dmg
-
-          echo "End of the processes"
-        else
-          echo "A problem happened in MSC compilation, no dmg is built"
-        fi
+        echo "DMG_NAME=${{dmg | first}}" >> $GITHUB_ENV
+        echo "The current package: $DMG_NAME"
       
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@v2
@@ -127,8 +94,8 @@ jobs:
         # A personal access token for the GitHub repository in which the release will be created and edited.
         # It is recommended to create the access token with the following scopes: `repo, user, admin:repo_hook`.
         repo_token: ${{ secrets.MSC_TOKEN }}
-        file: ${{github.workspace}}/build/MUSICardio.dmg
-        asset_name: MUSICardio.dmg
+        file: ${{github.workspace}}/build/$DMG_NAME
+        asset_name: $DMG_NAME
         tag: latest
         overwrite: true
         body: "MUSICardio binaries"

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -85,7 +85,7 @@ if (NOT WIN32)
   endif()
 endif()
 
-set(EXPIRATION_TIME "12" CACHE STRING "After X months the copy will expire")
+set(EXPIRATION_TIME "24" CACHE STRING "After X months the copy will expire")
 
 if (USE_Python)
     list(APPEND external_projects


### PR DESCRIPTION
Update the default expiration duration from 12 to 24 months.

Update the macos Github Action script, since a previous part is done automatically during the compilation of MUSICardio.

:m: