### PR TITLE
[VTK] from vtk 9.3.1 to 9.6.2, iostream and vtkIdFilter changes

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,6 +1,7 @@
 MUSICardio 4.2:
 - Removes FFMPEG to only keep OGV video export which is natively used by VTK.
 - On Linux now we generate AppImages, instead of ZIP packages for Ubuntu and Fedora.
+- Switch to VTK v9.6.2.
 
 MUSICardio 4.1:
 - Switch to VTK "v9.3.1", ITK "v5.4.5", Qt "5.15",

--- a/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
+++ b/src/layers/legacy/medVtkInria/vtkImageView/vtkImageView3D.cxx
@@ -21,8 +21,8 @@
 #include <vtkAnnotatedCubeActor.h>
 #include <vtkColorTransferFunction.h>
 #include <vtkDataSetCollection.h>
+#include <vtkGenerateIds.h>
 #include <vtkGeometryFilter.h>
-#include <vtkIdFilter.h>
 #include <vtkImageActor.h>
 #include <vtkImageAppendComponents.h>
 #include <vtkImageCast.h>
@@ -921,7 +921,7 @@ vtkActor* vtkImageView3D::AddDataSet(vtkPointSet* arg, vtkProperty* prop)
 //----------------------------------------------------------------------------
 vtkSmartPointer<vtkActor> vtkImageView3D::DataSetToActor(vtkPointSet* arg, vtkProperty* prop)
 {
-    auto idFilter = vtkSmartPointer<vtkIdFilter>::New();
+    auto idFilter = vtkSmartPointer<vtkGenerateIds>::New();
     auto geometryextractor = vtkSmartPointer<vtkGeometryFilter>::New();
     auto normalextractor = vtkSmartPointer<vtkPolyDataNormals>::New();
     auto mapper = vtkSmartPointer<vtkPolyDataMapper>::New();

--- a/src/plugins/legacy/itkDataImage/manager/vtkVectorVisuManager.cxx
+++ b/src/plugins/legacy/itkDataImage/manager/vtkVectorVisuManager.cxx
@@ -14,6 +14,7 @@
 #include <vtkVectorVisuManager.h>
 
 #include <limits>
+#include <iostream>
 
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
@@ -92,7 +93,7 @@ void vtkVectorVisuManager::SetInput(vtkImageData* data, vtkMatrix4x4 *matrix)
 {
     if( !data )
     {
-        std::cerr << "Error: null data." << std::endl;
+        std::cerr << "Error with vectors: null data." << std::endl;
         return;
     }
 
@@ -124,7 +125,7 @@ void vtkVectorVisuManager::SetGlyphScale(const float& f)
 {
     if (f <= 0.0)
     {
-        cerr << "[Glyphs::SetGlyphScale] Invalid input range" << endl;
+        std::cerr << "[Glyphs::SetGlyphScale] Invalid input range" << std::endl;
         return;
     }
 

--- a/src/plugins/legacy/itkDataTensorImage/manager/vtkTensorVisuManager.cxx
+++ b/src/plugins/legacy/itkDataTensorImage/manager/vtkTensorVisuManager.cxx
@@ -13,6 +13,8 @@
 
 #include "vtkTensorVisuManager.h"
 
+#include <iostream>
+
 #include <vtkObjectFactory.h>
 #include <vtkPointData.h>
 #include <vtkFieldData.h>
@@ -275,7 +277,7 @@ void vtkTensorVisuManager::SetGlyphScale(const float& f)
 {
     if (f <= 0.0)
     {
-        cerr << "[Glyphs::SetGlyphScale] Invalid input range" << endl;
+        std::cerr << "[Glyphs::SetGlyphScale] Invalid input range" << std::endl;
         return;
     }
 
@@ -291,7 +293,7 @@ void vtkTensorVisuManager::SetMaxGlyphSize(const float& f)
 {
     if (f < 0.0)
     {
-        cerr << "[Glyphs::SetMaxGlyphSize] Invalid input range" << endl;
+        std::cerr << "[Glyphs::SetMaxGlyphSize] Invalid input range" << std::endl;
         return;
     }
 

--- a/superbuild/projects_modules/VTK.cmake
+++ b/superbuild/projects_modules/VTK.cmake
@@ -41,7 +41,7 @@ if (NOT USE_SYSTEM_${ep})
 ## #############################################################################
 
 set(git_url ${GITHUB_PREFIX}Kitware/VTK.git)
-set(git_tag v9.3.1)
+set(git_tag v9.6.2)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project

--- a/superbuild/projects_modules/music-plugins.cmake
+++ b/superbuild/projects_modules/music-plugins.cmake
@@ -40,8 +40,8 @@ function(music_plugins_project)
 
     if (NOT USE_SYSTEM_${external_project})
 
-        set(git_url ${GITHUB_PREFIX}Inria-Asclepios/music.git)
-        set(git_tag dev)
+        set(git_url ${GITHUB_PREFIX}mathildemerle/music.git)
+        set(git_tag vtk9.6.2)
 
 ## #############################################################################
 ## Add specific cmake arguments for configuration step of the project


### PR DESCRIPTION
This Pull Request changes VTK version from 9.3.1 to 9.6.2. 

It has to be used with https://github.com/Inria-Asclepios/music/pull/1148

It has been compiled and tested on Ubuntu 24, but compilations need to be done on Windows (minimum Visual Studio now 2019) and macOS.

:m: