### PR TITLE
[Pipelines] fix memory errors with processes outputs and medDecimate parameter

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,6 +1,6 @@
 MUSICardio 4.1:
 - Switch to VTK "v9.3.1", ITK "v5.4.5", Qt "5.15", libarchive "v3.8.5", xz "v5.8.1", RPI "V2.0.0", DCMTK "DCMTK-3.6.9", QtDCM "DCMTK-3.6.9", mmg "v5.8.0", qwt "v6.3.0", ZLIB "v1.3.1.2"
-- Compatibility with Ubuntu 24, macOS 14 and 15 (Intel or Apple chip), Fedora 37 and still Windows 10.
+- Compatibility with Ubuntu 24, macOS 15 and 26 (Intel or Apple chip), Fedora 40 and still Windows 10.
 - macOS DMGs are locally signed.
 - Update the default expiration duration of binary from 12 to 24 months.
 - DICOM reader has been updated to be more robust.
@@ -15,6 +15,7 @@ MUSICardio 4.1:
 - New documentation website: https://mds-data.ihu-liryc.fr/tools/musicardio
 - Save last current paths in some dialog widget to open or export data.
 - Add new workspace to view and export EP maps.
+- Fix memory errors with outputs from processes in Pipelines
 
 MUSICardio 4.0.7:
 - PolygonROI:

--- a/src/layers/legacy/medUtilities/medUtilitiesVTK.cpp
+++ b/src/layers/legacy/medUtilities/medUtilitiesVTK.cpp
@@ -23,10 +23,25 @@
 #include <vtkPointData.h>
 #include <vtkPolyData.h>
 
-medAbstractData* medUtilitiesVTK::changeMaxNumberOfMeshTriangles(medAbstractData *mesh, int maxNumber)
+medAbstractData *medUtilitiesVTK::changeMaxNumberOfMeshTriangles(medAbstractData *mesh, int maxNumber)
 {
-    vtkMetaDataSet * dataset = reinterpret_cast<vtkMetaDataSet*>(mesh->data());
-    vtkPolyData * polydata = dynamic_cast<vtkPolyData*>(dataset->GetDataSet());
+    if (!mesh || !mesh->data())
+    {
+        qWarning() << "Error in changeMaxNumberOfMeshTriangles: invalid mesh input";
+        return mesh;
+    }
+    vtkMetaDataSet* dataset = reinterpret_cast<vtkMetaDataSet*>(mesh->data());
+    if (!dataset)
+    {
+        qWarning() << "Error in changeMaxNumberOfMeshTriangles: invalid dataset";
+        return mesh;
+    }
+    vtkPolyData* polydata = dynamic_cast<vtkPolyData*>(dataset->GetDataSet());
+    if (!polydata)
+    {
+        qWarning() << "Error in changeMaxNumberOfMeshTriangles: not a vtkPolyData";
+        return mesh;
+    }
 
     int initialNumber = polydata->GetNumberOfPolys();
 
@@ -34,11 +49,11 @@ medAbstractData* medUtilitiesVTK::changeMaxNumberOfMeshTriangles(medAbstractData
     {
         double decimateValue = 1.0 - (double)maxNumber/(double)initialNumber;
 
-        dtkSmartPointer<medAbstractProcessLegacy> process = dtkAbstractProcessFactory::instance()->createSmartPointer("medDecimateMeshProcess");
+        dtkSmartPointer<medAbstractProcessLegacy> process
+            = dtkAbstractProcessFactory::instance()->createSmartPointer("medDecimateMeshProcess");
         process->setInput(mesh);
-        process->setParameter(decimateValue);
+        process->setParameter(decimateValue, 0);
         process->update();
-
         return process->output();
     }
     return mesh;

--- a/src/plugins/legacy/itkFilters/itkFiltersProcessBase.cpp
+++ b/src/plugins/legacy/itkFilters/itkFiltersProcessBase.cpp
@@ -59,8 +59,13 @@ void itkFiltersProcessBase::setInput(medAbstractData *data, int channel)
 }
 
 medAbstractData * itkFiltersProcessBase::output()
-{   
-    return d->outputData;
+{
+    if (d->outputData)
+    {
+        d->outputData->retain();
+        return d->outputData;
+    }
+    return nullptr;
 }
 
 int itkFiltersProcessBase::update()

--- a/src/plugins/legacy/medBinaryOperation/medBinaryOperatorBase.cpp
+++ b/src/plugins/legacy/medBinaryOperation/medBinaryOperatorBase.cpp
@@ -254,5 +254,10 @@ template <class ImageType, class ImageType2> int medBinaryOperatorBase::runProce
 
 medAbstractData * medBinaryOperatorBase::output()
 {
-    return m_output;
+    if (m_output)
+    {
+        m_output->retain();
+        return m_output;
+    }
+    return nullptr;
 }

--- a/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.cpp
+++ b/src/plugins/legacy/medCreateMeshFromMask/medCreateMeshFromMask.cpp
@@ -267,7 +267,12 @@ int medCreateMeshFromMask::update()
 
 medAbstractData * medCreateMeshFromMask::output()
 {
-    return d->output;
+    if (d->output)
+    {
+        d->output->retain();
+        return d->output;
+    }
+    return nullptr;
 }
 
 int medCreateMeshFromMask::getNumberOfTriangles()

--- a/src/plugins/legacy/medMaskApplication/medMaskApplication.cpp
+++ b/src/plugins/legacy/medMaskApplication/medMaskApplication.cpp
@@ -260,7 +260,12 @@ int medMaskApplication::updateMaskType()
 
 medAbstractData * medMaskApplication::output()
 {
-    return d->output;
+    if (d->output)
+    {
+        d->output->retain();
+        return d->output;
+    }
+    return nullptr;
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src/plugins/legacy/medRemeshing/medDecimateMeshProcess.cpp
+++ b/src/plugins/legacy/medRemeshing/medDecimateMeshProcess.cpp
@@ -193,7 +193,12 @@ int medDecimateMeshProcess::update()
 
 medAbstractData * medDecimateMeshProcess::output()
 {
-    return d->output;
+    if (d->output)
+    {
+        d->output->retain();
+        return d->output;
+    }
+    return nullptr;
 }
 
 // /////////////////////////////////////////////////////////////////

--- a/src/plugins/legacy/reformat/resampleProcess.cpp
+++ b/src/plugins/legacy/reformat/resampleProcess.cpp
@@ -35,8 +35,8 @@ public:
     {
         parent = p;
     }
-    medAbstractData* input;
-    medAbstractData* output;
+    dtkSmartPointer <medAbstractData> input;
+    dtkSmartPointer <medAbstractData> output;
     int interpolator;
     int dimX, dimY, dimZ;
     double spacingX, spacingY, spacingZ;
@@ -184,7 +184,12 @@ int resampleProcess::resample(medAbstractData* inputData)
 
 medAbstractData * resampleProcess::output ( void )
 {
-    return d->output;
+    if (d->output)
+    {
+        d->output->retain();
+        return d->output;
+    }
+    return nullptr;
 }
 
 // /////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I had some crashs in some pipelines steps.

This PR fixes these crashs solving errors with the outputs of some processes, specially medDecimateMeshProcess. We need to retain outputs after the destruction of the processes, otherwise they could be removed too.

This PR also fixes a parameter problem with medDecimateMeshProcess.

:m: