### PR TITLE
[Python] vtk flag and python 3.12.3

### DIFF
--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -142,7 +142,6 @@ if(USE_Python)
     endif()
     list(APPEND cmake_args
         -DVTK_WRAP_PYTHON:BOOL=ON
-        -DVTK_PYTHON_VERSION:STRING=${PYTHON_VERSION_MAJOR}
         -DPython3_EXECUTABLE:PATH=${python_executable}
         -DPython3_INCLUDE_DIR:PATH=${python_include}
         -DPython3_LIBRARY:PATH=${python_library}

--- a/superbuild/projects_modules/pyncpp.cmake
+++ b/superbuild/projects_modules/pyncpp.cmake
@@ -12,7 +12,7 @@
 ################################################################################
 
 set(PYTHON_VERSION_MAJOR 3  CACHE STRING "Python major version")
-set(PYTHON_VERSION_MINOR 14 CACHE STRING "Python minor version")
+set(PYTHON_VERSION_MINOR 12 CACHE STRING "Python minor version")
 set(PYTHON_VERSION_PATCH 3  CACHE STRING "Python patch version")
 
 function(pyncpp_project)


### PR DESCRIPTION
Following https://github.com/Inria-Asclepios/medInria-public/pull/925

VTK_PYTHON_VERSION is deprecated, and switch to python 3.12 for ubuntu 24 and fedora

:m: