### PR TITLE
[QMessageBox] fix qt error of mac with bold text

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -466,8 +466,10 @@ AlgorithmPaintToolBox::AlgorithmPaintToolBox(QWidget *parent ) :
             "&nbsp;&nbsp;&nbsp;&nbsp;1. Click the color button to choose a new color.<br>"
             "&nbsp;&nbsp;&nbsp;&nbsp;2. You must <em>reset the mask</em> for the new color to be applied to existing data."
         );
+        // Fix Qt 5.15 (at least) bug on macOS which display messagebox text in bold
+        QString explanation = "<span style='font-weight: normal;'>" + text + "</span>";
 
-        msgBox.setText(text);
+        msgBox.setText(explanation);
         msgBox.setTextFormat(Qt::RichText);
         msgBox.exec();
     });

--- a/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
+++ b/src/plugins/legacy/polygonRoi/toolboxes/polygonRoiToolBox.cpp
@@ -640,7 +640,10 @@ void polygonRoiToolBox::showHelp() const
     }
     contextual += QString("</ul>");
 
-    const QString explanation = main + shortcut + contextual;
+    // Fix Qt 5.15 (at least) bug on macOS which display messagebox text in bold
+    QString explanation = "<span style='font-weight: normal;'>" + main + shortcut + contextual + "</span>";
+
+    msgBox.setTextFormat(Qt::RichText);
     msgBox.setText(explanation);
     msgBox.exec();
 }


### PR DESCRIPTION
Fix a known problem on macOS with QMessageBox where the text is displayed on bold by default even in rich text.

:m: