### PR TITLE
[VTK] give zlib path to inner libs if zlib is an external project

### DIFF
--- a/.github/workflows/musicardio-macos.yml
+++ b/.github/workflows/musicardio-macos.yml
@@ -87,8 +87,7 @@ jobs:
           -DOpenMP_ROOT=$OpenMP_ROOT \
           -DUSE_FFmpeg=OFF \
           -DEXPIRATION_TIME:STRING=$EXPIRATION_TIME \
-          -DUSE_RealTimeWorkspace=OFF \
-          -DUSE_SYSTEM_ZLIB:BOOL=TRUE #to remove when zlib removal will be done in MSC
+          -DUSE_RealTimeWorkspace=OFF
           
     - name: Build
       run: | 

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -94,6 +94,7 @@ if (USE_Python)
 endif()
 
 list(APPEND external_projects
+  ZLIB
   VTK
   ITK
   RPI
@@ -110,7 +111,6 @@ if(USE_MUSIC_PLUGINS)
         qwt
         mmg
         tetgen
-        ZLIB
         xz
         libarchive
         )

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -18,6 +18,8 @@ set(ep VTK)
 ## List the dependencies of the project
 ## #############################################################################
 
+list(APPEND ${ep}_dependencies ZLIB)
+
 if(${USE_FFmpeg})
   list(APPEND ${ep}_dependencies ffmpeg)
 endif()
@@ -79,10 +81,16 @@ set(cmake_args
   -DVTK_USE_OGGTHEORA_ENCODER:BOOL=ON
   -DVTK_MODULE_USE_EXTERNAL_VTK_zlib:BOOL=ON
   )
-  
+
 set(cmake_cache_args
   -DQt5_DIR:FILEPATH=${Qt5_DIR}
   )
+
+if(NOT USE_SYSTEM_ZLIB)
+    list(APPEND cmake_args -DZLIB_INCLUDE_DIR:FILEPATH=${ZLIB_ROOT}/include)
+    list(APPEND cmake_args -DZLIB_LIBRARY_RELEASE:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib)
+    list(APPEND cmake_args -DZLIB_LIBRARY_DEBUG:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib)
+endif()
 
 if(USE_OSPRay)
     list(APPEND cmake_args


### PR DESCRIPTION
VTK need ZLIB path for VTK_MODULE_USE_EXTERNAL_VTK_zlib, needed on github action / macos15.
Since we compile it in MUSICardio, it can be directly used.

:m: