### PR TITLE
[macOS] avoid problem with macOS Gatekeeper

### DIFF
--- a/src/cmake/MedInriaOSXBundleInfo.plist.in
+++ b/src/cmake/MedInriaOSXBundleInfo.plist.in
@@ -113,5 +113,24 @@
 		</dict>
 	</array>
 
+	<!-- Avoid macOS security pop-ups with read/write -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+
+	<!-- Allow access to Download, Documents and Desktop -->
+	<key>com.apple.security.files.downloads.read-write</key>
+	<true/>
+	<key>com.apple.security.files.documents.read-write</key>
+	<true/>
+	<key>com.apple.security.files.desktop.read-write</key>
+	<true/>
+
+	<!-- Various parameters to avoid security problem on macOS with non signed libs etc -->
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
On macOS 26 there was a Gatekeeper security pop-up when a user wanted to export a scene (from `mscPipelineExportToolBox::exportScene()` and `medViewContainer::saveScene()`).

This PR enhances the macOS plist file with parameters to avoid gatekeeper problems.

:m: