### PR TITLE
[Packaging] simplify Windows packaging and remove ZLIB parameter for VTK

### DIFF
--- a/.github/workflows/musicardio-macos.yml
+++ b/.github/workflows/musicardio-macos.yml
@@ -58,11 +58,6 @@ jobs:
         #brew info cmake
         brew uninstall --ignore-dependencies cmake
         pipx install cmake==3.31.10
-        brew install zlib
-        echo "LDFLAGS=-L/opt/homebrew/opt/zlib/lib" >> $GITHUB_ENV
-        echo "CPPFLAGS=-I/opt/homebrew/opt/zlib/include" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=/opt/homebrew/opt/zlib/lib/pkgconfig" >> $GITHUB_ENV
-        sudo xcode-select -switch /Applications/Xcode_16.4.app/Contents/Developer
 
     - name: Test dependencies
       run: |

--- a/packaging/windows/WindowsPackaging.cmake
+++ b/packaging/windows/WindowsPackaging.cmake
@@ -94,8 +94,7 @@ set(QT_BINARY_DIR "${Qt5_DIR}/../../../bin")
 set(QT_PLUGINS_DIR "${Qt5_DIR}/../../../plugins")
 set(MEDINRIA_FILES "${medInria_ROOT}/Release/bin")
 
-list(APPEND 
-  libSearchDirs 
+list(APPEND libSearchDirs
   ${QT_PLUGINS_DIR}/imageformats
   ${QT_PLUGINS_DIR}/platforms
   ${QT_BINARY_DIR}/sqldrivers
@@ -118,21 +117,6 @@ set(CPACK_INSTALL_CMAKE_PROJECTS
 
 install(CODE "
 
-file(GLOB_RECURSE itk_files LIST_DIRECTORIES true \"${ITK_ROOT}/bin/*.dll\")
-file(GLOB_RECURSE vtk_files LIST_DIRECTORIES true \"${VTK_ROOT}/bin/*.dll\")
-file(GLOB_RECURSE dtk_files LIST_DIRECTORIES true \"${dtk_ROOT}/bin/*.dll\")
-file(GLOB_RECURSE dcm_files LIST_DIRECTORIES true \"${QtDCM_ROOT}/bin/*.dll\")
-file(GLOB_RECURSE ttk_files LIST_DIRECTORIES true \"${TTK_ROOT}/bin/*.dll\")
-file(GLOB_RECURSE qt5_files LIST_DIRECTORIES true \"${QT_BINARY_DIR}/*.dll\")
-file(GLOB_RECURSE zlib_files LIST_DIRECTORIES true \"${ZLIB_ROOT}/*.dll\")
-list(APPEND files \${itk_files})
-list(APPEND files \${vtk_files})
-list(APPEND files \${dtk_files})
-list(APPEND files \${dcm_files})
-list(APPEND files \${ttk_files})
-list(APPEND files \${qt5_files})
-list(APPEND files \${zlib_files})
-
 file(INSTALL ${MEDINRIA_FILES}/
     DESTINATION \${CMAKE_INSTALL_PREFIX}/bin/
     FILES_MATCHING
@@ -140,13 +124,6 @@ file(INSTALL ${MEDINRIA_FILES}/
     PATTERN \"*${CMAKE_SHARED_LIBRARY_SUFFIX}\"
     PATTERN \"*.pyd\"
     )
-
-foreach(file \${files})
-  get_filename_component(file2delete \${file} NAME)
-  if(EXISTS \"\${CMAKE_INSTALL_PREFIX}/bin/\${file2delete}\")
-    file(REMOVE \"${MEDINRIA_FILES}/\${file2delete}\")
-  endif()
-endforeach()
 
 file(INSTALL ${QT_PLUGINS_DIR}/imageformats/qgif.dll    DESTINATION \${CMAKE_INSTALL_PREFIX}/bin/imageformats/ FILES_MATCHING PATTERN \"*${CMAKE_SHARED_LIBRARY_SUFFIX}\")
 file(INSTALL ${QT_PLUGINS_DIR}/imageformats/qicns.dll   DESTINATION \${CMAKE_INSTALL_PREFIX}/bin/imageformats/ FILES_MATCHING PATTERN \"*${CMAKE_SHARED_LIBRARY_SUFFIX}\")

--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -67,7 +67,7 @@ if(USE_MUSIC_PLUGINS)
 endif()
 
 ## #############################################################################
-## Add exteral projects
+## Add external projects
 ## #############################################################################
 
 # There are three possibilities:

--- a/superbuild/projects_modules/RPI.cmake
+++ b/superbuild/projects_modules/RPI.cmake
@@ -100,7 +100,6 @@ ExternalProject_Add(${ep}
 ExternalProject_Get_Property(${ep} binary_dir)
 set(${ep}_ROOT ${binary_dir} PARENT_SCOPE)
 
-
 endif() #NOT USE_SYSTEM_ep
 
 endfunction()

--- a/superbuild/projects_modules/TTK.cmake
+++ b/superbuild/projects_modules/TTK.cmake
@@ -100,7 +100,7 @@ ExternalProject_Add(${ep}
 
 ExternalProject_Get_Property(${ep} binary_dir)
 set(${ep}_ROOT ${binary_dir} PARENT_SCOPE)
-  
+
 endif() #NOT USE_SYSTEM_ep
 
 endfunction()

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -79,17 +79,20 @@ set(cmake_args
   -DVTK_MODULE_ENABLE_VTK_GUISupportQt=YES
   -DVTK_MODULE_ENABLE_VTK_RenderingQt=YES
   -DVTK_USE_OGGTHEORA_ENCODER:BOOL=ON
-  -DVTK_MODULE_USE_EXTERNAL_VTK_zlib:BOOL=ON
   )
 
 set(cmake_cache_args
   -DQt5_DIR:FILEPATH=${Qt5_DIR}
   )
 
+# VTK (v9.3.1 at least) internal zlib is outdated to compile with modern clang on some macos
 if(NOT USE_SYSTEM_ZLIB AND APPLE)
-    list(APPEND cmake_args -DZLIB_INCLUDE_DIR:FILEPATH=${ZLIB_ROOT}/include)
-    list(APPEND cmake_args -DZLIB_LIBRARY_RELEASE:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib)
-    list(APPEND cmake_args -DZLIB_LIBRARY_DEBUG:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib)
+    list(APPEND cmake_args
+        -DVTK_MODULE_USE_EXTERNAL_VTK_zlib:BOOL=ON
+        -DZLIB_INCLUDE_DIR:FILEPATH=${ZLIB_ROOT}/include
+        -DZLIB_LIBRARY_RELEASE:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib
+        -DZLIB_LIBRARY_DEBUG:FILEPATH=${ZLIB_ROOT}/lib/libz.dylib}
+    )
 endif()
 
 if(USE_OSPRay)

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -116,7 +116,6 @@ ExternalProject_Add(${ep}
 ExternalProject_Get_Property(${ep} binary_dir)
 set(${ep}_ROOT ${binary_dir} PARENT_SCOPE)
 
-
 endif() #NOT USE_SYSTEM_ep
 
 endfunction()

--- a/superbuild/projects_modules/zlib.cmake
+++ b/superbuild/projects_modules/zlib.cmake
@@ -1,18 +1,18 @@
 function(ZLIB_project)
 
-    set(external_project ZLIB)
+    set(ep ZLIB)
 
-    list(APPEND ${external_project}_dependencies
+    list(APPEND ${ep}_dependencies
         )
 
-    EP_Initialisation(${external_project}
+    EP_Initialisation(${ep}
         USE_SYSTEM OFF
         BUILD_SHARED_LIBS ON
         REQUIRED_FOR_PLUGINS OFF
         NO_CMAKE_PACKAGE
         )
 
-    if (NOT USE_SYSTEM_${external_project})
+    if (NOT USE_SYSTEM_${ep})
 
         set(git_url ${GITHUB_PREFIX}madler/zlib.git)
         set(git_tag v1.3.1.2)
@@ -35,18 +35,18 @@ function(ZLIB_project)
             -DCMAKE_C_FLAGS=${${ep}_c_flags}
             -DCMAKE_CXX_FLAGS=${${ep}_cxx_flags}
             -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-            -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS_${external_project}}
+            -DBUILD_SHARED_LIBS:BOOL=${BUILD_SHARED_LIBS_${ep}}
             )
 
 ## #############################################################################
 ## Add external-project
 ## #############################################################################
 
-        epComputPath(${external_project})
+        epComputPath(${ep})
 
-        ExternalProject_Add(${external_project}
+        ExternalProject_Add(${ep}
             PREFIX ${EP_PATH_SOURCE}
-            SOURCE_DIR ${EP_PATH_SOURCE}/${external_project}
+            SOURCE_DIR ${EP_PATH_SOURCE}/${ep}
             BINARY_DIR ${build_path}
             INSTALL_DIR ${build_path}
             TMP_DIR ${tmp_path}
@@ -57,11 +57,16 @@ function(ZLIB_project)
             CMAKE_GENERATOR ${gen}
             CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
             CMAKE_ARGS ${cmake_args}
-            DEPENDS ${${external_project}_dependencies}
+            DEPENDS ${${ep}_dependencies}
             UPDATE_COMMAND ""
             )
 
-        set(${external_project}_ROOT ${build_path} PARENT_SCOPE)
+## #############################################################################
+## Set variable to provide infos about the project
+## #############################################################################
+
+        ExternalProject_Get_Property(${ep} binary_dir)
+        set(${ep}_ROOT ${binary_dir} PARENT_SCOPE)
 
     endif()
 


### PR DESCRIPTION
This Pull Request allows to:
* simplify Windows packaging (and maintenance) removing a non useful part
* removing zlib installation on github action script
* on mac with zlib compiled as external project, we use our zlib in VTK instead of their outdated one

:m: