### PR TITLE
[macOS-M2] fix pipeline import, python3.14, allow lldb, fix VTK flags

### DIFF
--- a/superbuild/CMakeLists.txt
+++ b/superbuild/CMakeLists.txt
@@ -21,7 +21,7 @@ option(USE_OSPRay "Use OSPRay for CPU VR" OFF )
 
 option(USE_Python "Build with Python support" ON)
 
-option(USE_MUSIC_PLUGINS "Build MUSIC plugins" ON)
+option(USE_MUSIC_PLUGINS "Build MUSICardio plugins" ON)
 
 option(USE_RealTimeWorkspace "Build the real time workspace and linked externals libraries" OFF)
 
@@ -50,12 +50,16 @@ find_package(Boost REQUIRED)
 
 if(USE_Python AND UNIX)
     if(APPLE)
-        set(default_root_dir "/usr/local/opt/openssl")
+        if(CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+            set(default_root_dir "/opt/homebrew/opt/openssl") # macOS Apple ship (M1/M2/M3...)
+        else()
+            set(default_root_dir "/usr/local/opt/openssl") # macOS Intel
+        endif()
     else()
         set(default_root_dir)
     endif()
     set(OPENSSL_ROOT_DIR ${default_root_dir} CACHE PATH "Root directory of OpenSSL.")
-    find_package(OpenSSL COMPONENTS SSL)
+    find_package(OpenSSL COMPONENTS SSL REQUIRED)
 endif()
 
 if(USE_MUSIC_PLUGINS)
@@ -94,16 +98,16 @@ if (USE_Python)
 endif()
 
 list(APPEND external_projects
-  ZLIB
-  VTK
-  ITK
-  RPI
-  TTK
-  DCMTK
-  QtDCM
-  dtk
-  LogDemons
-  )
+    ZLIB
+    VTK
+    ITK
+    RPI
+    TTK
+    DCMTK
+    QtDCM
+    dtk
+    LogDemons
+    )
 
 if(USE_MUSIC_PLUGINS)
     list(APPEND external_projects

--- a/superbuild/launchers/MUSICardio.sh.in
+++ b/superbuild/launchers/MUSICardio.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage() {
     local ret="$1"
@@ -20,7 +20,11 @@ if [ "$1" == "--prefix" ]; then
 fi
 
 if [ "$1" == "--debug" ]; then
-    med_prefix="gdb --args"
+    case "$OSTYPE" in
+        linux*)   med_prefix="gdb --args" ;;
+        darwin*)  med_prefix="lldb" ;;
+        *)        echo "unknown: $OSTYPE" ;;
+    esac
 fi
 
 #   Locate the directory containing this script.

--- a/superbuild/projects_modules/ITK.cmake
+++ b/superbuild/projects_modules/ITK.cmake
@@ -92,7 +92,10 @@ ExternalProject_Add(${ep}
   
   GIT_REPOSITORY ${git_url}
   GIT_TAG ${git_tag}
+  GIT_SHALLOW True
+  GIT_PROGRESS True
   PATCH_COMMAND ${${ep}_PATCH_COMMAND}
+
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}  

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -74,11 +74,10 @@ set(cmake_args
   -DVTK_BUILD_TESTING=OFF
   -DVTK_BUILD_DOCUMENTATION=OFF
   -DVTK_BUILD_EXAMPLES=OFF
-  -DVTK_RENDERING_BACKEND=OpenGL2
   -DVTK_QT_VERSION=5
   -DVTK_MODULE_ENABLE_VTK_GUISupportQt=YES
   -DVTK_MODULE_ENABLE_VTK_RenderingQt=YES
-  -DVTK_USE_OGGTHEORA_ENCODER:BOOL=ON
+  -DVTK_MODULE_ENABLE_VTK_IOOggTheora:BOOL=YES
   )
 
 set(cmake_cache_args
@@ -129,24 +128,25 @@ endif()
 
 if(USE_Python)
     if(UNIX)
-        set(python_version "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+        set(python_version    "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+        set(python_root       "${pyncpp_ROOT}/lib/python${python_version}")
         set(python_executable "${pyncpp_ROOT}/lib/python${python_version}/bin/python${python_version}")
-        set(python_include "${pyncpp_ROOT}/lib/python${python_version}/include/python${python_version}")
-        set(python_library "${pyncpp_ROOT}/lib/python${python_version}/lib/libpython${python_version}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+        set(python_include    "${pyncpp_ROOT}/lib/python${python_version}/include/python${python_version}")
+        set(python_library    "${pyncpp_ROOT}/lib/python${python_version}/lib/libpython${python_version}${CMAKE_SHARED_LIBRARY_SUFFIX}")
     else()
-        set(python_version "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+        set(python_version    "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+        set(python_root       "${pyncpp_ROOT}/python${python_version}")
         set(python_executable "${pyncpp_ROOT}/python${python_version}/pythonw$<$<CONFIG:Debug>:_d>.exe")
-        set(python_include "${pyncpp_ROOT}/python${python_version}/include")
-        set(python_library "${pyncpp_ROOT}/python${python_version}/libs/python${python_version}$<$<CONFIG:Debug>:_d>.lib")
+        set(python_include    "${pyncpp_ROOT}/python${python_version}/include")
+        set(python_library    "${pyncpp_ROOT}/python${python_version}/libs/python${python_version}$<$<CONFIG:Debug>:_d>.lib")
     endif()
     list(APPEND cmake_args
         -DVTK_WRAP_PYTHON:BOOL=ON
-        -DModule_vtkPython:BOOL=ON
-        -DModule_vtkWrappingTools:BOOL=ON
         -DVTK_PYTHON_VERSION:STRING=${PYTHON_VERSION_MAJOR}
-        -DPYTHON_EXECUTABLE:PATH=${python_executable}
-        -DPYTHON_INCLUDE_DIR:PATH=${python_include}
-        -DPYTHON_LIBRARY:PATH=${python_library}
+        -DPython3_EXECUTABLE:PATH=${python_executable}
+        -DPython3_INCLUDE_DIR:PATH=${python_include}
+        -DPython3_LIBRARY:PATH=${python_library}
+        -DPython3_ROOT_DIR:PATH=${python_root}
         )
 endif()
 
@@ -171,7 +171,10 @@ ExternalProject_Add(${ep}
   
   GIT_REPOSITORY ${git_url}
   GIT_TAG ${git_tag}
+  GIT_SHALLOW True
+  GIT_PROGRESS True
   PATCH_COMMAND ${${ep}_PATCH_COMMAND}
+
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}

--- a/superbuild/projects_modules/dtk.cmake
+++ b/superbuild/projects_modules/dtk.cmake
@@ -43,7 +43,6 @@ if (NOT USE_SYSTEM_${ep})
 set(git_url ${GITLAB_INRIA_PREFIX}dtk/dtk.git)
 set(git_tag 1.7.1)
 
-
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project
 ## #############################################################################
@@ -100,6 +99,9 @@ ExternalProject_Add(${ep}
   
   GIT_REPOSITORY ${git_url}
   GIT_TAG ${git_tag}
+  GIT_SHALLOW True
+  GIT_PROGRESS True
+
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}

--- a/superbuild/projects_modules/medInria.cmake
+++ b/superbuild/projects_modules/medInria.cmake
@@ -47,7 +47,6 @@ EP_Initialisation(${ep}
   REQUIRED_FOR_PLUGINS ON
   )
 
-
 if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/mmg.cmake
+++ b/superbuild/projects_modules/mmg.cmake
@@ -64,13 +64,17 @@ ExternalProject_Add(${ep}
   INSTALL_DIR ${build_path}/install
   TMP_DIR ${tmp_path}
   STAMP_DIR ${stamp_path}
+
   GIT_REPOSITORY ${git_url}
   GIT_TAG ${git_tag}
+  GIT_SHALLOW True
+  GIT_PROGRESS True
+  PATCH_COMMAND ${${ep}_PATCH_COMMAND}
+
   CMAKE_GENERATOR ${gen}
   CMAKE_GENERATOR_PLATFORM ${CMAKE_GENERATOR_PLATFORM}
   CMAKE_ARGS ${cmake_args}
   DEPENDS ${${ep}_dependencies}
-  PATCH_COMMAND ${${ep}_PATCH_COMMAND}
   UPDATE_COMMAND ""
   )
 

--- a/superbuild/projects_modules/openssl.cmake
+++ b/superbuild/projects_modules/openssl.cmake
@@ -24,6 +24,7 @@ set(ep openssl)
 list(APPEND ${ep}_dependencies
   ""
   )
+
 ## #############################################################################
 ## Prepare the project
 ## ############################################################################# 
@@ -74,7 +75,7 @@ if (WIN32)
 ExternalProject_Add(${ep}
     PREFIX ${EP_PATH_SOURCE}
     SOURCE_DIR ${EP_PATH_SOURCE}/${ep}
-    BINARY_DIR ${build_path}/realBuild
+    BINARY_DIR ${build_path}
     TMP_DIR ${tmp_path}
     STAMP_DIR ${stamp_path}
 
@@ -91,7 +92,7 @@ else()
   ExternalProject_Add(${ep}
     PREFIX ${EP_PATH_SOURCE}
     SOURCE_DIR ${EP_PATH_SOURCE}/${ep}
-    BINARY_DIR ${build_path}/realBuild
+    BINARY_DIR ${build_path}
     TMP_DIR ${tmp_path}
     STAMP_DIR ${stamp_path}
 
@@ -100,7 +101,7 @@ else()
     CMAKE_ARGS ${cmake_args}
     UPDATE_COMMAND ""
     DEPENDS ${${ep}_dependencies}
-    CONFIGURE_COMMAND ${EP_PATH_SOURCE}/${ep}/config no-zlib no-tests no-shared --prefix=${build_path} --openssldir=${build_path} 
+    CONFIGURE_COMMAND ${EP_PATH_SOURCE}/${ep}/config no-zlib no-tests no-shared --prefix=${build_path} --openssldir=${build_path}
     BUILD_COMMAND ${CMAKE_MAKE_PROGRAM} install_sw
     INSTALL_COMMAND ""
   )

--- a/superbuild/projects_modules/pyncpp.cmake
+++ b/superbuild/projects_modules/pyncpp.cmake
@@ -11,9 +11,9 @@
 #
 ################################################################################
 
-set(PYTHON_VERSION_MAJOR 3 CACHE STRING "Python major version")
-set(PYTHON_VERSION_MINOR 10 CACHE STRING "Python minor version")
-set(PYTHON_VERSION_PATCH 10 CACHE STRING "Python patch version")
+set(PYTHON_VERSION_MAJOR 3  CACHE STRING "Python major version")
+set(PYTHON_VERSION_MINOR 14 CACHE STRING "Python minor version")
+set(PYTHON_VERSION_PATCH 3  CACHE STRING "Python patch version")
 
 function(pyncpp_project)
 
@@ -29,12 +29,8 @@ function(pyncpp_project)
 
         epComputPath(${ep})
 
-        set(project_args
-            GIT_REPOSITORY ${GITHUB_PREFIX}LIRYC-IHU/pyncpp.git
-            GIT_TAG working
-            GIT_SHALLOW True
-            GIT_PROGRESS True
-            )
+        set(git_url ${GITHUB_PREFIX}LIRYC-IHU/pyncpp.git)
+        set(git_tag working)
 
         set(cmake_args
             ${ep_common_cache_args}
@@ -61,10 +57,15 @@ function(pyncpp_project)
             BINARY_DIR ${build_path}
             TMP_DIR ${tmp_path}
             STAMP_DIR ${stamp_path}
+
+            GIT_REPOSITORY ${git_url}
+            GIT_TAG ${git_tag}
+            GIT_SHALLOW True
+            GIT_PROGRESS True
+
             DEPENDS ${${ep}_dependencies}
             CMAKE_ARGS ${cmake_args}
             INSTALL_COMMAND ""
-            "${project_args}"
             )
 
         ## #####################################################################


### PR DESCRIPTION
This PR:
* fix openssl via homebrew on apple ship macOS, to debug import of python script on mac
* switch to Python 3.14
* update VTK flags, mostly for Python
* allow use of lldb with `./MUSICardio.sh --debug`
* add some git shallow/progress

:m: