### PR TITLE
[Progression Bar] fix crash with signals post destruction

### DIFF
--- a/src/layers/legacy/medCoreLegacy/medJobItemL.cpp
+++ b/src/layers/legacy/medCoreLegacy/medJobItemL.cpp
@@ -15,12 +15,15 @@
 
 medJobItemL::medJobItemL() : QRunnable()
 {
-    connect(this, SIGNAL(progress(QObject*, int)), this, SLOT(onProgress(QObject*, int)));
+    connect(this, SIGNAL(progress(QObject*, int)),
+            this, SLOT(onProgress(QObject*, int)));
 }
 
 medJobItemL::~medJobItemL()
 {
-
+    blockSignals(true);
+    this->disconnect();
+    QCoreApplication::removePostedEvents(this);
 }
 
 void medJobItemL::run()
@@ -56,7 +59,9 @@ void medJobItemL::onCancel( QObject* )
 
 void medJobItemL::onProgress( QObject* sender, int prog )
 {
-    Q_UNUSED(sender);
-    emit progressed(prog);
+    if (sender)
+    {
+        emit progressed(prog);
+    }
 }
 

--- a/src/layers/legacy/medCoreLegacy/process/medRunnableProcess.cpp
+++ b/src/layers/legacy/medCoreLegacy/process/medRunnableProcess.cpp
@@ -31,6 +31,10 @@ medRunnableProcess::medRunnableProcess(void): medJobItemL(), d (new medRunnableP
 
 medRunnableProcess::~medRunnableProcess()
 {
+    blockSignals(true);
+    this->disconnect();
+    QCoreApplication::removePostedEvents(this);
+
     delete d;
     d = nullptr;
 }
@@ -87,10 +91,13 @@ void medRunnableProcess::onFailure()
     emit failure (this);
 }
 
-void medRunnableProcess::onProgressed (int value)
+void medRunnableProcess::onProgressed(int value)
 {
-    emit activate (this, false);
-    emit progress (this, value);
+    if (signalsBlocked())
+    {
+        emit activate(this, false);
+        emit progress(this, value);
+    }
 }
 
 /**


### PR DESCRIPTION
This PR cleans the way we handle signals post destruction of the process, specially for the progression bar.

:m: