### PR TITLE
[Paint] fix crash reopening a data in a cleaned view after region growing

### DIFF
--- a/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
+++ b/src/plugins/legacy/medAlgorithmPaint/medAlgorithmPaintToolBox.cpp
@@ -591,7 +591,7 @@ bool AlgorithmPaintToolBox::registered()
 
 void AlgorithmPaintToolBox::updateMagicWandComputation()
 {
-    if (seedPlanted && currentView)
+    if (seedPlanted && currentView && (tabWidget->tabBar()->currentIndex()==2))
     {
         if (m_wand3DCheckbox->isChecked() && wandTimer.elapsed()<600) // 1000/24 (24 images per second)
         {


### PR DESCRIPTION
This PR fixes a crash if the region growing tool of Paint is used, then the view is cleaned, then the user adds a new data in the view. 

:m: