### PR TITLE
[Remeshing] fix crash adding mesh to view on some computer and display on manual mode

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -24,12 +24,20 @@ MUSICardio 4.1:
 - Fix a bug with "starting workspace" setting.
 - Remove Composer workspace.
 - Remove duplicated "Filtering dtk2" workspace.
-- Pipelines: add a script version number to pipelines.
+- Pipelines:
+    * fix memory errors with outputs from processes
+    * add a script version number to pipelines
+    * our Python comes with numpy vtk SimpleITK scipy modules by default.
 - Histogram Analysis: fix problems/crashs with the Ventricle Max algo and its popup.
 - New documentation website: https://mds.ihu-liryc.fr/musicardio
 - Save last current paths in some dialog widget to open or export data.
 - Add new workspace to view and export EP maps.
-- Fix memory errors with outputs from processes in Pipelines
+- Remeshing:
+    * fix a crash displaying the output mesh on some computer
+    * now display the output mesh in the view after manual mode.
+- Data Projection:
+    * fix problem if the input data were dropped before the opening of the toolbox
+    * fix problem if a non-mesh is used.
 
 MUSICardio 4.0.7:
 - PolygonROI:

--- a/src/plugins/legacy/medRemeshing/medRemeshingToolBox.cpp
+++ b/src/plugins/legacy/medRemeshing/medRemeshingToolBox.cpp
@@ -480,32 +480,14 @@ double medRemeshingToolBox::getNumberOfCells(dtkSmartPointer<medAbstractData> da
 
 void medRemeshingToolBox::addMeshToView()
 {
-    medRunnableProcess *process = static_cast<medRunnableProcess*>(sender());
-
-    QStringList options;
-    options << "medDecimateMeshProcess" << "medRefineMeshProcess" << "medSmoothMeshProcess";
-
-    switch (options.indexOf(process->getProcess()->description()))
+    auto newData = processOutput();
+    if (newData)
     {
-        case 0:
+        displayComputedMesh(newData);
+
+        if (d->currentProcess == REFINE)
         {
-            displayComputedMesh(d->decimateProcess->output());
-            break;
-        }
-        case 1:
-        {
-            displayComputedMesh(d->refineProcess->output());
             allowDecimate();
-            break;
-        }
-        case 2:
-        {
-            displayComputedMesh(d->smoothProcess->output());
-            break;
-        }
-        default:
-        {
-            return;
         }
     }
 }


### PR DESCRIPTION
This PR fixes a crash displaying the output mesh on some computer, and allows to display the output mesh in the view after manual mode. It updates release notes also.

:m:
