### PR TITLE
[Paint] fix saving in magic wand with thresholds, safe tab clean

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -601,6 +601,8 @@ void AlgorithmPaintToolBox::updateMagicWandComputation()
         undo();
         updateWandRegion(currentView, m_seed);
         wandTimer.start();
+
+        m_applyButton->setDisabled(false);
     }
 }
 
@@ -1820,7 +1822,10 @@ void AlgorithmPaintToolBox::clear()
         }
     }
     clearMask();
-    tabWidget->setCurrentIndex(0);
+    if (tabWidget)
+    {
+        tabWidget->setCurrentIndex(0);
+    }
 }
 
 void AlgorithmPaintToolBox::clearMask()


### PR DESCRIPTION
This PR allows to enable the "Save" button when a simple magic wand is done, without 3D mode or second click on the view. It secures also the tabWidget variable at the closing of the toolbox.

:m: