### PR TITLE
[Qwt] correct Qt lib path during packaging on macos

### DIFF
--- a/packaging/apple/mac_packager.sh.in
+++ b/packaging/apple/mac_packager.sh.in
@@ -21,6 +21,7 @@ BUNDLE="MUSICardio"
 APP_EXE="${BUNDLE}.app/Contents/MacOS/${BUNDLE}"
 PLUGIN_DIR="${BUNDLE}.app/Contents/PlugIns"
 FRAMEWORK_DIR="${BUNDLE}.app/Contents/Frameworks"
+CERT_NAME="MDS-certificate"
 
 cd @PROJECT_BINARY_DIR@
 rm -fr TmpInstall
@@ -43,16 +44,36 @@ cd TmpInstall
 echo "# Copy QWT framework"
 QWT_DIR="${FRAMEWORK_DIR}/qwt.framework"
 mkdir -p "${QWT_DIR}"
-@CMAKE_COMMAND@ -E copy_directory \
-    "@qwt_ROOT@/lib/qwt.framework" \
-    "${QWT_DIR}"
+@CMAKE_COMMAND@ -E copy_directory "@qwt_ROOT@/lib/qwt.framework" "${QWT_DIR}"
+
 # Qwt bundle format is ambiguous we need to clarify it for signature
 rm -fr ${QWT_DIR}/Headers
 rm -fr ${QWT_DIR}/Resources
+rm -fr ${QWT_DIR}/Versions/Current
 rm ${QWT_DIR}/qwt
-@CMAKE_COMMAND@ -E create_symlink "Versions/Current/Headers" "${QWT_DIR}/Headers"
-@CMAKE_COMMAND@ -E create_symlink "Versions/Current/Resources" "${QWT_DIR}/Resources"
-@CMAKE_COMMAND@ -E create_symlink "Versions/Current/qwt" "${QWT_DIR}/qwt"
+@CMAKE_COMMAND@ -E create_symlink "Versions/6/Headers"   "${QWT_DIR}/Headers"
+@CMAKE_COMMAND@ -E create_symlink "Versions/6/Resources" "${QWT_DIR}/Resources"
+@CMAKE_COMMAND@ -E create_symlink "6"                    "${QWT_DIR}/Versions/Current"
+@CMAKE_COMMAND@ -E create_symlink "Versions/6/qwt"       "${QWT_DIR}/qwt"
+find "${QWT_DIR}" -name '.*' -type f -exec rm -f {} \; # remove hidden files
+chmod -R 755 "${QWT_DIR}/Versions/6"
+chmod 755 "${QWT_DIR}"
+
+# Correct Qwt framework dependencies
+QT_BASE_PATH=$(dirname "$(dirname "@Qt5_DIR@")")
+QWT_BINARY="${QWT_DIR}/Versions/6/qwt"
+echo "Qt5_DIR = @Qt5_DIR@"
+echo "QT_BASE_PATH = $QT_BASE_PATH"
+echo "QWT_BINARY = $QWT_BINARY"
+for qt_lib in QtCore QtGui QtWidgets QtPrintSupport QtSvg QtOpenGL QtConcurrent; do
+    OLD_PATH="${QT_BASE_PATH}/${qt_lib}.framework/Versions/5/${qt_lib}"
+    NEW_PATH="@executable_path/../Frameworks/${qt_lib}.framework/Versions/5/${qt_lib}"
+
+    if otool -L "$QWT_BINARY" | grep -q "$OLD_PATH"; then
+        echo "Changing $OLD_PATH to $NEW_PATH"
+        install_name_tool -change "$OLD_PATH" "$NEW_PATH" "$QWT_BINARY"
+    fi
+done
 
 # Deploy Qt libraries using their tool
 echo "# Deploy Qt libs"
@@ -122,11 +143,15 @@ mkdir -p ${BUNDLE}.app/Contents/Resources/lib
 mv lib/python@PYTHON_VERSION_MAJOR@.@PYTHON_VERSION_MINOR@ ${BUNDLE}.app/Contents/Resources/lib
 
 # Sign the app
-CERT_NAME="MDS-certificate"
 if check_certificate "$CERT_NAME"; then
     echo "# Sign the app"
 
-    codesign --force --timestamp --sign "$CERT_NAME" "${FRAMEWORK_DIR}/qwt.framework/Versions/Current/qwt"
+    codesign --force --timestamp --sign "$CERT_NAME" --options runtime "${QWT_DIR}/Versions/6/qwt"
+    codesign --force --timestamp --sign "$CERT_NAME" "${QWT_DIR}/Versions/6"
+    codesign --force --timestamp --sign "$CERT_NAME" "${QWT_DIR}"
+    codesign --verify --deep --strict --verbose=2 "${QWT_DIR}"
+    spctl -a -vv "${QWT_DIR}"
+
     find "$FRAMEWORK_DIR" -type f -name "*.dylib" -exec \
         codesign --force --timestamp --sign "$CERT_NAME" {} \;
     find "$PLUGIN_DIR" -type f -name "*.dylib" -exec \
@@ -149,7 +174,6 @@ DMG_NAME="${BUNDLE}-@MEDINRIA_SUPERBUILD_VERSION@.dmg"
 dmgbuild -s "../../../packaging/apple/settings.json" "${BUNDLE}" "${DMG_NAME}"
 
 # Sign the DMG
-CERT_NAME="MDS-certificate"
 if check_certificate "$CERT_NAME"; then
     echo "# Sign the DMG"
     codesign --sign "${CERT_NAME}" --timestamp --options runtime "${DMG_NAME}"

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -41,8 +41,8 @@ function(music_plugins_project)
 
     if (NOT USE_SYSTEM_${external_project})
 
-        set(git_url ${GITHUB_PREFIX}mathildemerle/music.git)
-        set(git_tag qwtPlot)
+        set(git_url ${GITHUB_PREFIX}Inria-Asclepios/music.git)
+        set(git_tag 4.1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project


### PR DESCRIPTION
This PR fixes the qwt framework bundle to be consistent with the format asked by macOS, in order to allow the signature of the app bundle. Also it solves dependance paths in qwt libs.

:m: