### PR TITLE
[Linux] fix problem with sqlite for tensorflow

### DIFF
--- a/superbuild/launchers/MUSICardio.sh.in
+++ b/superbuild/launchers/MUSICardio.sh.in
@@ -31,6 +31,13 @@ fi
 MEDINRIA_DIR="@MEDINRIA_DIR@"
 MEDINRIA_BIN="@MEDINRIA_BIN@"
 
+# TensorFlow (at least) can be installed by users in our own Python.
+# It can creates conflicts between the SQLite system used by Qt and the one from TensorFlow.
+# This line forces the SQLite system one. Does not occur on macOS.
+if [[ "$OSTYPE" == linux* ]]; then
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libsqlite3.so.0
+fi
+
 #   Set the plugins and library paths.
 export MEDINRIA_PLUGINS_DIR="@MEDINRIA_PLUGINS_DIRS@"
 export MEDINRIA_PLUGINS_DIR_LEGACY="@MEDINRIA_PLUGINS_LEGACY_DIRS@"


### PR DESCRIPTION
This is a fix to use tensorflow on our python. There were conflicts between SQLite used by Qt and tensorflow, leading to crash in the app (for instance creating pipeline or closing the app).

:m: