### PR TITLE
[macOS] set gui identifier to bundle to fix QFileDialog not displayed

### DIFF
--- a/src/cmake/module/set_exe_install_rules.cmake
+++ b/src/cmake/module/set_exe_install_rules.cmake
@@ -56,6 +56,7 @@ if (APPLE)
   set(MACOSX_BUNDLE_LONG_VERSION_STRING
     "Version ${${target}_VERSION}"
     )
+  set(MACOSX_BUNDLE_GUI_IDENTIFIER "org.liryc.${target}.macos")
 
   install(CODE "
   execute_process(COMMAND


### PR DESCRIPTION
On some macOS ~15, the QFileDialog windows were not displayed.

It's a known bug: https://forum.qt.io/topic/162825/qfiledialog-getopenfilename-fails-to-display-dialog-with-native-macos/5

I added an identifier to our bundle and it seems to be working again.

:m: