### PR TITLE
[Documentation] change website path

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -12,6 +12,7 @@ MUSICardio 4.1:
 - Remove Composer workspace.
 - Pipelines: add a script version number to pipelines.
 - Histogram Analysis: fix problems/crashs with the Ventricle Max algo and its popup.
+- New documentation website: https://mds-data.ihu-liryc.fr/tools/musicardio
 
 MUSICardio 4.0.7:
 - PolygonROI:

--- a/src/app/medInria/areas/homepage/medHomepageArea.cpp
+++ b/src/app/medInria/areas/homepage/medHomepageArea.cpp
@@ -522,7 +522,7 @@ void medHomepageArea::onShowInfo()
 
 void medHomepageArea::onShowHelp()
 {
-    QDesktopServices::openUrl(QUrl("https://music-test.inria.fr/musicardio/"));
+    QDesktopServices::openUrl(QUrl("https://mds-data.ihu-liryc.fr/tools/musicardio"));
 }
 
 void medHomepageArea::onShowSettings()


### PR DESCRIPTION
Change the path for the documentation to the new website hosted on IHU Bordeaux server, on public except binaries.

:m: