### PR TITLE
[macOS] same icon between bundle and app, and fix size

### DIFF
--- a/src/app/medInria/medApplication.cpp
+++ b/src/app/medInria/medApplication.cpp
@@ -135,7 +135,12 @@ medApplication::medApplication(int & argc, char**argv) :
         qssFile = ":/music_light.qss";
         break;
     }
-    this->setWindowIcon(QIcon(":MUSICardio_logo_small_light.png"));
+    #ifdef Q_OS_MAC
+        this->setWindowIcon(QIcon(":/MUSICardio.icns"));
+    #else
+        this->setWindowIcon(QIcon(":MUSICardio_logo_small_light.png"));
+    #endif
+
     medStyleSheetParser parser(dtkReadFile(qssFile));
     this->setStyleSheet(parser.result());
 


### PR DESCRIPTION
On macOS 26, the size of the application icon (seen in the dock after launch, or in COMMAND-TAB) was too big and not the same as the one from the bundle (seen in Applications or in the dock if the app is not run).

:m: