### PR TITLE
[macOS] switch to macos 15 in github action script and access to dmgbuild

### DIFF
--- a/.github/workflows/musicardio-macos.yml
+++ b/.github/workflows/musicardio-macos.yml
@@ -26,7 +26,7 @@ env:
 jobs:
   build:
     # https://docs.github.com/en/actions/using-jobs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
     - name: Checkout repository

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -149,7 +149,10 @@ DMG_NAME="${BUNDLE}-@MEDINRIA_SUPERBUILD_VERSION@.dmg"
 dmgbuild -s "../../../packaging/apple/settings.json" "${BUNDLE}" "${DMG_NAME}"
 
 # Sign the DMG
-echo "# Sign the DMG"
-codesign --sign "${CERT_NAME}" --timestamp --options runtime "${DMG_NAME}"
+CERT_NAME="MDS-certificate"
+if check_certificate "$CERT_NAME"; then
+    echo "# Sign the DMG"
+    codesign --sign "${CERT_NAME}" --timestamp --options runtime "${DMG_NAME}"
+fi
 
 mv "${DMG_NAME}" @CMAKE_BINARY_DIR@/

--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -146,10 +146,7 @@ fi
 # Create the DMG
 echo "# Create the DMG"
 DMG_NAME="${BUNDLE}-@MEDINRIA_SUPERBUILD_VERSION@.dmg"
-/usr/bin/python3 -m dmgbuild \
-    -s "../../../packaging/apple/settings.json" \
-    "${BUNDLE}" \
-    "${DMG_NAME}"
+dmgbuild -s "../../../packaging/apple/settings.json" "${BUNDLE}" "${DMG_NAME}"
 
 # Sign the DMG
 echo "# Sign the DMG"


### PR DESCRIPTION
The macos 13 runner on Github Action is deprecated, i switch with this PR on macos 15.

On macos 15, we have directly access to dmgbuild through the prerequisite "pipx install dmgbuild
pipx ensurepath" (with pipx path in PATH for Jenkins).

:m: