### PR TITLE
[DICOM] avoid crash if delete is run before end of initialisation

### DIFF
--- a/src/plugins/legacy/itkDataImage/readers/itkGDCMDataImageReader.cpp
+++ b/src/plugins/legacy/itkDataImage/readers/itkGDCMDataImageReader.cpp
@@ -157,12 +157,15 @@ itkGDCMDataImageReaderPrivate::itkGDCMDataImageReaderPrivate()
 
 itkGDCMDataImageReaderPrivate::~itkGDCMDataImageReaderPrivate()
 {
-    threadDone(io);
-
-    QMutex *m_ptr = mutex.fetchAndStoreOrdered(nullptr);
-    if (m_ptr)
+    if (io && ioThreads)
     {
-        delete m_ptr;
+        threadDone(io);
+
+        QMutex *m_ptr = mutex.fetchAndStoreOrdered(nullptr);
+        if (m_ptr)
+        {
+            delete m_ptr;
+        }
     }
 }
 


### PR DESCRIPTION
This Pull Request adds a test to avoid using a variable before it has been initialized (which crash).

:m: