### PR TITLE
[VoiCutter] keep data from view even after closing for processOutput

### DIFF
--- a/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
+++ b/src/plugins/legacy/voiCutter/voiCutterToolBox.cpp
@@ -48,6 +48,7 @@ public:
     medAbstractImageView *currentView;
     bool scissorOn;
     vtkCutterObserver *observer;
+    dtkSmartPointer<medAbstractData> originalData;
     dtkSmartPointer<medAbstractData> resultData;
     medAbstractData *input;
     unsigned int layerInput;
@@ -144,6 +145,7 @@ voiCutterToolBox::voiCutterToolBox(QWidget *parent) :
 
     d->scissorOn = false;
     d->currentView = nullptr;
+    d->originalData = nullptr;
     d->resultData = nullptr;
     d->input = nullptr;
     d->layerInput = 0;
@@ -271,6 +273,7 @@ void voiCutterToolBox::onViewClosed()
         d->scissorButton->click(); // Deactivate cut volume tool
     }
 
+    d->originalData = nullptr;
     d->resultData = nullptr;
     activateButtons(false);
 }
@@ -293,7 +296,9 @@ medAbstractData *voiCutterToolBox::processOutput()
     }
     else if (d->currentView)
     {
-        return d->currentView->layerData(d->currentView->currentLayer());
+        // Needed to keep the original data even after the closing of the view, after processOutput()
+        d->originalData = d->currentView->layerData(d->currentView->currentLayer())->clone();
+        return d->originalData;
     }
     return nullptr;
 }


### PR DESCRIPTION
I had some problems with some VOICutter steps in pipelines, where i could not redo a step because the output data previously saved was invalid. This was happening only if i did not segment the data previously (hence we had the original data from the view saved).

This PR saves correctly the original data even if the original view is closed.

:m: