### PR TITLE
[QWT-ZLIB] compilation on all OS, packaging and new zlib version

### DIFF
--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -107,7 +107,8 @@ list(APPEND
   ${TTK_ROOT}/bin
   ${dtk_ROOT}/bin/Release
   ${RPI_ROOT}/bin/Release
-  ${ZLIB_ROOT}/Release
+  ${ZLIB_ROOT}/bin
+  ${qwt_ROOT}/lib
   )
 
 set(CPACK_INSTALL_CMAKE_PROJECTS

--- a/src/cmake/FindQwt.cmake
+++ b/src/cmake/FindQwt.cmake
@@ -44,7 +44,8 @@ else()
     find_path(qwt_INCLUDE_DIR_SYSTEM
         NAMES qwt.h
         PATHS /opt/homebrew/lib/qwt.framework/Versions/Current/Headers # mac
-              /usr/include                                             # linux
+              /usr/include/qwt                                         # ubuntu
+              /usr/include/qt5/qwt                                     # fedora
               ${CMAKE_PREFIX_PATH}/include                             # windows
               ${VCPKG_INSTALLED_DIR}/include                           # windows
               ${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/include  # windows
@@ -52,7 +53,8 @@ else()
     find_library(qwt_LIBRARIES
         NAMES qwt qwt-qt6 libqwt-qt5.so
         PATHS /opt/homebrew/lib                                    # mac
-              /usr/lib                                             # linux
+              /usr/lib                                             # ubuntu
+              /usr/lib64                                           # fedora
               ${CMAKE_PREFIX_PATH}/lib                             # windows
               ${VCPKG_INSTALLED_DIR}/lib                           # windows
               ${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}/lib  # windows

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -86,7 +86,7 @@ set(cmake_cache_args
   -DQt5_DIR:FILEPATH=${Qt5_DIR}
   )
 
-if(NOT USE_SYSTEM_ZLIB)
+if(NOT USE_SYSTEM_ZLIB AND APPLE)
     list(APPEND cmake_args -DZLIB_INCLUDE_DIR:FILEPATH=${ZLIB_ROOT}/include)
     list(APPEND cmake_args -DZLIB_LIBRARY_RELEASE:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib)
     list(APPEND cmake_args -DZLIB_LIBRARY_DEBUG:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib)

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -41,8 +41,8 @@ function(music_plugins_project)
 
     if (NOT USE_SYSTEM_${external_project})
 
-        set(git_url ${GITHUB_PREFIX}mathildemerle/music.git)
-        set(git_tag dllimport)
+        set(git_url ${GITHUB_PREFIX}Inria-Asclepios/music.git)
+        set(git_tag 4.1)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -41,8 +41,8 @@ function(music_plugins_project)
 
     if (NOT USE_SYSTEM_${external_project})
 
-        set(git_url ${GITHUB_PREFIX}Inria-Asclepios/music.git)
-        set(git_tag 4.1)
+        set(git_url ${GITHUB_PREFIX}mathildemerle/music.git)
+        set(git_tag dllimport)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/zlib.cmake
+++ b/superbuild/projects_modules/zlib.cmake
@@ -15,7 +15,7 @@ function(ZLIB_project)
     if (NOT USE_SYSTEM_${external_project})
 
         set(git_url ${GITHUB_PREFIX}madler/zlib.git)
-        set(git_tag v1.2.11)
+        set(git_tag v1.3.1.2)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
@@ -48,7 +48,7 @@ function(ZLIB_project)
             PREFIX ${EP_PATH_SOURCE}
             SOURCE_DIR ${EP_PATH_SOURCE}/${external_project}
             BINARY_DIR ${build_path}
-            INSTALL_DIR ${build_path}/install
+            INSTALL_DIR ${build_path}
             TMP_DIR ${tmp_path}
             STAMP_DIR ${stamp_path}
 
@@ -61,7 +61,7 @@ function(ZLIB_project)
             UPDATE_COMMAND ""
             )
 
-        set(${external_project}_ROOT ${build_path}/install PARENT_SCOPE)
+        set(${external_project}_ROOT ${build_path} PARENT_SCOPE)
 
     endif()
 


### PR DESCRIPTION
In order to compile on Windows, macOS 15, Fedora and Ubuntu:
* i updated windows packaging commands to find dll in right directories on Windows
* in FindQwt.cmake i updated path of libs and headers on linux
* i updated zlib version to compile with modern clang on github action macos runners

:m: